### PR TITLE
External driver handles restsart of MCM gracefully

### DIFF
--- a/cmd/external-aws-client/external-aws-client.go
+++ b/cmd/external-aws-client/external-aws-client.go
@@ -45,7 +45,7 @@ func main() {
 	awsDriver.(*aws.AwsDriverProvider).MachineClassDataProvider = externalDriver
 
 	defer externalDriver.Stop()
-	externalDriver.Start()
+	go externalDriver.Start()
 	log.Printf("Started external aws client")
 	<-stopCh
 }

--- a/pkg/external/driver/aws/aws.go
+++ b/pkg/external/driver/aws/aws.go
@@ -276,6 +276,7 @@ func (d *AwsDriverProvider) List(machineClassMeta *infraclient.MachineClassMeta,
 		}
 	}
 
+	fmt.Println("List() returned: ", listOfVMs)
 	return listOfVMs, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
External driver handles restsart of MCM gracefully, instead of crashing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
NONE
-->
```improvement operator

```
