### PR TITLE
Add Calico subnet to OpenStack ports

### DIFF
--- a/kubernetes/openstack-machine-class.yaml
+++ b/kubernetes/openstack-machine-class.yaml
@@ -15,6 +15,7 @@ spec:
   - <security_group_name> # List of security groups which should be used for this machine
   region: <region> # Region where to place the machine
   availabilityZone: <availability_zone> # Availability zone where to place the machine
+  podNetworkCidr: <pod_network_cidr> # CIDR of the overlay Calico IP pool
   # OpenStack machine metadata block
   # Be aware, that metadata keys (tags) in OpenStack can not contain special characters likes "/"
   tags:

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -728,6 +728,7 @@ type OpenStackMachineClassSpec struct {
 	Tags             map[string]string
 	NetworkID        string
 	SecretRef        *corev1.SecretReference
+	PodNetworkCidr   string
 }
 
 /********************** AWSMachineClass APIs ***************/

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -726,6 +726,7 @@ type OpenStackMachineClassSpec struct {
 	Tags             map[string]string       `json:"tags,omitempty"`
 	NetworkID        string                  `json:"networkID"`
 	SecretRef        *corev1.SecretReference `json:"secretRef,omitempty"`
+	PodNetworkCidr   string                  `json:"podNetworkCidr"`
 }
 
 /********************** AWSMachineClass APIs ***************/

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -1902,6 +1902,7 @@ func autoConvert_v1alpha1_OpenStackMachineClassSpec_To_machine_OpenStackMachineC
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.NetworkID = in.NetworkID
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.PodNetworkCidr = in.PodNetworkCidr
 	return nil
 }
 
@@ -1920,6 +1921,7 @@ func autoConvert_machine_OpenStackMachineClassSpec_To_v1alpha1_OpenStackMachineC
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.NetworkID = in.NetworkID
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.PodNetworkCidr = in.PodNetworkCidr
 	return nil
 }
 

--- a/pkg/apis/machine/validation/openstackmachineclass.go
+++ b/pkg/apis/machine/validation/openstackmachineclass.go
@@ -58,6 +58,9 @@ func validateOpenStackMachineClassSpec(spec *machine.OpenStackMachineClassSpec, 
 	if "" == spec.NetworkID {
 		allErrs = append(allErrs, field.Required(fldPath.Child("networkID"), "NetworkID is required"))
 	}
+	if "" == spec.PodNetworkCidr {
+		allErrs = append(allErrs, field.Required(fldPath.Child("podNetworkCidr"), "PodNetworkCidr is required"))
+	}
 
 	allErrs = append(allErrs, validateSecretRef(spec.SecretRef, field.NewPath("spec.secretRef"))...)
 	allErrs = append(allErrs, validateOSClassSpecTags(spec.Tags, field.NewPath("spec.tags"))...)

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -61,8 +61,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	securityGroups := d.OpenStackMachineClass.Spec.SecurityGroups
 	availabilityZone := d.OpenStackMachineClass.Spec.AvailabilityZone
 	metadata := d.OpenStackMachineClass.Spec.Tags
-
-	podNetworkCidr := "100.96.0.0/11"
+	podNetworkCidr := d.OpenStackMachineClass.Spec.PodNetworkCidr
 
 	var createOpts servers.CreateOptsBuilder
 

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -97,6 +97,8 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 		return "", "", err
 	}
 
+	servers.WaitForStatus(client, server.ID, "ACTIVE", 300)
+
 	listOpts := &ports.ListOpts{
 		NetworkID: networkID,
 		DeviceID:  server.ID,
@@ -113,7 +115,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	}
 
 	if len(allPorts) == 0 {
-		return "", "", fmt.Errorf("got an empty port list for network ID %s", networkID)
+		return "", "", fmt.Errorf("got an empty port list for network ID %s and server ID %s", networkID, server.ID)
 	}
 
 	port, err := ports.Update(nwClient, allPorts[0].ID, ports.UpdateOpts{

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -60,6 +61,8 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	securityGroups := d.OpenStackMachineClass.Spec.SecurityGroups
 	availabilityZone := d.OpenStackMachineClass.Spec.AvailabilityZone
 	metadata := d.OpenStackMachineClass.Spec.Tags
+
+	podNetworkCidr := "100.96.0.0/11"
 
 	var createOpts servers.CreateOptsBuilder
 
@@ -89,6 +92,37 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	server, err := servers.Create(client, createOpts).Extract()
 
 	d.MachineID = d.encodeMachineID(d.OpenStackMachineClass.Spec.Region, server.ID)
+
+	nwClient, err := d.createNeutronClient()
+	if err != nil {
+		return "", "", err
+	}
+
+	listOpts := &ports.ListOpts{
+		NetworkID: networkID,
+		DeviceID:  server.ID,
+	}
+
+	allPages, err := ports.List(nwClient, listOpts).AllPages()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get ports for network ID %s: %s", networkID, err)
+	}
+
+	allPorts, err := ports.ExtractPorts(allPages)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to extract ports for network ID %s: %s", networkID, err)
+	}
+
+	port := allPorts[0]
+
+	updateOpts := ports.UpdateOpts{
+		AllowedAddressPairs: &[]ports.AddressPair{ports.AddressPair{IPAddress: podNetworkCidr}},
+	}
+
+	port, err := ports.Update(nwClient, port.ID, updateOpts).Extract()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to update allowed address pair for port ID %s: %s", port.ID, err)
+	}
 
 	return d.MachineID, d.MachineName, err
 }
@@ -279,6 +313,96 @@ func (d *OpenStackDriver) createNovaClient() (*gophercloud.ServiceClient, error)
 	}
 
 	return openstack.NewComputeV2(client, gophercloud.EndpointOpts{
+		Region:       strings.TrimSpace(region),
+		Availability: gophercloud.AvailabilityPublic,
+	})
+}
+
+// createNeutronClient is used to create a Neutron client
+func (d *OpenStackDriver) createNeutronClient() (*gophercloud.ServiceClient, error) {
+
+	config := &tls.Config{}
+
+	authURL, ok := d.CloudConfig.Data[v1alpha1.OpenStackAuthURL]
+	if !ok {
+		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackAuthURL)
+	}
+	username, ok := d.CloudConfig.Data[v1alpha1.OpenStackUsername]
+	if !ok {
+		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackUsername)
+	}
+	password, ok := d.CloudConfig.Data[v1alpha1.OpenStackPassword]
+	if !ok {
+		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackPassword)
+	}
+	domainName, ok := d.CloudConfig.Data[v1alpha1.OpenStackDomainName]
+	if !ok {
+		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackDomainName)
+	}
+	tenantName, ok := d.CloudConfig.Data[v1alpha1.OpenStackTenantName]
+	if !ok {
+		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackTenantName)
+	}
+
+	region := d.OpenStackMachineClass.Spec.Region
+	caCert, ok := d.CloudConfig.Data[v1alpha1.OpenStackCACert]
+	if !ok {
+		caCert = nil
+	}
+
+	insecure, ok := d.CloudConfig.Data[v1alpha1.OpenStackInsecure]
+	if ok && strings.TrimSpace(string(insecure)) == "true" {
+		config.InsecureSkipVerify = true
+	}
+
+	if caCert != nil {
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(caCert))
+		config.RootCAs = caCertPool
+	}
+
+	clientCert, ok := d.CloudConfig.Data[v1alpha1.OpenStackClientCert]
+	if ok {
+		clientKey, ok := d.CloudConfig.Data[v1alpha1.OpenStackClientKey]
+		if ok {
+			cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
+			if err != nil {
+				return nil, err
+			}
+			config.Certificates = []tls.Certificate{cert}
+			config.BuildNameToCertificate()
+		} else {
+			return nil, fmt.Errorf("%s missing in secret", v1alpha1.OpenStackClientKey)
+		}
+	}
+
+	opts := gophercloud.AuthOptions{
+		IdentityEndpoint: strings.TrimSpace(string(authURL)),
+		Username:         strings.TrimSpace(string(username)),
+		Password:         strings.TrimSpace(string(password)),
+		DomainName:       strings.TrimSpace(string(domainName)),
+		TenantName:       strings.TrimSpace(string(tenantName)),
+	}
+
+	client, err := openstack.NewClient(opts.IdentityEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set UserAgent
+	client.UserAgent.Prepend("Machine Controller 08/15")
+
+	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
+	client.HTTPClient = http.Client{
+		Transport: transport,
+	}
+
+	err = openstack.Authenticate(client, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return openstack.NewNetworkV2(client, gophercloud.EndpointOpts{
 		Region:       strings.TrimSpace(region),
 		Availability: gophercloud.AvailabilityPublic,
 	})

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -112,13 +112,13 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 		return "", "", fmt.Errorf("failed to extract ports for network ID %s: %s", networkID, err)
 	}
 
-	port := allPorts[0]
-
-	updateOpts := ports.UpdateOpts{
-		AllowedAddressPairs: &[]ports.AddressPair{ports.AddressPair{IPAddress: podNetworkCidr}},
+	if len(allPorts) == 0 {
+		return "", "", fmt.Errorf("got an empty port list for network ID %s", networkID)
 	}
 
-	port, err := ports.Update(nwClient, port.ID, updateOpts).Extract()
+	port, err := ports.Update(nwClient, allPorts[0].ID, ports.UpdateOpts{
+		AllowedAddressPairs: &[]ports.AddressPair{ports.AddressPair{IPAddress: podNetworkCidr}},
+	}).Extract()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to update allowed address pair for port ID %s: %s", port.ID, err)
 	}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2544,8 +2544,14 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref: ref("k8s.io/api/core/v1.SecretReference"),
 							},
 						},
+						"podNetworkCidr": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"string"},
+								Format: "",
+							},
+						},
 					},
-					Required: []string{"imageName", "region", "availabilityZone", "flavorName", "keyName", "securityGroups", "networkID"},
+					Required: []string{"imageName", "region", "availabilityZone", "flavorName", "keyName", "securityGroups", "networkID", "podNetworkCidr"},
 				},
 			},
 			Dependencies: []string{

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/doc.go
@@ -1,0 +1,73 @@
+/*
+Package ports contains functionality for working with Neutron port resources.
+
+A port represents a virtual switch port on a logical network switch. Virtual
+instances attach their interfaces into ports. The logical port also defines
+the MAC address and the IP address(es) to be assigned to the interfaces
+plugged into them. When IP addresses are associated to a port, this also
+implies the port is associated with a subnet, as the IP address was taken
+from the allocation pool for a specific subnet.
+
+Example to List Ports
+
+	listOpts := ports.ListOpts{
+		DeviceID: "b0b89efe-82f8-461d-958b-adbf80f50c7d",
+	}
+
+	allPages, err := ports.List(networkClient, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allPorts, err := ports.ExtractPorts(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, port := range allPorts {
+		fmt.Printf("%+v\n", port)
+	}
+
+Example to Create a Port
+
+	createOtps := ports.CreateOpts{
+		Name:         "private-port",
+		AdminStateUp: &asu,
+		NetworkID:    "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		FixedIPs: []ports.IP{
+			{SubnetID: "a0304c3a-4f08-4c43-88af-d796509c97d2", IPAddress: "10.0.0.2"},
+		},
+		SecurityGroups: &[]string{"foo"},
+		AllowedAddressPairs: []ports.AddressPair{
+			{IPAddress: "10.0.0.4", MACAddress: "fa:16:3e:c9:cb:f0"},
+		},
+	}
+
+	port, err := ports.Create(networkClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Update a Port
+
+	portID := "c34bae2b-7641-49b6-bf6d-d8e473620ed8"
+
+	updateOpts := ports.UpdateOpts{
+		Name:           "new_name",
+		SecurityGroups: &[]string{},
+	}
+
+	port, err := ports.Update(networkClient, portID, updateOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete a Port
+
+	portID := "c34bae2b-7641-49b6-bf6d-d8e473620ed8"
+	err := ports.Delete(networkClient, portID).ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package ports

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/requests.go
@@ -1,0 +1,177 @@
+package ports
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToPortListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the port attributes you want to see returned. SortKey allows you to sort
+// by a particular port attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Status       string `q:"status"`
+	Name         string `q:"name"`
+	AdminStateUp *bool  `q:"admin_state_up"`
+	NetworkID    string `q:"network_id"`
+	TenantID     string `q:"tenant_id"`
+	DeviceOwner  string `q:"device_owner"`
+	MACAddress   string `q:"mac_address"`
+	ID           string `q:"id"`
+	DeviceID     string `q:"device_id"`
+	Limit        int    `q:"limit"`
+	Marker       string `q:"marker"`
+	SortKey      string `q:"sort_key"`
+	SortDir      string `q:"sort_dir"`
+}
+
+// ToPortListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToPortListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// ports. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+//
+// Default policy settings return only those ports that are owned by the tenant
+// who submits the request, unless the request is submitted by a user with
+// administrative rights.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToPortListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return PortPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific port based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPortCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents the attributes used when creating a new port.
+type CreateOpts struct {
+	NetworkID           string        `json:"network_id" required:"true"`
+	Name                string        `json:"name,omitempty"`
+	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
+	MACAddress          string        `json:"mac_address,omitempty"`
+	FixedIPs            interface{}   `json:"fixed_ips,omitempty"`
+	DeviceID            string        `json:"device_id,omitempty"`
+	DeviceOwner         string        `json:"device_owner,omitempty"`
+	TenantID            string        `json:"tenant_id,omitempty"`
+	SecurityGroups      *[]string     `json:"security_groups,omitempty"`
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+}
+
+// ToPortCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToPortCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "port")
+}
+
+// Create accepts a CreateOpts struct and creates a new network using the values
+// provided. You must remember to provide a NetworkID value.
+func Create(c *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPortCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(createURL(c), b, &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPortUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts represents the attributes used when updating an existing port.
+type UpdateOpts struct {
+	Name                string         `json:"name,omitempty"`
+	AdminStateUp        *bool          `json:"admin_state_up,omitempty"`
+	FixedIPs            interface{}    `json:"fixed_ips,omitempty"`
+	DeviceID            string         `json:"device_id,omitempty"`
+	DeviceOwner         string         `json:"device_owner,omitempty"`
+	SecurityGroups      *[]string      `json:"security_groups,omitempty"`
+	AllowedAddressPairs *[]AddressPair `json:"allowed_address_pairs,omitempty"`
+}
+
+// ToPortUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToPortUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "port")
+}
+
+// Update accepts a UpdateOpts struct and updates an existing port using the
+// values provided.
+func Update(c *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPortUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(updateURL(c, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the port associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
+}
+
+// IDFromName is a convenience function that returns a port's ID,
+// given its name.
+func IDFromName(client *gophercloud.ServiceClient, name string) (string, error) {
+	count := 0
+	id := ""
+	pages, err := List(client, nil).AllPages()
+	if err != nil {
+		return "", err
+	}
+
+	all, err := ExtractPorts(pages)
+	if err != nil {
+		return "", err
+	}
+
+	for _, s := range all {
+		if s.Name == name {
+			count++
+			id = s.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", gophercloud.ErrResourceNotFound{Name: name, ResourceType: "port"}
+	case 1:
+		return id, nil
+	default:
+		return "", gophercloud.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "port"}
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/results.go
@@ -1,0 +1,140 @@
+package ports
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract is a function that accepts a result and extracts a port resource.
+func (r commonResult) Extract() (*Port, error) {
+	var s Port
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "port")
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Port.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Port.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Port.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// IP is a sub-struct that represents an individual IP.
+type IP struct {
+	SubnetID  string `json:"subnet_id"`
+	IPAddress string `json:"ip_address,omitempty"`
+}
+
+// AddressPair contains the IP Address and the MAC address.
+type AddressPair struct {
+	IPAddress  string `json:"ip_address,omitempty"`
+	MACAddress string `json:"mac_address,omitempty"`
+}
+
+// Port represents a Neutron port. See package documentation for a top-level
+// description of what this is.
+type Port struct {
+	// UUID for the port.
+	ID string `json:"id"`
+
+	// Network that this port is associated with.
+	NetworkID string `json:"network_id"`
+
+	// Human-readable name for the port. Might not be unique.
+	Name string `json:"name"`
+
+	// Administrative state of port. If false (down), port does not forward
+	// packets.
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// Indicates whether network is currently operational. Possible values include
+	// `ACTIVE', `DOWN', `BUILD', or `ERROR'. Plug-ins might define additional
+	// values.
+	Status string `json:"status"`
+
+	// Mac address to use on this port.
+	MACAddress string `json:"mac_address"`
+
+	// Specifies IP addresses for the port thus associating the port itself with
+	// the subnets where the IP addresses are picked from
+	FixedIPs []IP `json:"fixed_ips"`
+
+	// Owner of network.
+	TenantID string `json:"tenant_id"`
+
+	// Identifies the entity (e.g.: dhcp agent) using this port.
+	DeviceOwner string `json:"device_owner"`
+
+	// Specifies the IDs of any security groups associated with a port.
+	SecurityGroups []string `json:"security_groups"`
+
+	// Identifies the device (e.g., virtual server) using this port.
+	DeviceID string `json:"device_id"`
+
+	// Identifies the list of IP addresses the port will recognize/accept
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs"`
+}
+
+// PortPage is the page returned by a pager when traversing over a collection
+// of network ports.
+type PortPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of ports has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r PortPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"ports_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a PortPage struct is empty.
+func (r PortPage) IsEmpty() (bool, error) {
+	is, err := ExtractPorts(r)
+	return len(is) == 0, err
+}
+
+// ExtractPorts accepts a Page struct, specifically a PortPage struct,
+// and extracts the elements into a slice of Port structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractPorts(r pagination.Page) ([]Port, error) {
+	var s []Port
+	err := ExtractPortsInto(r, &s)
+	return s, err
+}
+
+func ExtractPortsInto(r pagination.Page, v interface{}) error {
+	return r.(PortPage).Result.ExtractIntoSlicePtr(v, "ports")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports/urls.go
@@ -1,0 +1,31 @@
+package ports
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("ports", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("ports")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
Add allowed address pair with the Calico IPPool subnet to OpenStack ports during server creation to allow communication between worker without additional IPinIP protocol.

Fixes #141 

See https://github.com/gardener/gardener/issues/160 for the gardener related changes.

