### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Release note**:
+<!--  Write your release note:
+1. Enter your release note in the below block.
+2. If no release note is required, just write "NONE" within the block.
+
+Format of block header: <category> <target_group>
+Possible values:
+- category:       improvement|noteworthy
+- target_group:   user|operator
+-->
+```improvement operator
+
+```


### PR DESCRIPTION
added PR template (similar to https://github.com/kubernetes/kubernetes/edit/master/.github/PULL_REQUEST_TEMPLATE.md)

I also defaulted the release note code block to "improvement operator", which maps to the title "Improvements" and subtitle "To operator team".
FYI: noteworthy maps to the title "Most notable changes"