### PR TITLE
BugFix: Azure now tracks of all VMs resources

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -414,14 +414,17 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 				LastUpdateTime: metav1.Now(),
 			}
 			machine, err = c.updateMachineStatus(machine, lastOperation, currentStatus)
-			if err != nil {
-				// Object no longer exits and has been deleted
+			if err != nil && apierrors.IsNotFound(err) {
+				// Object no longer exists and has been deleted
 				glog.Warning(err)
 				return nil
+			} else if err != nil {
+				// Any other type of errors
+				glog.Error(err)
+				return err
 			}
 		}
 
-		var err error
 		if machineID != "" {
 			timeOutDuration := time.Duration(c.safetyOptions.MachineDrainTimeout) * time.Minute
 			// Timeout value obtained by subtracting last operation with expected time out period

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -320,7 +320,10 @@ func (c *controller) checkMachineClass(
 		machineClass,
 		"",
 	)
-	listOfVMs := dvr.GetVMs("")
+	listOfVMs, err := dvr.GetVMs("")
+	if err != nil {
+		glog.Warningf("Failed to list VMs at provider. Err - %s", err)
+	}
 
 	// Making sure that its not a VM just being created, machine object not yet updated at API server
 	if len(listOfVMs) > 1 {
@@ -348,7 +351,7 @@ func (c *controller) checkMachineClass(
 
 			// Re-check VM object existance
 			// before deleting orphan VM
-			result := dvr.GetVMs(machineID)
+			result, _ := dvr.GetVMs(machineID)
 			for reMachineID := range result {
 				if reMachineID == machineID {
 					// Get latest version of machine object and verfiy again

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -425,6 +425,12 @@ func (c *controller) manageReplicas(allMachines []*v1alpha1.Machine, machineSet 
 // meaning it did not expect to see any more of its machines created or deleted. This function is not meant to be
 // invoked concurrently with the same key.
 func (c *controller) reconcileClusterMachineSet(key string) error {
+	startTime := time.Now()
+	glog.V(4).Infof("Start syncing %q (%v)", key)
+	defer func() {
+		glog.V(4).Infof("Finished syncing %q (%v)", key, time.Since(startTime))
+	}()
+
 	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -425,11 +425,6 @@ func (c *controller) manageReplicas(allMachines []*v1alpha1.Machine, machineSet 
 // meaning it did not expect to see any more of its machines created or deleted. This function is not meant to be
 // invoked concurrently with the same key.
 func (c *controller) reconcileClusterMachineSet(key string) error {
-	startTime := time.Now()
-	defer func() {
-		glog.V(4).Infof("Finished syncing %q (%v)", key, time.Since(startTime))
-	}()
-
 	_, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -628,6 +623,14 @@ func (c *controller) prepareMachineForDeletion(targetMachine *v1alpha1.Machine, 
 		return
 	}
 
+	if err := c.machineControl.DeleteMachine(targetMachine.Namespace, targetMachine.Name, machineSet); err != nil {
+		// Decrement the expected number of deletes because the informer won't observe this deletion
+		machineKey := MachineKey(targetMachine)
+		glog.V(2).Infof("Failed to delete %v, decrementing expectations for %v %s/%s", machineKey, machineSet.Kind, machineSet.Namespace, machineSet.Name)
+		c.expectations.DeletionObserved(machineSetKey, machineKey)
+		*errCh <- err
+	}
+
 	// Force trigger deletion to reflect in machine status
 	lastOperation := v1alpha1.LastOperation{
 		Description:    "Deleting machine from cloud provider",
@@ -641,15 +644,7 @@ func (c *controller) prepareMachineForDeletion(targetMachine *v1alpha1.Machine, 
 		LastUpdateTime: metav1.Now(),
 	}
 	c.updateMachineStatus(targetMachine, lastOperation, currentStatus)
-	glog.V(2).Info("Delete machine from machineset:", targetMachine.Name)
-
-	if err := c.machineControl.DeleteMachine(targetMachine.Namespace, targetMachine.Name, machineSet); err != nil {
-		// Decrement the expected number of deletes because the informer won't observe this deletion
-		machineKey := MachineKey(targetMachine)
-		glog.V(2).Infof("Failed to delete %v, decrementing expectations for %v %s/%s", machineKey, machineSet.Kind, machineSet.Namespace, machineSet.Name)
-		c.expectations.DeletionObserved(machineSetKey, machineKey)
-		*errCh <- err
-	}
+	glog.V(2).Infof("Delete machine from machineset %q", targetMachine.Name)
 }
 
 func (c *controller) terminateMachines(inactiveMachines []*v1alpha1.Machine, machineSet *v1alpha1.MachineSet) error {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -27,14 +27,13 @@ type Driver interface {
 	Create() (string, string, error)
 	Delete() error
 	GetExisting() (string, error)
-	GetVMs(string) []VM
+	GetVMs(string) VMs
 }
 
-// VM tracks all orphanVMs
-type VM struct {
-	MachineName string
-	MachineID   string
-}
+// VMs maintains a list of VM returned by the provider
+// Key refers to the machine-id on the cloud provider
+// value refers to the machine-name of the machine object
+type VMs map[string]string
 
 // NewDriver creates a new driver object based on the classKind
 func NewDriver(machineID string, secretRef *corev1.Secret, classKind string, machineClass interface{}, machineName string) Driver {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -27,7 +27,7 @@ type Driver interface {
 	Create() (string, string, error)
 	Delete() error
 	GetExisting() (string, error)
-	GetVMs(string) VMs
+	GetVMs(string) (VMs, error)
 }
 
 // VMs maintains a list of VM returned by the provider

--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -183,8 +183,8 @@ func (d *AWSDriver) GetExisting() (string, error) {
 
 // GetVMs returns a VM matching the machineID
 // If machineID is an empty string then it returns all matching instances
-func (d *AWSDriver) GetVMs(machineID string) []VM {
-	var listOfVMs []VM
+func (d *AWSDriver) GetVMs(machineID string) VMs {
+	listOfVMs := make(map[string]string)
 
 	clusterName := ""
 	nodeRole := ""
@@ -256,12 +256,7 @@ func (d *AWSDriver) GetVMs(machineID string) []VM {
 					break
 				}
 			}
-
-			vm := VM{
-				MachineName: machineName,
-				MachineID:   d.encodeMachineID(d.AWSMachineClass.Spec.Region, *instance.InstanceId),
-			}
-			listOfVMs = append(listOfVMs, vm)
+			listOfVMs[d.encodeMachineID(d.AWSMachineClass.Spec.Region, *instance.InstanceId)] = machineName
 		}
 	}
 

--- a/pkg/driver/driver_fake.go
+++ b/pkg/driver/driver_fake.go
@@ -50,7 +50,7 @@ func (d *FakeDriver) GetExisting() (string, error) {
 }
 
 // GetVMs returns a list of VMs
-func (d *FakeDriver) GetVMs(name string) []VM {
-	var listOfVMs []VM
+func (d *FakeDriver) GetVMs(name string) VMs {
+	listOfVMs := make(map[string]string)
 	return listOfVMs
 }

--- a/pkg/driver/driver_fake.go
+++ b/pkg/driver/driver_fake.go
@@ -50,7 +50,7 @@ func (d *FakeDriver) GetExisting() (string, error) {
 }
 
 // GetVMs returns a list of VMs
-func (d *FakeDriver) GetVMs(name string) VMs {
+func (d *FakeDriver) GetVMs(name string) (VMs, error) {
 	listOfVMs := make(map[string]string)
-	return listOfVMs
+	return listOfVMs, nil
 }

--- a/pkg/driver/driver_gcp.go
+++ b/pkg/driver/driver_gcp.go
@@ -187,8 +187,8 @@ func (d *GCPDriver) GetExisting() (string, error) {
 }
 
 // GetVMs returns a list of VMs
-func (d *GCPDriver) GetVMs(machineID string) []VM {
-	var listOfVMs []VM
+func (d *GCPDriver) GetVMs(machineID string) VMs {
+	listOfVMs := make(map[string]string)
 
 	searchClusterName := ""
 	searchNodeRole := ""
@@ -234,15 +234,12 @@ func (d *GCPDriver) GetVMs(machineID string) []VM {
 			}
 
 			if clusterName == searchClusterName && nodeRole == searchNodeRole {
-				vm := VM{
-					MachineName: server.Name,
-					MachineID:   d.encodeMachineID(project, zone, server.Name),
-				}
+				instanceID := d.encodeMachineID(project, zone, server.Name)
 
 				if machineID == "" {
-					listOfVMs = append(listOfVMs, vm)
-				} else if machineID == vm.MachineID {
-					listOfVMs = append(listOfVMs, vm)
+					listOfVMs[instanceID] = server.Name
+				} else if machineID == instanceID {
+					listOfVMs[instanceID] = server.Name
 					glog.V(3).Infof("Found machine with name: %q", server.Name)
 					break
 				}

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -90,10 +90,12 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 // Delete method is used to delete an OS machine
 func (d *OpenStackDriver) Delete() error {
 
-	res := d.GetVMs(d.MachineID)
-	if len(res) == 0 {
+	res, err := d.GetVMs(d.MachineID)
+	if err != nil {
+		return err
+	} else if len(res) == 0 {
 		// No running instance exists with the given machine-ID
-		glog.V(3).Infof("No VM matching the machine-ID found on the provider %q", d.MachineID)
+		glog.V(2).Infof("No VM matching the machine-ID found on the provider %q", d.MachineID)
 		return nil
 	}
 
@@ -120,7 +122,7 @@ func (d *OpenStackDriver) GetExisting() (string, error) {
 
 // GetVMs returns a VM matching the machineID
 // If machineID is an empty string then it returns all matching instances
-func (d *OpenStackDriver) GetVMs(machineID string) VMs {
+func (d *OpenStackDriver) GetVMs(machineID string) (VMs, error) {
 	listOfVMs := make(map[string]string)
 
 	searchClusterName := ""
@@ -135,17 +137,21 @@ func (d *OpenStackDriver) GetVMs(machineID string) VMs {
 	}
 
 	if searchClusterName == "" || searchNodeRole == "" {
-		return listOfVMs
+		return listOfVMs, nil
 	}
 
 	client, err := d.createNovaClient()
 	if err != nil {
 		glog.Errorf("Could not connect to NovaClient. Error Message - %s", err)
-		return listOfVMs
+		return listOfVMs, err
 	}
 
 	// Retrieve a pager (i.e. a paginated collection)
 	pager := servers.List(client, servers.ListOpts{})
+	if pager.Err != nil {
+		glog.Errorf("Could not list instances. Error Message - %s", err)
+		return listOfVMs, err
+	}
 
 	// Define an anonymous function to be executed on each page's iteration
 	err = pager.EachPage(func(page pagination.Page) (bool, error) {
@@ -180,7 +186,7 @@ func (d *OpenStackDriver) GetVMs(machineID string) VMs {
 		return true, err
 	})
 
-	return listOfVMs
+	return listOfVMs, err
 }
 
 // createNovaClient is used to create a Nova client

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -120,8 +120,8 @@ func (d *OpenStackDriver) GetExisting() (string, error) {
 
 // GetVMs returns a VM matching the machineID
 // If machineID is an empty string then it returns all matching instances
-func (d *OpenStackDriver) GetVMs(machineID string) []VM {
-	var listOfVMs []VM
+func (d *OpenStackDriver) GetVMs(machineID string) VMs {
+	listOfVMs := make(map[string]string)
 
 	searchClusterName := ""
 	searchNodeRole := ""
@@ -165,15 +165,12 @@ func (d *OpenStackDriver) GetVMs(machineID string) []VM {
 			}
 
 			if clusterName == searchClusterName && nodeRole == searchNodeRole {
-				vm := VM{
-					MachineName: server.Name,
-					MachineID:   d.encodeMachineID(d.OpenStackMachineClass.Spec.Region, server.ID),
-				}
+				instanceID := d.encodeMachineID(d.OpenStackMachineClass.Spec.Region, server.ID)
 
 				if machineID == "" {
-					listOfVMs = append(listOfVMs, vm)
-				} else if machineID == vm.MachineID {
-					listOfVMs = append(listOfVMs, vm)
+					listOfVMs[instanceID] = server.Name
+				} else if machineID == instanceID {
+					listOfVMs[instanceID] = server.Name
 					glog.V(3).Infof("Found machine with name: %q", server.Name)
 					break
 				}


### PR DESCRIPTION
Azure earlier treated all VM resources (VMs, NIC, Disks) as a single resource and atomically created/deleted them in the driver interface. This caused issues when the controller crashes, during deletions. To fix this, now GetVMs interface checks for all resources instead of just VMs.