### PR TITLE
Propagate machine status to machineset and machinedeployment

### DIFF
--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -225,6 +225,25 @@ const (
 	ConditionUnknown ConditionStatus = "Unknown"
 )
 
+//MachineSummary store the summary of machine.
+type MachineSummary struct {
+	// +optional
+	Name *string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+
+	// ProviderID represents the provider's unique ID given to a machine
+	// +optional
+	ProviderID *string `json:"providerID,omitempty"`
+
+	// Phase of the machine
+	Phase *MachinePhase `json:"phase,omitempty" protobuf:"bytes,1,opt,name=phase,casttype=MachinePhase"`
+
+	// Last operation refers to the status of the last operation performed
+	LastOperation *LastOperation `json:"lastOperation,omitempty"`
+
+	// OwnerRef
+	OwnerRef *string `json:"ownerRef,omitempty"`
+}
+
 /********************** MachineSet APIs ***************/
 
 // +genclient
@@ -333,6 +352,9 @@ type MachineSetStatus struct {
 
 	// ObservedGeneration
 	ObservedGeneration int64 `json:"observedGeneration,inline"`
+
+	// MachinesNotRunning has summary of machines that are not in "Running" phase
+	MachinesNotRunning []MachineSummary `json:"MachinesNotRunning ,inline"`
 }
 
 /********************** MachineDeployment APIs ***************/
@@ -533,6 +555,9 @@ type MachineDeploymentStatus struct {
 	// newest MachineSet.
 	// +optional
 	CollisionCount *int32 `json:"collisionCount,omitempty" protobuf:"varint,8,opt,name=collisionCount"`
+
+	// MachinesNotRunning has summary of machines that are not in "Running" phase
+	MachinesNotRunning []*MachineSummary `json:"MachinesNotRunning,inline"`
 }
 
 type MachineDeploymentConditionType string

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -228,20 +228,17 @@ const (
 //MachineSummary store the summary of machine.
 type MachineSummary struct {
 	// +optional
-	Name *string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 
 	// ProviderID represents the provider's unique ID given to a machine
 	// +optional
-	ProviderID *string `json:"providerID,omitempty"`
-
-	// Phase of the machine
-	Phase *MachinePhase `json:"phase,omitempty" protobuf:"bytes,1,opt,name=phase,casttype=MachinePhase"`
+	ProviderID string `json:"providerID,omitempty"`
 
 	// Last operation refers to the status of the last operation performed
-	LastOperation *LastOperation `json:"lastOperation,omitempty"`
+	LastOperation LastOperation `json:"lastOperation,omitempty"`
 
 	// OwnerRef
-	OwnerRef *string `json:"ownerRef,omitempty"`
+	OwnerRef string `json:"ownerRef,omitempty"`
 }
 
 /********************** MachineSet APIs ***************/
@@ -353,8 +350,8 @@ type MachineSetStatus struct {
 	// ObservedGeneration
 	ObservedGeneration int64 `json:"observedGeneration,inline"`
 
-	// MachinesNotRunning has summary of machines that are not in "Running" phase
-	MachinesNotRunning []MachineSummary `json:"MachinesNotRunning ,inline"`
+	// FailedMachines has summary of machines on which lastOperation Failed
+	FailedMachines *[]MachineSummary `json:"failedMachines,inline"`
 }
 
 /********************** MachineDeployment APIs ***************/
@@ -556,8 +553,8 @@ type MachineDeploymentStatus struct {
 	// +optional
 	CollisionCount *int32 `json:"collisionCount,omitempty" protobuf:"varint,8,opt,name=collisionCount"`
 
-	// MachinesNotRunning has summary of machines that are not in "Running" phase
-	MachinesNotRunning []*MachineSummary `json:"MachinesNotRunning,inline"`
+	// FailedMachines has summary of machines that are not in "Running" phase
+	FailedMachines []*MachineSummary `json:"failedMachines,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,9,rep,name=failedMachines"`
 }
 
 type MachineDeploymentConditionType string

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -553,7 +553,7 @@ type MachineDeploymentStatus struct {
 	// +optional
 	CollisionCount *int32 `json:"collisionCount,omitempty" protobuf:"varint,8,opt,name=collisionCount"`
 
-	// FailedMachines has summary of machines that are not in "Running" phase
+	// FailedMachines has summary of machines on which lastOperation Failed
 	FailedMachines []*MachineSummary `json:"failedMachines,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,9,rep,name=failedMachines"`
 }
 

--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -598,14 +598,14 @@ func calculateDeploymentStatus(allISs []*v1alpha1.MachineSet, newIS *v1alpha1.Ma
 		UnavailableReplicas: unavailableReplicas,
 		CollisionCount:      deployment.Status.CollisionCount,
 	}
-	status.MachinesNotRunning = []*v1alpha1.MachineSummary{}
+	status.FailedMachines = []*v1alpha1.MachineSummary{}
 
 	for _, is := range allISs {
-		if is != nil {
-			for idx := range is.Status.MachinesNotRunning {
-				// Memory pointed by MachinesNotRunning's pointer fields should never be altered using them
+		if is != nil && is.Status.FailedMachines != nil {
+			for idx := range *is.Status.FailedMachines {
+				// Memory pointed by FailedMachines's pointer fields should never be altered using them
 				// as they point to the machineset object's fields, and only machineset controller should alter them
-				status.MachinesNotRunning = append(status.MachinesNotRunning, &is.Status.MachinesNotRunning[idx])
+				status.FailedMachines = append(status.FailedMachines, &(*is.Status.FailedMachines)[idx])
 			}
 		}
 	}

--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -598,6 +598,17 @@ func calculateDeploymentStatus(allISs []*v1alpha1.MachineSet, newIS *v1alpha1.Ma
 		UnavailableReplicas: unavailableReplicas,
 		CollisionCount:      deployment.Status.CollisionCount,
 	}
+	status.MachinesNotRunning = []*v1alpha1.MachineSummary{}
+
+	for _, is := range allISs {
+		if is != nil {
+			for idx := range is.Status.MachinesNotRunning {
+				// Memory pointed by MachinesNotRunning's pointer fields should never be altered using them
+				// as they point to the machineset object's fields, and only machineset controller should alter them
+				status.MachinesNotRunning = append(status.MachinesNotRunning, &is.Status.MachinesNotRunning[idx])
+			}
+		}
+	}
 
 	// Copy conditions one by one so we won't mutate the original object.
 	conditions := deployment.Status.Conditions

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -668,7 +668,7 @@ func (c *controller) checkMachineTimeout(machine *v1alpha1.Machine) {
 
 			if machine.Status.CurrentStatus.Phase == v1alpha1.MachinePending {
 				lastOperation := v1alpha1.LastOperation{
-					Description:    machine.Status.LastOperation.Description,
+					Description:    "Machine could not join the cluster. Operation timed out",
 					State:          "Failed",
 					Type:           machine.Status.LastOperation.Type,
 					LastUpdateTime: metav1.Now(),


### PR DESCRIPTION
The summary of machineobjects which are not in "Running" phase is propagated to machineset and machinedeployment. Decision pending on:

1. which fields are required to propagate

1. Under what conditions should the summary be propagated