### PR TITLE
Problem: Can't assign static addresses on GCP

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -1101,8 +1101,12 @@ type GCPMetadata struct {
 
 // GCPNetworkInterface describes network interfaces for GCP
 type GCPNetworkInterface struct {
-	Network    string
-	Subnetwork string
+	Network              string
+	Subnetwork           string
+	CreateStaticExternal bool
+	CreateStaticInternal bool
+	AttachExternal       string
+	AttachInternal       string
 }
 
 // GCPScheduling describes scheduling configuration for GCP.

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -1101,6 +1101,20 @@ type GCPMetadata struct {
 type GCPNetworkInterface struct {
 	Network    string `json:"network,omitempty"`
 	Subnetwork string `json:"subnetwork,omitempty"`
+
+	// CreateStaticExternal creates a new IP ant ensures this node gets attached to it.
+	// If this is specified you can't use AttachExternal
+	CreateStaticExternal bool `json:"createStaticExternal,omitemptu"`
+
+	// CreateStaticInternal creates a new IP ant ensures this node gets attached to it.
+	// If this is specified you can't use AttachInternal
+	CreateStaticInternal bool `json:"createStaticInternal,omitemptu"`
+
+	// AttachExternal attaches this interface to the specified IPv4 External address
+	AttachExternal string `json:"attachExternal,omitempty"`
+
+	// AttachInternal attaches this interface to the specified IPv4 Internal address
+	AttachInternal string `json:"attachInternal,omitempty"`
 }
 
 // GCPScheduling describes scheduling configuration for GCP.

--- a/pkg/apis/machine/validation/gcpmachineclass.go
+++ b/pkg/apis/machine/validation/gcpmachineclass.go
@@ -120,6 +120,14 @@ func validateGCPNetworkInterfaces(interfaces []*machine.GCPNetworkInterface, fld
 		if "" == nic.Network && "" == nic.Subnetwork {
 			allErrs = append(allErrs, field.Required(idxPath, "either network or subnetwork or both is required"))
 		}
+
+		if nic.CreateStaticExternal && nic.AttachExternal != "" {
+			allErrs = append(allErrs, field.Required(idxPath, "either attachExternal or createStaticExternal can be used, but not both"))
+		}
+
+		if nic.CreateStaticInternal && nic.AttachInternal != "" {
+			allErrs = append(allErrs, field.Required(idxPath, "either attachInternal or createStaticInternal can be used, but not both"))
+		}
 	}
 
 	return allErrs


### PR DESCRIPTION
Solution: Allow the user to specify 'createStaticExternal',
'createStaticInternal' to have the driver make new static addresses and
attach them when making an interface. Also allows for attaching a
specific static internal/external via  'attachInternal' and
'attachExternal' keys on an interface object. Where the value should be
the internal or external IPv4 address. At this time the driver doesn't
handle removal of static addresses, and it is assumed the user would
handle that via other means.
