### PR TITLE
Removed any unwanted re-enqueuing of machine objects

### DIFF
--- a/pkg/controller/deployment_progress.go
+++ b/pkg/controller/deployment_progress.go
@@ -24,7 +24,6 @@ package controller
 
 import (
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/golang/glog"
@@ -108,7 +107,7 @@ func (dc *controller) syncRolloutStatus(allISs []*v1alpha1.MachineSet, newIS *v1
 	}
 
 	// Do not update if there is nothing new to add.
-	if reflect.DeepEqual(d.Status, newStatus) {
+	if !statusUpdateRequired(d.Status, newStatus) {
 		// Requeue the deployment if required.
 		dc.requeueStuckMachineDeployment(d, newStatus)
 		return nil

--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -24,6 +24,7 @@ package controller
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1016,4 +1017,22 @@ func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired
 	}
 
 	return int32(surge), int32(unavailable), nil
+}
+
+// statusUpdateRequired checks for if status update is required comparing two MachineDeployment statuses
+func statusUpdateRequired(old v1alpha1.MachineDeploymentStatus, new v1alpha1.MachineDeploymentStatus) bool {
+
+	if old.AvailableReplicas == new.AvailableReplicas &&
+		old.CollisionCount == new.CollisionCount &&
+		len(old.FailedMachines) == len(new.FailedMachines) &&
+		old.ObservedGeneration == new.ObservedGeneration &&
+		old.ReadyReplicas == new.ReadyReplicas &&
+		old.Replicas == new.Replicas &&
+		old.UpdatedReplicas == new.UpdatedReplicas &&
+		reflect.DeepEqual(old.Conditions, new.Conditions) {
+		// If all conditions are matching
+		return false
+	}
+
+	return true
 }

--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -1031,6 +1031,25 @@ func statusUpdateRequired(old v1alpha1.MachineDeploymentStatus, new v1alpha1.Mac
 		old.UpdatedReplicas == new.UpdatedReplicas &&
 		reflect.DeepEqual(old.Conditions, new.Conditions) {
 		// If all conditions are matching
+
+		// Iterate through all new failed machines and check if there
+		// exists an older machine with same name and description
+		for _, newMachine := range new.FailedMachines {
+			found := false
+
+			for _, oldMachine := range old.FailedMachines {
+				if oldMachine.Name == newMachine.Name &&
+					oldMachine.LastOperation.Description == newMachine.LastOperation.Description {
+					found = true
+					continue
+				}
+			}
+
+			if !found {
+				return true
+			}
+		}
+
 		return false
 	}
 

--- a/pkg/controller/machine_util.go
+++ b/pkg/controller/machine_util.go
@@ -199,3 +199,19 @@ func (c *controller) validateMachineClass(classSpec *v1alpha1.ClassSpec) (interf
 
 	return MachineClass, secretRef, nil
 }
+
+// nodeConditionsHaveChanged compares two node statuses to see if any of the statuses have changed
+func nodeConditionsHaveChanged(machineConditions []v1.NodeCondition, nodeConditions []v1.NodeCondition) bool {
+
+	if len(machineConditions) != len(nodeConditions) {
+		return true
+	}
+
+	for i := range nodeConditions {
+		if nodeConditions[i].Status != machineConditions[i].Status {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -140,7 +140,7 @@ func (c *controller) machineSetUpdate(old, cur interface{}) {
 	// that bad as MachineSets that haven't met expectations yet won't
 	// sync, and all the listing is done using local stores.
 	if oldMachineSet.Spec.Replicas != currentMachineSet.Spec.Replicas {
-		glog.V(4).Infof("%v %v updated. Desired machine count change: %d->%d", currentMachineSet.Name, oldMachineSet.Spec.Replicas, currentMachineSet.Spec.Replicas)
+		glog.V(4).Infof("%v updated. Desired machine count change: %d->%d", currentMachineSet.Name, oldMachineSet.Spec.Replicas, currentMachineSet.Spec.Replicas)
 	}
 	c.enqueueMachineSet(currentMachineSet)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- There were several places where machine objects were re-enqueued unwantedly
- This lead to several reconcilation loops and objects being updated frequently
- This commit removes any such code

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Removed any unwanted re-enqueuing/re-conciliation of machine objects  
```
