### PR TITLE
Added OpenStack metadata/tags support for machine creation

### DIFF
--- a/kubernetes/openstack-machine-class.yaml
+++ b/kubernetes/openstack-machine-class.yaml
@@ -14,6 +14,11 @@ spec:
   - <security_group_name> # List of security groups which should be used for this machine
   region: <region> # Region where to place the machine
   availabilityZone: <availability_zone> # Availability zone where to place the machine
+  # OpenStack machine metadata block
+  # Be aware, that metadata keys in OpenStack can not contain special characters likes "/"
+  tags:
+    tag1: tag1-value # A set of additional tags attached to a machine (optional)
+    tag2: tag2-value # A set of additional tags attached to a machine (optional)
   secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
     namespace: default  # Namespace
     name: test-secret # Name of the secret

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -59,6 +59,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	networkID := d.OpenStackMachineClass.Spec.NetworkID
 	securityGroups := d.OpenStackMachineClass.Spec.SecurityGroups
 	availabilityZone := d.OpenStackMachineClass.Spec.AvailabilityZone
+	metadata := d.OpenStackMachineClass.Spec.Tags
 
 	var createOpts servers.CreateOptsBuilder
 
@@ -69,6 +70,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 		ImageName:        imageName,
 		Networks:         []servers.Network{{UUID: networkID}},
 		SecurityGroups:   securityGroups,
+		Metadata:         metadata,
 		UserData:         []byte(d.UserData),
 		AvailabilityZone: availabilityZone,
 	}


### PR DESCRIPTION
According to other infrastructures an tags block can be now specified in the machine class:

```
tags:
    tag1: tag1-value 
    tag2: tag2-value
```