### PR TITLE
Adding cluster-api ref in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ See the design documentation in the `/docs/design` repository, please [find the 
 ## To start using or developing the Machine Controller Manager
 
 See the documentation in the `/docs` repository, please [find the index here](docs/README.md).
+
+## Cluster-api Implementation
+- `cluster-api` branch of machine-controller-manager implements the machine-api aspect of the [cluster-api project](https://github.com/kubernetes-sigs/cluster-api).
+- Link: https://github.com/gardener/machine-controller-manager/tree/cluster-api
+- Once cluster-api project gets stable, we may make `master` branch of MCM as well cluster-api compliant, with well-defined migration notes.


### PR DESCRIPTION
**What this PR does / why we need it**: Updating to README to include the cluster-api reference in it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator

```
