### PR TITLE
Bugfix: Draining issue and Azure error handling

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -518,9 +518,9 @@ func (c *controller) updateMachineStatus(
 	if err != nil {
 		// Keep retrying until update goes through
 		glog.V(3).Infof("Warning: Updated failed, retrying, error: %q", err)
-		c.updateMachineStatus(machine, lastOperation, currentStatus)
+		return c.updateMachineStatus(machine, lastOperation, currentStatus)
 	}
-	return machine, nil
+	return clone, nil
 }
 
 func (c *controller) updateMachineConditions(machine *v1alpha1.Machine, conditions []v1.NodeCondition) *v1alpha1.Machine {


### PR DESCRIPTION
- The drain nodes logic was reading an older version of the object while making drain call, there by fetching the wrong last operation timestamp. This lead to forceful draining of nodes. This was fixed by updating the updateMachineStatus method to return the new object instead of the old one.
- Azure didn't handle error handling for cases when NIC wasn't created properly. This commit fixes that by embedding appropriate error messages when errors occur in Azure driver machine creation logic.

Resolves: https://github.com/gardener/machine-controller-manager/issues/67