### PR TITLE
Some unit tests for safety controller.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -289,6 +289,7 @@
   packages = [
     ".",
     "config",
+    "extensions/table",
     "internal/codelocation",
     "internal/containernode",
     "internal/failer",

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -94,7 +94,7 @@ func (c *controller) checkAndFreezeORUnfreezeMachineSets(wg *sync.WaitGroup) {
 		lowerThreshold := higherThreshold - c.safetyOptions.SafetyDown
 
 		machineDeployments := c.getMachineDeploymentsForMachineSet(machineSet)
-		if machineDeployments != nil && len(machineDeployments) >= 1 {
+		if len(machineDeployments) >= 1 {
 			machineDeployment := machineDeployments[0]
 			if machineDeployment != nil {
 				surge, err := intstrutil.GetValueFromIntOrPercent(
@@ -481,7 +481,7 @@ func (c *controller) freezeMachineSetsAndDeployments(machineSet *v1alpha1.Machin
 	}
 
 	machineDeployments := c.getMachineDeploymentsForMachineSet(machineSet)
-	if machineDeployments != nil && len(machineDeployments) >= 1 {
+	if len(machineDeployments) >= 1 {
 		machineDeployment := machineDeployments[0]
 		if machineDeployment != nil {
 			for {

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -93,23 +93,27 @@ func (c *controller) checkAndFreezeORUnfreezeMachineSets(wg *sync.WaitGroup) {
 		// Unfreeze machineset when replica count reaches higherThreshold - SafetyDown
 		lowerThreshold := higherThreshold - c.safetyOptions.SafetyDown
 
-		machineDeployment := c.getMachineDeploymentsForMachineSet(machineSet)[0]
-		if machineDeployment != nil {
+		machineDeployments := c.getMachineDeploymentsForMachineSet(machineSet)
+		if machineDeployments != nil && len(machineDeployments) >= 1 {
+			machineDeployment := machineDeployments[0]
+			if machineDeployment != nil {
+				surge, err := intstrutil.GetValueFromIntOrPercent(
+					machineDeployment.Spec.Strategy.RollingUpdate.MaxSurge,
+					int(machineDeployment.Spec.Replicas),
+					true,
+				)
+				if err != nil {
+					//TODO explore if we can log/annotate this machineset and continue here.
+					glog.Error("Safety-Net: Error getting surge value - ", err)
+					wg.Done()
+					return
+				}
 
-			surge, err := intstrutil.GetValueFromIntOrPercent(
-				machineDeployment.Spec.Strategy.RollingUpdate.MaxSurge,
-				int(machineDeployment.Spec.Replicas),
-				true,
-			)
-			if err != nil {
-				glog.Error("Safety-Net: Error getting surge value - ", err)
-				wg.Done()
-				return
+				higherThreshold = machineDeployment.Spec.Replicas + int32(surge) + c.safetyOptions.SafetyUp
+				lowerThreshold = higherThreshold - c.safetyOptions.SafetyDown
 			}
-
-			higherThreshold = machineDeployment.Spec.Replicas + int32(surge) + c.safetyOptions.SafetyUp
-			lowerThreshold = higherThreshold - c.safetyOptions.SafetyDown
 		}
+
 		glog.V(3).Infof(
 			"MS:%q LowerThreshold:%d FullyLabeledReplicas:%d HigherThreshold:%d",
 			machineSet.Name,
@@ -476,31 +480,35 @@ func (c *controller) freezeMachineSetsAndDeployments(machineSet *v1alpha1.Machin
 		glog.Warning("Updated failed, retrying - ", err)
 	}
 
-	machineDeployment := c.getMachineDeploymentsForMachineSet(machineSet)[0]
-	if machineDeployment != nil {
-		for {
-			// Get the latest version of the machineDeployment so that we can avoid conflicts
-			machineDeployment, err := c.controlMachineClient.MachineDeployments(machineDeployment.Namespace).Get(machineDeployment.Name, metav1.GetOptions{})
-			if err != nil {
-				// Some error occued while fetching object from API server
-				glog.Error(err)
-				break
+	machineDeployments := c.getMachineDeploymentsForMachineSet(machineSet)
+	if machineDeployments != nil && len(machineDeployments) >= 1 {
+		machineDeployment := machineDeployments[0]
+		if machineDeployment != nil {
+			for {
+				// Get the latest version of the machineDeployment so that we can avoid conflicts
+				machineDeployment, err := c.controlMachineClient.MachineDeployments(machineDeployment.Namespace).Get(machineDeployment.Name, metav1.GetOptions{})
+				if err != nil {
+					// Some error occued while fetching object from API server
+					//TODO explore if we can log/annotate this machinedeployment and continue here.
+					glog.Error(err)
+					break
+				}
+				clone := machineDeployment.DeepCopy()
+				newStatus := clone.Status
+				mdcond := NewMachineDeploymentCondition(v1alpha1.MachineDeploymentFrozen, v1alpha1.ConditionTrue, reason, message)
+				SetMachineDeploymentCondition(&newStatus, *mdcond)
+				if clone.Labels == nil {
+					clone.Labels = make(map[string]string)
+				}
+				clone.Status = newStatus
+				clone.Labels["freeze"] = "True"
+				_, err = c.controlMachineClient.MachineDeployments(clone.Namespace).Update(clone)
+				if err == nil {
+					break
+				}
+				// Keep retrying until update goes through
+				glog.Warning("Updated failed, retrying - ", err)
 			}
-			clone := machineDeployment.DeepCopy()
-			newStatus := clone.Status
-			mdcond := NewMachineDeploymentCondition(v1alpha1.MachineDeploymentFrozen, v1alpha1.ConditionTrue, reason, message)
-			SetMachineDeploymentCondition(&newStatus, *mdcond)
-			if clone.Labels == nil {
-				clone.Labels = make(map[string]string)
-			}
-			clone.Status = newStatus
-			clone.Labels["freeze"] = "True"
-			_, err = c.controlMachineClient.MachineDeployments(clone.Namespace).Update(clone)
-			if err == nil {
-				break
-			}
-			// Keep retrying until update goes through
-			glog.Warning("Updated failed, retrying - ", err)
 		}
 	}
 }

--- a/pkg/controller/machine_safety_test.go
+++ b/pkg/controller/machine_safety_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controller
+
+import (
+	"sync"
+	"time"
+
+	machinev1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	fakeuntyped "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/fake"
+	faketyped "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/typed/machine/v1alpha1/fake"
+	machineinformers "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+const namespace = "test"
+
+var _ = Describe("machine", func() {
+	DescribeTable("##freezeMachineSetsAndDeployments",
+		func(initialMachines, initialMachineSets map[string]string, initialMachineDeployments []string, freezeMachineSets, freezeMachineDeployments []string) {
+			createController := func(objects ...runtime.Object) *controller {
+				fakeUntypedClient := fakeuntyped.NewSimpleClientset(objects...)
+				fakeTypedClient := &faketyped.FakeMachineV1alpha1{
+					&fakeUntypedClient.Fake,
+				}
+
+				return &controller{
+					controlMachineClient: fakeTypedClient,
+				}
+			}
+
+			const freezeReason = OverShootingReplicaCount
+			const freezeMessage = OverShootingReplicaCount
+
+			objects := newInitialObjects(initialMachines, initialMachineSets, initialMachineDeployments)
+			c := createController(objects...)
+
+			for _, msName := range freezeMachineSets {
+				machineSets, err := c.controlMachineClient.MachineSets(namespace).List(metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				Expect(machineSets).To(Not(BeNil()))
+				for _, ms := range machineSets.Items {
+					if ms.Name != msName {
+						continue
+					}
+
+					c.freezeMachineSetsAndDeployments(&ms, freezeReason, freezeMessage)
+				}
+			}
+		},
+		Entry("no objects", nil, nil, nil, nil, nil),
+		Entry("one machineset", nil, map[string]string{"machineset-1": ""}, nil, []string{"machineset-1"}, nil),
+	)
+
+	DescribeTable("##checkAndFreezeORUnfreezeMachineSets",
+		func(initialMachines, initialMachineSets map[string]string, initialMachineDeployments []string) {
+			createController := func(stop <-chan struct{}, objects ...runtime.Object) *controller {
+				fakeUntypedClient := fakeuntyped.NewSimpleClientset(objects...)
+				fakeTypedClient := &faketyped.FakeMachineV1alpha1{
+					&fakeUntypedClient.Fake,
+				}
+				controlMachineInformerFactory := machineinformers.NewSharedInformerFactory(fakeUntypedClient, 100*time.Millisecond)
+				defer controlMachineInformerFactory.Start(stop)
+
+				machineSharedInformers := controlMachineInformerFactory.Machine().V1alpha1()
+				machines := machineSharedInformers.Machines()
+				machineSets := machineSharedInformers.MachineSets()
+				machineDeployments := machineSharedInformers.MachineDeployments()
+
+				return &controller{
+					controlMachineClient:    fakeTypedClient,
+					machineLister:           machines.Lister(),
+					machineSetLister:        machineSets.Lister(),
+					machineDeploymentLister: machineDeployments.Lister(),
+					machineSynced:           machines.Informer().HasSynced,
+					machineSetSynced:        machineSets.Informer().HasSynced,
+					machineDeploymentSynced: machineDeployments.Informer().HasSynced,
+				}
+			}
+
+			stop := make(chan struct{})
+			defer close(stop)
+
+			objects := newInitialObjects(initialMachines, initialMachineSets, initialMachineDeployments)
+			c := createController(stop, objects...)
+
+			Expect(cache.WaitForCacheSync(stop, c.machineSynced, c.machineSetSynced, c.machineDeploymentSynced)).To(BeTrue())
+
+			machineSets, err := c.machineSetLister.List(labels.Everything())
+			Expect(err).To(BeNil())
+			Expect(len(machineSets)).To(Equal(len(initialMachineSets)))
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			done := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(done)
+			}()
+
+			c.checkAndFreezeORUnfreezeMachineSets(&wg)
+
+			select {
+			case <-done:
+			// All done!
+			case <-time.After(100 * time.Millisecond):
+				//Timeout!
+			}
+
+			Expect(done).To(BeClosed())
+		},
+		Entry("no objects", nil, nil, nil),
+		Entry("one machineset", nil, map[string]string{"machineset-1": ""}, nil),
+	)
+})
+
+func newMachineSet(name, namespace, owner string, labels map[string]string) *machinev1.MachineSet {
+	ms := &machinev1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: machinev1.MachineSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+
+	if owner == "" {
+		return ms
+	}
+
+	ms.OwnerReferences = []metav1.OwnerReference{
+		metav1.OwnerReference{
+			APIVersion: controllerKindMachineSet.GroupVersion().String(),
+			Kind:       controllerKindMachineSet.Kind,
+			Name:       owner,
+		},
+	}
+
+	return ms
+}
+
+func newInitialObjects(initialMachines, initialMachineSets map[string]string, initialMachineDeployments []string) []runtime.Object {
+	objects := []runtime.Object{}
+	for msName, owner := range initialMachineSets {
+		objects = append(objects, newMachineSet(msName, namespace, owner, map[string]string{
+			"machineset": owner,
+		}))
+	}
+	return objects
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,98 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, false)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, false, true)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, true, false)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, pending bool, focused bool) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	if pending {
+		ginkgo.PDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else if focused {
+		ginkgo.FDescribe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	} else {
+		ginkgo.Describe(description, func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		})
+	}
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,81 @@
+package table
+
+import (
+	"reflect"
+
+	"github.com/onsi/ginkgo"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description string
+	Parameters  []interface{}
+	Pending     bool
+	Focused     bool
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	if t.Pending {
+		ginkgo.PIt(t.Description)
+		return
+	}
+
+	values := []reflect.Value{}
+	for i, param := range t.Parameters {
+		var value reflect.Value
+
+		if param == nil {
+			inType := itBody.Type().In(i)
+			value = reflect.Zero(inType)
+		} else {
+			value = reflect.ValueOf(param)
+		}
+
+		values = append(values, value)
+	}
+
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		ginkgo.FIt(t.Description, body)
+	} else {
+		ginkgo.It(t.Description, body)
+	}
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, false}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, false, true}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description string, parameters ...interface{}) TableEntry {
+	return TableEntry{description, parameters, true, false}
+}


### PR DESCRIPTION
Added ginkgo sub-package github.com/onsi/ginkgo/extensions/table to vendoring.

Added bugfixes in a couple of places in machine_safety.go to handle machinesets without machinedeployments.