### PR TITLE
Fix unexpected freeze during scale-down 

### DIFF
--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -451,7 +451,7 @@ func (dc *controller) reconcileClusterMachineDeployment(key string) error {
 	// If MachineDeployment is frozen and no deletion timestamp, don't process it
 	if deployment.Labels["freeze"] == "True" && deployment.DeletionTimestamp == nil {
 		glog.V(3).Infof("MachineDeployment %q is frozen, and hence not processeing", deployment.Name)
-		return nil
+		//return nil
 	}
 
 	// Validate MachineDeployment

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -44,7 +44,7 @@ const (
 	LastReplicaUpdate = "safety.machine.sapcloud.io/lastreplicaupdate"
 )
 
-// SafetyCheck controller is used to protect the controller from orphan VMs being created
+// SafetyCheck controller is used to protect the controller from orphan or excess VMs being created
 func (c *controller) reconcileClusterMachineSafety(key string) error {
 	var wg sync.WaitGroup
 
@@ -125,7 +125,7 @@ func (c *controller) checkAndFreezeORUnfreezeMachineSets(wg *sync.WaitGroup) {
 		if machineSet.Labels["freeze"] != "True" &&
 			fullyLabeledReplicasCount >= higherThreshold {
 			message := fmt.Sprintf(
-				"The number of machines backing MachineSet: %s is %d > %d which is the Max-ScaleUp-Limit",
+				"The number of machines backing MachineSet: %s is %d >= %d which is the Max-ScaleUp-Limit",
 				machineSet.Name,
 				fullyLabeledReplicasCount,
 				higherThreshold,

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -83,9 +83,12 @@ func (c *controller) checkAndFreezeORUnfreezeMachineSets(wg *sync.WaitGroup) {
 		templateLabel := labels.Set(machineSet.Spec.Template.Labels).AsSelectorPreValidated()
 		for _, machine := range filteredMachines {
 			if templateLabel.Matches(labels.Set(machine.Labels)) &&
-				len(machine.OwnerReferences) >= 1 &&
-				machine.OwnerReferences[0].Name == machineSet.Name {
-				fullyLabeledReplicasCount++
+				len(machine.OwnerReferences) >= 1 {
+				for i := range machine.OwnerReferences {
+					if machine.OwnerReferences[i].Name == machineSet.Name {
+						fullyLabeledReplicasCount++
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
MachineSet currently gets frozen unexpectedly during major scale-down. That was because safety-controller does not have any means to understand if it's genuine scale-down or over-shooting of the machine-objects. 
I am solving the issue, by reducing the scope of the Freeze-function, where now it applies only while scale-up and scale-down works as it is even when MachineSet is Frozen. Open for suggestions.
