### PR TITLE
Fix panic issue when AccessKeyID or AccessKeySecret is empty

### DIFF
--- a/kubernetes/machine_classes/alicloud-machine-class.yaml
+++ b/kubernetes/machine_classes/alicloud-machine-class.yaml
@@ -6,10 +6,10 @@ metadata:
   name: test-alicloud # Name of Alicloud machine class goes here
   namespace: default # Namespace in which the machine class is to be deployed
 spec:
-  imageName: coreos_1745_7_0_64_30G_alibase_20180705.vhd # Alicloud machine image name goes here, e.g. centos_7_04_64_20G_alibase_201701015
+  imageID: coreos_1745_7_0_64_30G_alibase_20180705.vhd # Alicloud machine image name goes here, e.g. centos_7_04_64_20G_alibase_201701015
   instanceType: ecs.n1.medium # Type of ecs machine ecs.t5-lc1m1.small ecs.t5-lc2m1.nano
   region: cn-hangzhou # Region in which machine is to be deployed
-  zone: cn-hangzhou-e # Zone of the region
+  zoneID: cn-hangzhou-e # Zone of the region
   securityGroupID: sg-1234567890 # ID of security group, it has to be within the same VPC of vSwitch
   vSwitchID: vsw-1234567890 # similar to AWS subnet ID
   systemDisk:

--- a/pkg/apis/machine/validation/alicloudmachineclass.go
+++ b/pkg/apis/machine/validation/alicloudmachineclass.go
@@ -45,10 +45,13 @@ func validateAlicloudMachineClassSpec(spec *machine.AlicloudMachineClassSpec, fl
 	allErrs := field.ErrorList{}
 
 	if "" == spec.ImageID {
-		allErrs = append(allErrs, field.Required(fldPath.Child("imageName"), "ImageName is required"))
+		allErrs = append(allErrs, field.Required(fldPath.Child("imageID"), "ImageID is required"))
 	}
 	if "" == spec.Region {
 		allErrs = append(allErrs, field.Required(fldPath.Child("region"), "Region is required"))
+	}
+	if "" == spec.ZoneID {
+		allErrs = append(allErrs, field.Required(fldPath.Child("zoneID"), "ZoneID is required"))
 	}
 	if "" == spec.InstanceType {
 		allErrs = append(allErrs, field.Required(fldPath.Child("instanceType"), "InstanceType is required"))

--- a/pkg/driver/driver_alicloud.go
+++ b/pkg/driver/driver_alicloud.go
@@ -283,7 +283,7 @@ func (c *AlicloudDriver) getEcsClient() (*ecs.Client, error) {
 	if accessKeyID != "" && accessKeySecret != "" && region != "" {
 		ecsClient, err = ecs.NewClientWithAccessKey(region, accessKeyID, accessKeySecret)
 	} else {
-		ecsClient, err = ecs.NewClient()
+		err = errors.New("alicloudAccessKeyID or alicloudAccessKeySecret can't be empty")
 	}
 	return ecsClient, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the issue that panic happens when AccessKeyID or AccessKeySecret is empty for alicloud.
**Which issue(s) this PR fixes**:
Fixes #145

**Special notes for your reviewer**:
NONE
**Release note**:
NONE
