### PR TITLE
Machine prioritization while scale down

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -658,6 +658,8 @@ func (s ActiveMachines) Less(i, j int) bool {
 		num, err := strconv.Atoi(s[i].Annotations[MachinePriority])
 		if err == nil {
 			machineIPriority = num
+		} else {
+			glog.Errorf("Machine priority is taken to be the default value (3). Couldn't convert machine priority to integer for machine:%s. Error message - %s", s[i].Name, err)
 		}
 	}
 
@@ -665,6 +667,8 @@ func (s ActiveMachines) Less(i, j int) bool {
 		num, err := strconv.Atoi(s[j].Annotations[MachinePriority])
 		if err == nil {
 			machineJPriority = num
+		} else {
+			glog.Errorf("Machine priority is taken to be the default value (3). Couldn't convert machine priority to integer for machine:%s. Error message - %s", s[j].Name, err)
 		}
 	}
 

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -344,7 +344,9 @@ func (c *controller) machineCreate(machine *v1alpha1.Machine, driver driver.Driv
 		if clone.Annotations == nil {
 			clone.Annotations = make(map[string]string)
 		}
-		clone.Annotations[MachinePriority] = "3"
+		if clone.Annotations[MachinePriority] == "" {
+			clone.Annotations[MachinePriority] = "3"
+		}
 
 		clone.Spec.ProviderID = actualProviderID
 		clone.Status.Node = nodeName

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -40,6 +40,14 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/driver"
 )
 
+const (
+	// MachinePriority is the annotation used to specify priority
+	// associated with a machine while deleting it. The less its
+	// priority the more likely it is to be deleted first
+	// Default priority for a machine is set to 3
+	MachinePriority = "machinepriority.machine.sapcloud.io"
+)
+
 /*
 	SECTION
 	Machine controller - Machine add, update, delete watches
@@ -328,11 +336,17 @@ func (c *controller) machineCreate(machine *v1alpha1.Machine, driver driver.Driv
 		}
 
 		clone := machine.DeepCopy()
-		clone.Spec.ProviderID = actualProviderID
+
 		if clone.Labels == nil {
 			clone.Labels = make(map[string]string)
 		}
 		clone.Labels["node"] = nodeName
+		if clone.Annotations == nil {
+			clone.Annotations = make(map[string]string)
+		}
+		clone.Annotations[MachinePriority] = "3"
+
+		clone.Spec.ProviderID = actualProviderID
 		clone.Status.Node = nodeName
 		clone.Status.LastOperation = lastOperation
 		clone.Status.CurrentStatus = currentStatus


### PR DESCRIPTION
Added an annotation on machine creation which indicates its priority while scaling down of machine-set replicas. The lower its priority, the higher its chances for getting scheduled for deletion during scale down. The default priority is 3.

This feature can be used while integrating cluster auto-scaler to indicate machines targeted for deletion by cluster autoscaler.