### PR TITLE
Bugfix: Fixes bug while deploying machines backed by SSD on GCP

### DIFF
--- a/pkg/apis/machine/validation/gcpmachineclass.go
+++ b/pkg/apis/machine/validation/gcpmachineclass.go
@@ -97,7 +97,7 @@ func validateGCPDisks(disks []*machine.GCPDisk, fldPath *field.Path) field.Error
 		if disk.SizeGb < 20 {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("sizeGb"), disk.SizeGb, "disk size must be at least 20 GB"))
 		}
-		if disk.Type != "pd-standard" && disk.Type != "pd-sdd" {
+		if disk.Type != "pd-standard" && disk.Type != "pd-ssd" {
 			allErrs = append(allErrs, field.NotSupported(idxPath.Child("type"), disk.Type, []string{"pd-standard", "pd-ssd"}))
 		}
 		if "" == disk.Image {


### PR DESCRIPTION
Machine Class validation for GCP had a spelling mistake while validation due to which machines deployed with SSD backing failed. This commit fixes the bug.

Resolves: https://github.com/gardener/machine-controller-manager/issues/83