### PR TITLE
Enhancement/object consistency

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -86,7 +86,6 @@ func NewController(
 		expectations:                   NewUIDTrackingContExpectations(NewContExpectations()),
 		secretQueue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secret"),
 		nodeQueue:                      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node"),
-		nodeToMachineQueue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "nodeToMachine"),
 		openStackMachineClassQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "openstackmachineclass"),
 		awsMachineClassQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "awsmachineclass"),
 		azureMachineClassQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "azuremachineclass"),
@@ -364,7 +363,6 @@ type controller struct {
 	// queues
 	secretQueue                    workqueue.RateLimitingInterface
 	nodeQueue                      workqueue.RateLimitingInterface
-	nodeToMachineQueue             workqueue.RateLimitingInterface
 	openStackMachineClassQueue     workqueue.RateLimitingInterface
 	awsMachineClassQueue           workqueue.RateLimitingInterface
 	azureMachineClassQueue         workqueue.RateLimitingInterface
@@ -402,7 +400,6 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 	defer c.machineQueue.ShutDown()
 	defer c.machineSetQueue.ShutDown()
 	defer c.machineDeploymentQueue.ShutDown()
-	defer c.nodeToMachineQueue.ShutDown()
 	defer c.machineSafetyOrphanVMsQueue.ShutDown()
 	defer c.machineSafetyOvershootingQueue.ShutDown()
 
@@ -422,7 +419,6 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 		createWorker(c.secretQueue, "ClusterSecret", maxRetries, true, c.reconcileClusterSecretKey, stopCh, &waitGroup)
 		createWorker(c.nodeQueue, "ClusterNode", maxRetries, true, c.reconcileClusterNodeKey, stopCh, &waitGroup)
 		createWorker(c.machineQueue, "ClusterMachine", maxRetries, true, c.reconcileClusterMachineKey, stopCh, &waitGroup)
-		createWorker(c.nodeToMachineQueue, "ClusterNodeToMachine", maxRetries, true, c.reconcileClusterNodeToMachineKey, stopCh, &waitGroup)
 		createWorker(c.machineSetQueue, "ClusterMachineSet", maxRetries, true, c.reconcileClusterMachineSet, stopCh, &waitGroup)
 		createWorker(c.machineDeploymentQueue, "ClusterMachineDeployment", maxRetries, true, c.reconcileClusterMachineDeployment, stopCh, &waitGroup)
 		createWorker(c.machineSafetyOrphanVMsQueue, "ClusterMachineSafetyOrphanVMs", maxRetries, true, c.reconcileClusterMachineSafetyOrphanVMs, stopCh, &waitGroup)

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -280,7 +280,6 @@ func createController(stop <-chan struct{}, namespace string, machineObjects, co
 		machineDeploymentSynced:        machineDeployments.Informer().HasSynced,
 		secretQueue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secret"),
 		nodeQueue:                      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node"),
-		nodeToMachineQueue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "nodeToMachine"),
 		openStackMachineClassQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "openstackmachineclass"),
 		awsMachineClassQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "awsmachineclass"),
 		azureMachineClassQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "azuremachineclass"),

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -281,8 +281,8 @@ func (dc *controller) enqueueRateLimited(deployment *v1alpha1.MachineDeployment)
 	dc.machineDeploymentQueue.AddRateLimited(key)
 }
 
-// enqueueAfter will enqueue a deployment after the provided amount of time.
-func (dc *controller) enqueueAfter(deployment *v1alpha1.MachineDeployment, after time.Duration) {
+//  enqueueMachineDeploymentAfter will enqueue a deployment after the provided amount of time.
+func (dc *controller) enqueueMachineDeploymentAfter(deployment *v1alpha1.MachineDeployment, after time.Duration) {
 	key, err := KeyFunc(deployment)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", deployment, err))
@@ -447,8 +447,7 @@ func (dc *controller) reconcileClusterMachineDeployment(key string) error {
 
 	// If MachineDeployment is frozen and no deletion timestamp, don't process it
 	if deployment.Labels["freeze"] == "True" && deployment.DeletionTimestamp == nil {
-		glog.V(3).Infof("MachineDeployment %q is frozen, however, will still pe processed if its scaling down", deployment.Name)
-		//return nil
+		glog.V(3).Infof("MachineDeployment %q is frozen. However, it will still be processed if it there is an scale down event.", deployment.Name)
 	}
 
 	// Validate MachineDeployment

--- a/pkg/controller/deployment_progress.go
+++ b/pkg/controller/deployment_progress.go
@@ -197,6 +197,6 @@ func (dc *controller) requeueStuckMachineDeployment(d *v1alpha1.MachineDeploymen
 	glog.V(4).Infof("Queueing up machine deployment %q for a progress check after %ds", d.Name, int(after.Seconds()))
 	// Add a second to avoid milliseconds skew in AddAfter.
 	// See https://github.com/kubernetes/kubernetes/issues/39785#issuecomment-279959133 for more info.
-	dc.enqueueAfter(d, after+time.Second)
+	dc.enqueueMachineDeploymentAfter(d, after+time.Second)
 	return after
 }

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -278,7 +278,6 @@ func (c *controller) updateMachineState(machine *v1alpha1.Machine) (*v1alpha1.Ma
 			}
 			clone, err := c.updateMachineStatus(machine, lastOperation, currentStatus)
 			if err != nil {
-				// Keep retrying until update goes through
 				glog.Errorf("Machine updated failed for %s, Error: %q", machine.Name, err)
 				return machine, err
 			}
@@ -288,8 +287,7 @@ func (c *controller) updateMachineState(machine *v1alpha1.Machine) (*v1alpha1.Ma
 		// Hence returning
 		return machine, nil
 	} else if err != nil {
-		// Any other types of errors while
-		// fetching node object
+		// Any other types of errors while fetching node object
 		glog.Errorf("Could not fetch node object for machine %s", machine.Name)
 		return machine, err
 	}

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -170,6 +170,7 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 		}
 	}
 
+	c.enqueueMachineAfter(machine, time.Minute*10)
 	return nil
 }
 

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -533,7 +533,7 @@ func (c *controller) reconcileClusterMachineSet(key string) error {
 	if manageReplicasErr == nil && updatedMachineSet.Spec.MinReadySeconds > 0 &&
 		updatedMachineSet.Status.ReadyReplicas == updatedMachineSet.Spec.Replicas &&
 		updatedMachineSet.Status.AvailableReplicas != updatedMachineSet.Spec.Replicas {
-		c.enqueueMachineSetAfter(updatedMachineSet, time.Duration(updatedMachineSet.Spec.MinReadySeconds)*time.Second)
+		c.enqueueMachineSetAfter(updatedMachineSet, 10*time.Minute)
 	}
 
 	return manageReplicasErr


### PR DESCRIPTION
- Periodic re-enqueue of machine object
- Removed unwanted nodeToMachine worker queue
- Machine health status is now updated periodically (even if node backing it isn't found)
- Unit tests for updateMachineState

-Bugfix: Fixes runtime panic issue while running controller suite test