### PR TITLE
post release notes to internal slack channel

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -38,4 +38,10 @@ machine-controller-manager:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'k8s-mcm'
+              slack_cfg_name: 'scp_workspace'
         component_descriptor: ~


### PR DESCRIPTION
**What this PR does / why we need it**:
On a new release of the machine-controller-manager, the release notes should be published to the internal slack channel `k8s-mcm`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We have requested a [slack bot](https://kubernetes.slack.com/apps/A0F7YS25R-bots?next_id=0) on the `Kubernetes` workspace to publish release notes to the public `gardener` channel but it was rejected by one of the Kubernetes slack admins.  

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```