### PR TITLE
Problem: can't add non image disk on GCP

### DIFF
--- a/pkg/apis/machine/validation/gcpmachineclass.go
+++ b/pkg/apis/machine/validation/gcpmachineclass.go
@@ -100,8 +100,8 @@ func validateGCPDisks(disks []*machine.GCPDisk, fldPath *field.Path) field.Error
 		if disk.Type != "pd-standard" && disk.Type != "pd-ssd" {
 			allErrs = append(allErrs, field.NotSupported(idxPath.Child("type"), disk.Type, []string{"pd-standard", "pd-ssd"}))
 		}
-		if "" == disk.Image {
-			allErrs = append(allErrs, field.Required(idxPath.Child("image"), "image is required"))
+		if disk.Boot && "" == disk.Image {
+			allErrs = append(allErrs, field.Required(idxPath.Child("image"), "image is required for boot disk"))
 		}
 	}
 


### PR DESCRIPTION
Solution: Only the root disk on GCP has an image requirement. You can
attach other block storage without a source image, and this change
allows for that.