### PR TITLE
Machine health considers - Kubelet and DiskPressure status

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -623,20 +623,12 @@ func (c *controller) isHealthy(machine *v1alpha1.Machine) bool {
 	}
 
 	for _, condition := range machine.Status.Conditions {
-		if condition.Type == v1.NodeReady {
-			// Kubelet is not ready
-			if condition.Status != v1.ConditionTrue {
-				return false
-			}
-		} else {
-			// Check if ConditionType is not ConfigOK
-			if condition.Type != v1.NodeConfigOK {
-				// Every other condition, status has to be false. If not, then the machine is unhealthy
-				// Undesired Status can be True or Unknown, hence safe to check != "False"
-				if condition.Status != v1.ConditionFalse {
-					return false
-				}
-			}
+		if condition.Type == v1.NodeReady && condition.Status != v1.ConditionTrue {
+			// If Kubelet is not ready
+			return false
+		} else if condition.Type == v1.NodeDiskPressure && condition.Status != v1.ConditionFalse {
+			// If DiskPressure has occurred on node
+			return false
 		}
 	}
 	return true

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -178,18 +178,26 @@ var _ = Describe("machine", func() {
 			Entry("with NodeReady is True", corev1.NodeReady, corev1.ConditionTrue, true),
 			Entry("with NodeReady is False", corev1.NodeReady, corev1.ConditionFalse, false),
 			Entry("with NodeReady is Unknown", corev1.NodeReady, corev1.ConditionUnknown, false),
-			Entry("with NodeOutOfDisk is True", corev1.NodeOutOfDisk, corev1.ConditionTrue, false),
-			Entry("with NodeOutOfDisk is Unknown", corev1.NodeOutOfDisk, corev1.ConditionUnknown, false),
-			Entry("with NodeDiskPressure is True", corev1.NodeDiskPressure, corev1.ConditionTrue, false),
-			Entry("with NodeDiskPressure is Unknown", corev1.NodeDiskPressure, corev1.ConditionUnknown, false),
-			Entry("with NodeMemoryPressure is True", corev1.NodeMemoryPressure, corev1.ConditionTrue, false),
-			Entry("with NodeMemoryPressure is Unknown", corev1.NodeMemoryPressure, corev1.ConditionUnknown, false),
-			Entry("with NodeNetworkUnavailable is True", corev1.NodeNetworkUnavailable, corev1.ConditionTrue, false),
-			Entry("with NodeNetworkUnavailable is Unknown", corev1.NodeNetworkUnavailable, corev1.ConditionUnknown, false),
 
-			//TODO: To be enhanced later, currently unclear on how to handle the NodeConfigOK NodeConditionType
-			//Entry("with NodeConfigOK is False", corev1.NodeConfigOK, corev1.ConditionFalse, false),
-			//Entry("with NodeConfigOK is Unknown", corev1.NodeConfigOK, corev1.ConditionUnknown, false),
+			Entry("with NodeDiskPressure is True", corev1.NodeDiskPressure, corev1.ConditionTrue, false),
+			Entry("with NodeDiskPressure is False", corev1.NodeDiskPressure, corev1.ConditionFalse, true),
+			Entry("with NodeDiskPressure is Unknown", corev1.NodeDiskPressure, corev1.ConditionUnknown, false),
+
+			Entry("with NodeOutOfDisk is True", corev1.NodeOutOfDisk, corev1.ConditionTrue, true),
+			Entry("with NodeOutOfDisk is Unknown", corev1.NodeOutOfDisk, corev1.ConditionUnknown, true),
+			Entry("with NodeOutOfDisk is False", corev1.NodeOutOfDisk, corev1.ConditionFalse, true),
+
+			Entry("with NodeMemoryPressure is True", corev1.NodeMemoryPressure, corev1.ConditionTrue, true),
+			Entry("with NodeMemoryPressure is Unknown", corev1.NodeMemoryPressure, corev1.ConditionUnknown, true),
+			Entry("with NodeOutOfDisk is False", corev1.NodeMemoryPressure, corev1.ConditionFalse, true),
+
+			Entry("with NodeNetworkUnavailable is True", corev1.NodeNetworkUnavailable, corev1.ConditionTrue, true),
+			Entry("with NodeNetworkUnavailable is Unknown", corev1.NodeNetworkUnavailable, corev1.ConditionUnknown, true),
+			Entry("with NodeNetworkUnavailable is False", corev1.NodeNetworkUnavailable, corev1.ConditionFalse, true),
+
+			Entry("with NodeConfigOK is True", corev1.NodeConfigOK, corev1.ConditionTrue, true),
+			Entry("with NodeConfigOK is Unknown", corev1.NodeConfigOK, corev1.ConditionUnknown, true),
+			Entry("with NodeConfigOK is False", corev1.NodeConfigOK, corev1.ConditionFalse, true),
 		)
 	})
 

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -189,7 +189,7 @@ var _ = Describe("machine", func() {
 
 			Entry("with NodeMemoryPressure is True", corev1.NodeMemoryPressure, corev1.ConditionTrue, true),
 			Entry("with NodeMemoryPressure is Unknown", corev1.NodeMemoryPressure, corev1.ConditionUnknown, true),
-			Entry("with NodeOutOfDisk is False", corev1.NodeMemoryPressure, corev1.ConditionFalse, true),
+			Entry("with NodeMemoryPressure is False", corev1.NodeMemoryPressure, corev1.ConditionFalse, true),
 
 			Entry("with NodeNetworkUnavailable is True", corev1.NodeNetworkUnavailable, corev1.ConditionTrue, true),
 			Entry("with NodeNetworkUnavailable is Unknown", corev1.NodeNetworkUnavailable, corev1.ConditionUnknown, true),


### PR DESCRIPTION
- This PR changes machine health check logic to only watch out for issues of Kubelet or diskPressure.
- Changes on Kubelet configuration to handle memory/disk pressure are to be done on Gardener next

Partially Resolves: https://github.com/gardener/machine-controller-manager/issues/95