### PR TITLE
Enhancement freeze logic

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -49,7 +49,9 @@ if [[ "${SOURCE_PATH}" != *"src/github.com/gardener/machine-controller-manager" 
 fi
 
 # Install Ginkgo (test framework) to be able to execute the tests.
+echo "Fetching Ginkgo frawework"
 go get -u github.com/onsi/ginkgo/ginkgo
+echo "Successfully fetched Ginkgo frawework"
 
 ##############################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ start:
 			--machine-set-scale-timeout=20 \
 			--machine-safety-orphan-vms-period=30 \
 			--machine-safety-overshooting-period=1 \
+			--machine-safety-apiserver-period=1m \
+			--machine-safety-apiserver-timeout=30s \
 			--v=2
 
 #################################################################

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -61,13 +61,15 @@ func NewMCMServer() *MCMServer {
 			LeaderElection:          leaderelectionconfig.DefaultLeaderElectionConfiguration(),
 			ControllerStartInterval: metav1.Duration{Duration: 0 * time.Second},
 			SafetyOptions: machineconfig.SafetyOptions{
-				SafetyUp:                        2,
-				SafetyDown:                      1,
-				MachineHealthTimeout:            10,
-				MachineDrainTimeout:             5,
-				MachineSetScaleTimeout:          20,
-				MachineSafetyOrphanVMsPeriod:    30,
-				MachineSafetyOvershootingPeriod: 1,
+				SafetyUp:                            2,
+				SafetyDown:                          1,
+				MachineHealthTimeout:                10,
+				MachineDrainTimeout:                 5,
+				MachineSetScaleTimeout:              20,
+				MachineSafetyOrphanVMsPeriod:        30,
+				MachineSafetyOvershootingPeriod:     1,
+				MachineSafetyAPIServerStatusPeriod:  metav1.Duration{Duration: 1 * time.Minute},
+				MachineSafetyAPIServerStatusTimeout: metav1.Duration{Duration: 30 * time.Second},
 			},
 		},
 	}
@@ -99,6 +101,9 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&s.SafetyOptions.MachineSetScaleTimeout, "machine-set-scale-timeout", s.SafetyOptions.MachineSetScaleTimeout, "Timeout (in minutes) used while scaling machineSet if timeout occurs machineSet is frozen.")
 	fs.Int32Var(&s.SafetyOptions.MachineSafetyOrphanVMsPeriod, "machine-safety-orphan-vms-period", s.SafetyOptions.MachineSafetyOrphanVMsPeriod, "Time period (in minutes) used to poll for orphan VMs by safety controller.")
 	fs.Int32Var(&s.SafetyOptions.MachineSafetyOvershootingPeriod, "machine-safety-overshooting-period", s.SafetyOptions.MachineSafetyOvershootingPeriod, "Time period (in minutes) used to poll for overshooting of machine objects backing a machineSet by safety controller.")
+
+	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusTimeout.Duration, "machine-safety-apiserver-timeout", s.SafetyOptions.MachineSafetyAPIServerStatusTimeout.Duration, "Timeout (in duration) for which the APIServer can be down before declare the machine controller frozen by safety controller")
+	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusPeriod.Duration, "machine-safety-apiserver-period", s.SafetyOptions.MachineSafetyAPIServerStatusPeriod.Duration, "Period (in duration) used to poll for APIServer's health by safety controller")
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -61,15 +61,15 @@ func NewMCMServer() *MCMServer {
 			LeaderElection:          leaderelectionconfig.DefaultLeaderElectionConfiguration(),
 			ControllerStartInterval: metav1.Duration{Duration: 0 * time.Second},
 			SafetyOptions: machineconfig.SafetyOptions{
-				SafetyUp:                            2,
-				SafetyDown:                          1,
-				MachineHealthTimeout:                10,
-				MachineDrainTimeout:                 5,
-				MachineSetScaleTimeout:              20,
-				MachineSafetyOrphanVMsPeriod:        30,
-				MachineSafetyOvershootingPeriod:     1,
-				MachineSafetyAPIServerStatusPeriod:  metav1.Duration{Duration: 1 * time.Minute},
-				MachineSafetyAPIServerStatusTimeout: metav1.Duration{Duration: 30 * time.Second},
+				SafetyUp:                                 2,
+				SafetyDown:                               1,
+				MachineHealthTimeout:                     10,
+				MachineDrainTimeout:                      5,
+				MachineSetScaleTimeout:                   20,
+				MachineSafetyOrphanVMsPeriod:             30,
+				MachineSafetyOvershootingPeriod:          1,
+				MachineSafetyAPIServerStatusCheckPeriod:  metav1.Duration{Duration: 1 * time.Minute},
+				MachineSafetyAPIServerStatusCheckTimeout: metav1.Duration{Duration: 30 * time.Second},
 			},
 		},
 	}
@@ -102,8 +102,8 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&s.SafetyOptions.MachineSafetyOrphanVMsPeriod, "machine-safety-orphan-vms-period", s.SafetyOptions.MachineSafetyOrphanVMsPeriod, "Time period (in minutes) used to poll for orphan VMs by safety controller.")
 	fs.Int32Var(&s.SafetyOptions.MachineSafetyOvershootingPeriod, "machine-safety-overshooting-period", s.SafetyOptions.MachineSafetyOvershootingPeriod, "Time period (in minutes) used to poll for overshooting of machine objects backing a machineSet by safety controller.")
 
-	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusTimeout.Duration, "machine-safety-apiserver-timeout", s.SafetyOptions.MachineSafetyAPIServerStatusTimeout.Duration, "Timeout (in duration) for which the APIServer can be down before declare the machine controller frozen by safety controller")
-	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusPeriod.Duration, "machine-safety-apiserver-period", s.SafetyOptions.MachineSafetyAPIServerStatusPeriod.Duration, "Period (in duration) used to poll for APIServer's health by safety controller")
+	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "machine-safety-apiserver-statuscheck-timeout", s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "Timeout (in duration) for which the APIServer can be down before declare the machine controller frozen by safety controller")
+	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "machine-safety-apiserver-statuscheck-period", s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "Period (in duration) used to poll for APIServer's health by safety controller")
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -18,40 +18,30 @@ package controller
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
-	"errors"
+	"testing"
 
 	machine_internal "github.com/gardener/machine-controller-manager/pkg/apis/machine"
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	fakeuntyped "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/fake"
 	faketyped "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/typed/machine/v1alpha1/fake"
 	machineinformers "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions"
+	customfake "github.com/gardener/machine-controller-manager/pkg/fakeclient"
 	"github.com/gardener/machine-controller-manager/pkg/options"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/watch"
 	coreinformers "k8s.io/client-go/informers"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
-	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-
-	"testing"
 )
 
 func TestMachineControllerManagerSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Machine Controller Manager suite")
+	RunSpecs(t, "Machine Controller Manager Suite")
 }
 
 var (
@@ -227,25 +217,37 @@ func newSecretReference(meta *metav1.ObjectMeta, index int) *corev1.SecretRefere
 	return r
 }
 
-func createController(stop <-chan struct{}, namespace string, machineObjects, coreObjects []runtime.Object) (*controller, *watchableObjectTracker) {
-	// TODO controlCoreClient
-	fakeCoreClient := k8sfake.NewSimpleClientset(coreObjects...)
-	coreInformerFactory := coreinformers.NewFilteredSharedInformerFactory(
-		fakeCoreClient,
+func createController(stop <-chan struct{}, namespace string, controlMachineObjects, controlCoreObjects, targetCoreObjects []runtime.Object) (*controller, []*customfake.FakeObjectTracker) {
+
+	var (
+		watchableObjectTrackers []*customfake.FakeObjectTracker
+	)
+
+	fakeMachineClient, w := customfake.NewMachineClientSet(controlMachineObjects...)
+	go w.Start()
+	watchableObjectTrackers = append(watchableObjectTrackers, w)
+	fakeTypedMachineClient := &faketyped.FakeMachineV1alpha1{
+		Fake: &fakeMachineClient.Fake,
+	}
+
+	fakeControlCoreClient, w := customfake.NewCoreClientSet(controlCoreObjects...)
+	go w.Start()
+	watchableObjectTrackers = append(watchableObjectTrackers, w)
+
+	fakeTargetCoreClient, w := customfake.NewCoreClientSet(targetCoreObjects...)
+	go w.Start()
+	watchableObjectTrackers = append(watchableObjectTrackers, w)
+
+	coreTargetInformerFactory := coreinformers.NewFilteredSharedInformerFactory(
+		fakeTargetCoreClient,
 		100*time.Millisecond,
 		namespace,
 		nil,
 	)
-	defer coreInformerFactory.Start(stop)
+	defer coreTargetInformerFactory.Start(stop)
+	coreTargetSharedInformers := coreTargetInformerFactory.Core().V1()
+	nodes := coreTargetSharedInformers.Nodes()
 
-	coreSharedInformers := coreInformerFactory.Core().V1()
-	nodes := coreSharedInformers.Nodes()
-
-	fakeMachineClient, w := newMachineClientSet(machineObjects...)
-	go w.Start()
-	fakeTypedMachineClient := &faketyped.FakeMachineV1alpha1{
-		Fake: &fakeMachineClient.Fake,
-	}
 	controlMachineInformerFactory := machineinformers.NewFilteredSharedInformerFactory(
 		fakeMachineClient,
 		100*time.Millisecond,
@@ -285,7 +287,8 @@ func createController(stop <-chan struct{}, namespace string, machineObjects, co
 		azureMachineClassLister:        azure.Lister(),
 		gcpMachineClassLister:          gcp.Lister(),
 		openStackMachineClassLister:    openstack.Lister(),
-		controlCoreClient:              fakeCoreClient,
+		targetCoreClient:               fakeTargetCoreClient,
+		controlCoreClient:              fakeControlCoreClient,
 		controlMachineClient:           fakeTypedMachineClient,
 		internalExternalScheme:         internalExternalScheme,
 		nodeLister:                     nodes.Lister(),
@@ -306,7 +309,8 @@ func createController(stop <-chan struct{}, namespace string, machineObjects, co
 		machineDeploymentQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinedeployment"),
 		machineSafetyOrphanVMsQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyorphanvms"),
 		machineSafetyOvershootingQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyovershooting"),
-	}, w
+		machineSafetyAPIServerQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyapiserver"),
+	}, watchableObjectTrackers
 }
 
 func waitForCacheSync(stop <-chan struct{}, controller *controller) {
@@ -317,254 +321,6 @@ func waitForCacheSync(stop <-chan struct{}, controller *controller) {
 		controller.machineSetSynced,
 		controller.machineDeploymentSynced,
 	)).To(BeTrue())
-}
-
-func newMachineClientSet(objects ...runtime.Object) (*fakeuntyped.Clientset, *watchableObjectTracker) {
-	var scheme = runtime.NewScheme()
-	var codecs = serializer.NewCodecFactory(scheme)
-
-	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
-	fakeuntyped.AddToScheme(scheme)
-
-	o := &watchableObjectTracker{
-		FakeWatcher: watch.NewFake(),
-		delegatee:   k8stesting.NewObjectTracker(scheme, codecs.UniversalDecoder()),
-	}
-
-	for _, obj := range objects {
-		if err := o.Add(obj); err != nil {
-			panic(err)
-		}
-	}
-
-	cs := &fakeuntyped.Clientset{}
-	cs.Fake.AddReactor("*", "*", k8stesting.ObjectReaction(o))
-	cs.Fake.AddWatchReactor("*", o.watchReactionfunc)
-
-	return cs, o
-}
-
-//watchableObjectTracker implements both k8stesting.ObjectTracker as well as watch.Interface.
-type watchableObjectTracker struct {
-	*watch.FakeWatcher
-	delegatee    k8stesting.ObjectTracker
-	watchers     []*watcher
-	trackerMutex sync.Mutex
-}
-
-func (t *watchableObjectTracker) Add(obj runtime.Object) error {
-	return t.delegatee.Add(obj)
-}
-
-func (t *watchableObjectTracker) Get(gvr schema.GroupVersionResource, ns, name string) (runtime.Object, error) {
-	return t.delegatee.Get(gvr, ns, name)
-}
-
-func (t *watchableObjectTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
-	err := t.delegatee.Create(gvr, obj, ns)
-	if err != nil {
-		return err
-	}
-
-	if t.FakeWatcher == nil {
-		return errors.New("Error sending event on a tracker with no watch support")
-	}
-
-	if t.IsStopped() {
-		return errors.New("Error sending event on a stopped tracker")
-	}
-
-	t.FakeWatcher.Add(obj)
-	return nil
-}
-
-func (t *watchableObjectTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
-	err := t.delegatee.Update(gvr, obj, ns)
-	if err != nil {
-		return err
-	}
-
-	if t.FakeWatcher == nil {
-		return errors.New("Error sending event on a tracker with no watch support")
-	}
-
-	if t.IsStopped() {
-		return errors.New("Error sending event on a stopped tracker")
-	}
-
-	t.FakeWatcher.Modify(obj)
-	return nil
-}
-
-func (t *watchableObjectTracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string) (runtime.Object, error) {
-	return t.delegatee.List(gvr, gvk, ns)
-}
-
-func (t *watchableObjectTracker) Delete(gvr schema.GroupVersionResource, ns, name string) error {
-	obj, errGet := t.delegatee.Get(gvr, ns, name)
-	err := t.delegatee.Delete(gvr, ns, name)
-	if err != nil {
-		return err
-	}
-
-	if errGet != nil {
-		return errGet
-	}
-
-	if t.FakeWatcher == nil {
-		return errors.New("Error sending event on a tracker with no watch support")
-	}
-
-	if t.IsStopped() {
-		return errors.New("Error sending event on a stopped tracker")
-	}
-
-	t.FakeWatcher.Delete(obj)
-	return nil
-}
-
-func (t *watchableObjectTracker) Watch(gvr schema.GroupVersionResource, name string) (watch.Interface, error) {
-	// TODO: Fix this
-	return nil, errors.New("Cannot watch on a tracker with no watch support")
-}
-
-func (t *watchableObjectTracker) watchReactionfunc(action k8stesting.Action) (bool, watch.Interface, error) {
-	if t.FakeWatcher == nil {
-		return false, nil, errors.New("Cannot watch on a tracker with no watch support")
-	}
-
-	switch a := action.(type) {
-	case k8stesting.WatchAction:
-		w := &watcher{
-			FakeWatcher: watch.NewFake(),
-			action:      a,
-		}
-		go w.dispatchInitialObjects(a, t)
-		t.trackerMutex.Lock()
-		defer t.trackerMutex.Unlock()
-		t.watchers = append(t.watchers, w)
-		return true, w, nil
-	default:
-		return false, nil, fmt.Errorf("Expected WatchAction but got %v", action)
-	}
-}
-
-func (t *watchableObjectTracker) Start() error {
-	if t.FakeWatcher == nil {
-		return errors.New("Tracker has no watch support")
-	}
-
-	for event := range t.ResultChan() {
-		t.dispatch(&event)
-	}
-
-	return nil
-}
-
-func (t *watchableObjectTracker) dispatch(event *watch.Event) {
-	for _, w := range t.watchers {
-		go w.dispatch(event)
-	}
-}
-
-func (t *watchableObjectTracker) Stop() {
-	if t.FakeWatcher == nil {
-		panic(errors.New("Tracker has no watch support"))
-	}
-
-	t.trackerMutex.Lock()
-	defer t.trackerMutex.Unlock()
-
-	t.FakeWatcher.Stop()
-	for _, w := range t.watchers {
-		w.Stop()
-	}
-	t.watchers = []*watcher{}
-}
-
-type watcher struct {
-	*watch.FakeWatcher
-	action      k8stesting.WatchAction
-	updateMutex sync.Mutex
-}
-
-func (w *watcher) Stop() {
-	w.updateMutex.Lock()
-	defer w.updateMutex.Unlock()
-
-	w.FakeWatcher.Stop()
-}
-
-func (w *watcher) handles(event *watch.Event) bool {
-	if w.IsStopped() {
-		return false
-	}
-
-	t, err := meta.TypeAccessor(event.Object)
-	if err != nil {
-		return false
-	}
-
-	gvr, _ := meta.UnsafeGuessKindToResource(schema.FromAPIVersionAndKind(t.GetAPIVersion(), t.GetKind()))
-	if !(&k8stesting.SimpleWatchReactor{Resource: gvr.Resource}).Handles(w.action) {
-		return false
-	}
-
-	o, err := meta.Accessor(event.Object)
-	if err != nil {
-		return false
-	}
-
-	info := w.action.GetWatchRestrictions()
-	rv, fs, ls := info.ResourceVersion, info.Fields, info.Labels
-	if rv != "" && o.GetResourceVersion() != rv {
-		return false
-	}
-
-	if fs != nil && !fs.Matches(fields.Set{
-		"metadata.name":      o.GetName(),
-		"metadata.namespace": o.GetNamespace(),
-	}) {
-		return false
-	}
-
-	if ls != nil && !ls.Matches(labels.Set(o.GetLabels())) {
-		return false
-	}
-
-	return true
-}
-
-func (w *watcher) dispatch(event *watch.Event) {
-	w.updateMutex.Lock()
-	defer w.updateMutex.Unlock()
-
-	if !w.handles(event) {
-		return
-	}
-	w.Action(event.Type, event.Object)
-}
-
-func (w *watcher) dispatchInitialObjects(action k8stesting.WatchAction, t k8stesting.ObjectTracker) error {
-	listObj, err := t.List(action.GetResource(), action.GetResource().GroupVersion().WithKind(action.GetResource().Resource), action.GetNamespace())
-	if err != nil {
-		return err
-	}
-
-	itemsPtr, err := meta.GetItemsPtr(listObj)
-	if err != nil {
-		return err
-	}
-
-	items := itemsPtr.([]runtime.Object)
-	for _, o := range items {
-		w.dispatch(&watch.Event{
-			Type:   watch.Added,
-			Object: o,
-		})
-	}
-
-	return nil
 }
 
 var _ = Describe("#createController", func() {
@@ -581,13 +337,15 @@ var _ = Describe("#createController", func() {
 		stop := make(chan struct{})
 		defer close(stop)
 
-		c, w := createController(stop, objMeta.Namespace, nil, nil)
-		defer w.Stop()
+		c, watches := createController(stop, objMeta.Namespace, nil, nil, nil)
+		for _, watch := range watches {
+			defer watch.Stop()
+			Expect(watch).NotTo(BeNil())
+		}
 
 		waitForCacheSync(stop, c)
 
 		Expect(c).NotTo(BeNil())
-		Expect(w).NotTo(BeNil())
 
 		allMachineWatch, err := c.controlMachineClient.Machines(objMeta.Namespace).Watch(metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -270,13 +270,15 @@ func createController(stop <-chan struct{}, namespace string, controlMachineObje
 	Expect(v1alpha1.AddToScheme(internalExternalScheme)).To(Succeed())
 
 	safetyOptions := options.SafetyOptions{
-		SafetyUp:                        2,
-		SafetyDown:                      1,
-		MachineDrainTimeout:             5,
-		MachineHealthTimeout:            10,
-		MachineSetScaleTimeout:          2,
-		MachineSafetyOrphanVMsPeriod:    30,
-		MachineSafetyOvershootingPeriod: 1,
+		SafetyUp:                            2,
+		SafetyDown:                          1,
+		MachineDrainTimeout:                 5,
+		MachineHealthTimeout:                10,
+		MachineSetScaleTimeout:              2,
+		MachineSafetyOrphanVMsPeriod:        30,
+		MachineSafetyOvershootingPeriod:     1,
+		MachineSafetyAPIServerStatusPeriod:  metav1.Duration{Duration: 1 * time.Minute},
+		MachineSafetyAPIServerStatusTimeout: metav1.Duration{Duration: 30 * time.Second},
 	}
 
 	return &controller{

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -119,8 +119,6 @@ func (c *controller) reconcileClusterMachineSafetyAPIServer(key string) error {
 				c.enqueueMachineAfter(machine, 30*time.Second)
 			}
 
-			// Wait 30 seconds for machines to rejoin
-			time.Sleep(30 * time.Second)
 			c.safetyOptions.MachineControllerFrozen = false
 			c.safetyOptions.APIserverInactiveStartTime = time.Time{}
 			glog.V(2).Infof("reconcileClusterMachineSafetyAPIServer: UnFreezing Machine Controller")

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -151,18 +151,18 @@ func (c *controller) reconcileClusterMachineSafetyAPIServer(key string) error {
 // Both control and target APIServers
 func (c *controller) isAPIServerUp() bool {
 	// Dummy get call to check if control APIServer is reachable
-	_, err := c.controlMachineClient.Machines(c.namespace).Get("", metav1.GetOptions{})
+	_, err := c.controlMachineClient.Machines(c.namespace).Get("dummy_name", metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		// Get returns an error other than object not found = Assume APIServer is not reachable
-		glog.Warning("Unable to list on machine objects", err)
+		glog.Warning("Unable to get on machine objects ", err)
 		return false
 	}
 
 	// Dummy get call to check if target APIServer is reachable
-	_, err = c.targetCoreClient.CoreV1().Nodes().Get("", metav1.GetOptions{})
+	_, err = c.targetCoreClient.CoreV1().Nodes().Get("dummy_name", metav1.GetOptions{})
 	if err != nil && !apierrors.IsNotFound(err) {
 		// Get returns an error other than object not found = Assume APIServer is not reachable
-		glog.Warning("Unable to list on node objects", err)
+		glog.Warning("Unable to get on node objects ", err)
 		return false
 	}
 

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -140,7 +140,7 @@ func (c *controller) reconcileClusterMachineSafetyAPIServer(key string) error {
 			}
 
 			// Re-enqueue the safety check more often if APIServer is not active and is not frozen yet
-			defer c.machineSafetyAPIServerQueue.AddAfter("", sleepPeriod/5)
+			defer c.machineSafetyAPIServerQueue.AddAfter("", inactivePeriod/5)
 			return nil
 		}
 	}

--- a/pkg/controller/machine_safety_test.go
+++ b/pkg/controller/machine_safety_test.go
@@ -37,12 +37,15 @@ var _ = Describe("machine", func() {
 			const freezeReason = OverShootingReplicaCount
 			const freezeMessage = OverShootingReplicaCount
 
-			objects := []runtime.Object{}
+			controlMachineObjects := []runtime.Object{}
 			if machineSet != nil {
-				objects = append(objects, machineSet)
+				controlMachineObjects = append(controlMachineObjects, machineSet)
 			}
-			c, w := createController(stop, namespace, objects, nil)
-			defer w.Stop()
+			c, watches := createController(stop, namespace, controlMachineObjects, nil, nil)
+			for _, watch := range watches {
+				defer watch.Stop()
+				Expect(watch).NotTo(BeNil())
+			}
 
 			machineSets, err := c.controlMachineClient.MachineSets(machineSet.Namespace).List(metav1.ListOptions{})
 			Expect(err).To(BeNil())
@@ -105,15 +108,18 @@ var _ = Describe("machine", func() {
 			stop := make(chan struct{})
 			defer close(stop)
 
-			objects := []runtime.Object{}
+			controlMachineObjects := []runtime.Object{}
 			if machineSetExists {
-				objects = append(objects, testMachineSet)
+				controlMachineObjects = append(controlMachineObjects, testMachineSet)
 			}
 			if parentExists {
-				objects = append(objects, testMachineDeployment)
+				controlMachineObjects = append(controlMachineObjects, testMachineDeployment)
 			}
-			c, w := createController(stop, namespace, objects, nil)
-			defer w.Stop()
+			c, watches := createController(stop, namespace, controlMachineObjects, nil, nil)
+			for _, watch := range watches {
+				defer watch.Stop()
+				Expect(watch).NotTo(BeNil())
+			}
 
 			Expect(cache.WaitForCacheSync(stop, c.machineSetSynced, c.machineDeploymentSynced)).To(BeTrue())
 
@@ -145,17 +151,20 @@ var _ = Describe("machine", func() {
 			stop := make(chan struct{})
 			defer close(stop)
 
-			objects := []runtime.Object{}
+			controlMachineObjects := []runtime.Object{}
 			if machineSet != nil {
-				objects = append(objects, machineSet)
+				controlMachineObjects = append(controlMachineObjects, machineSet)
 			}
-			c, w := createController(stop, namespace, objects, nil)
-			defer w.Stop()
+			c, watches := createController(stop, namespace, controlMachineObjects, nil, nil)
+			for _, watch := range watches {
+				defer watch.Stop()
+				Expect(watch).NotTo(BeNil())
+			}
 
 			waitForCacheSync(stop, c)
 			machineSets, err := c.machineSetLister.List(labels.Everything())
 			Expect(err).To(BeNil())
-			Expect(len(machineSets)).To(Equal(len(objects)))
+			Expect(len(machineSets)).To(Equal(len(controlMachineObjects)))
 
 			c.checkAndFreezeORUnfreezeMachineSets()
 		},

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -216,11 +216,8 @@ var _ = Describe("machine", func() {
 				defer close(stop)
 
 				objects := []runtime.Object{}
-				c, watches := createController(stop, namespace, objects, nil, nil)
-				for _, watch := range watches {
-					defer watch.Stop()
-					Expect(watch).NotTo(BeNil())
-				}
+				c, trackers := createController(stop, namespace, objects, nil, nil)
+				defer trackers.Stop()
 
 				testMachine := &machinev1.Machine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -257,11 +254,8 @@ var _ = Describe("machine", func() {
 				objects := []runtime.Object{}
 				objects = append(objects, testMachine)
 
-				c, watches := createController(stop, namespace, objects, nil, nil)
-				for _, watch := range watches {
-					defer watch.Stop()
-					Expect(watch).NotTo(BeNil())
-				}
+				c, trackers := createController(stop, namespace, objects, nil, nil)
+				defer trackers.Stop()
 
 				var updatedMachine, err = c.updateMachineConditions(testMachine, conditions)
 				Expect(updatedMachine.Status.Conditions).Should(BeEquivalentTo(conditions))
@@ -349,11 +343,8 @@ var _ = Describe("machine", func() {
 					coreObjects = append(coreObjects, o)
 				}
 
-				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
-				for _, watch := range watches {
-					defer watch.Stop()
-					Expect(watch).NotTo(BeNil())
-				}
+				controller, trackers := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				defer trackers.Stop()
 
 				waitForCacheSync(stop, controller)
 				machineClass, secret, err := controller.validateMachineClass(data.action)
@@ -496,11 +487,8 @@ var _ = Describe("machine", func() {
 					coreObjects = append(coreObjects, o)
 				}
 
-				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
-				for _, watch := range watches {
-					defer watch.Stop()
-					Expect(watch).NotTo(BeNil())
-				}
+				controller, trackers := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				defer trackers.Stop()
 
 				waitForCacheSync(stop, controller)
 
@@ -615,11 +603,8 @@ var _ = Describe("machine", func() {
 
 				coreObjects := []runtime.Object{}
 
-				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
-				for _, watch := range watches {
-					defer watch.Stop()
-					Expect(watch).NotTo(BeNil())
-				}
+				controller, trackers := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				defer trackers.Stop()
 				waitForCacheSync(stop, controller)
 
 				action := data.action
@@ -838,11 +823,8 @@ var _ = Describe("machine", func() {
 					coreObjects = append(coreObjects, o)
 				}
 
-				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
-				for _, watch := range watches {
-					defer watch.Stop()
-					Expect(watch).NotTo(BeNil())
-				}
+				controller, trackers := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				defer trackers.Stop()
 				waitForCacheSync(stop, controller)
 
 				action := data.action

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -216,8 +216,11 @@ var _ = Describe("machine", func() {
 				defer close(stop)
 
 				objects := []runtime.Object{}
-				c, w := createController(stop, namespace, objects, nil)
-				defer w.Stop()
+				c, watches := createController(stop, namespace, objects, nil, nil)
+				for _, watch := range watches {
+					defer watch.Stop()
+					Expect(watch).NotTo(BeNil())
+				}
 
 				testMachine := &machinev1.Machine{
 					ObjectMeta: metav1.ObjectMeta{
@@ -254,8 +257,11 @@ var _ = Describe("machine", func() {
 				objects := []runtime.Object{}
 				objects = append(objects, testMachine)
 
-				c, w := createController(stop, namespace, objects, nil)
-				defer w.Stop()
+				c, watches := createController(stop, namespace, objects, nil, nil)
+				for _, watch := range watches {
+					defer watch.Stop()
+					Expect(watch).NotTo(BeNil())
+				}
 
 				var updatedMachine, err = c.updateMachineConditions(testMachine, conditions)
 				Expect(updatedMachine.Status.Conditions).Should(BeEquivalentTo(conditions))
@@ -343,8 +349,11 @@ var _ = Describe("machine", func() {
 					coreObjects = append(coreObjects, o)
 				}
 
-				controller, w := createController(stop, objMeta.Namespace, machineObjects, coreObjects)
-				defer w.Stop()
+				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				for _, watch := range watches {
+					defer watch.Stop()
+					Expect(watch).NotTo(BeNil())
+				}
 
 				waitForCacheSync(stop, controller)
 				machineClass, secret, err := controller.validateMachineClass(data.action)
@@ -487,8 +496,11 @@ var _ = Describe("machine", func() {
 					coreObjects = append(coreObjects, o)
 				}
 
-				controller, w := createController(stop, objMeta.Namespace, machineObjects, coreObjects)
-				defer w.Stop()
+				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				for _, watch := range watches {
+					defer watch.Stop()
+					Expect(watch).NotTo(BeNil())
+				}
 
 				waitForCacheSync(stop, controller)
 
@@ -603,8 +615,11 @@ var _ = Describe("machine", func() {
 
 				coreObjects := []runtime.Object{}
 
-				controller, watch := createController(stop, objMeta.Namespace, machineObjects, coreObjects)
-				defer watch.Stop()
+				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				for _, watch := range watches {
+					defer watch.Stop()
+					Expect(watch).NotTo(BeNil())
+				}
 				waitForCacheSync(stop, controller)
 
 				action := data.action
@@ -823,8 +838,11 @@ var _ = Describe("machine", func() {
 					coreObjects = append(coreObjects, o)
 				}
 
-				controller, w := createController(stop, objMeta.Namespace, machineObjects, coreObjects)
-				defer w.Stop()
+				controller, watches := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects)
+				for _, watch := range watches {
+					defer watch.Stop()
+					Expect(watch).NotTo(BeNil())
+				}
 				waitForCacheSync(stop, controller)
 
 				action := data.action

--- a/pkg/fakeclient/client.go
+++ b/pkg/fakeclient/client.go
@@ -1,0 +1,417 @@
+/*
+Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fakeclient
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"errors"
+
+	fakeuntyped "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/fake"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/watch"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// FakeObjectTracker implements both k8stesting.ObjectTracker as well as watch.Interface.
+type FakeObjectTracker struct {
+	*watch.FakeWatcher
+	delegatee    k8stesting.ObjectTracker
+	watchers     []*watcher
+	trackerMutex sync.Mutex
+	fakingOptions
+}
+
+// Add recieves an add event with the object
+func (t *FakeObjectTracker) Add(obj runtime.Object) error {
+	if t.fakingEnabled {
+		err := t.RunFakeInvokations()
+		if err != nil {
+			return err
+		}
+	}
+
+	return t.delegatee.Add(obj)
+}
+
+// Get recieves an get event with the object
+func (t *FakeObjectTracker) Get(gvr schema.GroupVersionResource, ns, name string) (runtime.Object, error) {
+	if t.fakingEnabled {
+		err := t.RunFakeInvokations()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return t.delegatee.Get(gvr, ns, name)
+}
+
+// Create recieves an create event with the object
+func (t *FakeObjectTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	if t.fakingEnabled {
+		err := t.RunFakeInvokations()
+		if err != nil {
+			return err
+		}
+	}
+
+	err := t.delegatee.Create(gvr, obj, ns)
+	if err != nil {
+		return err
+	}
+
+	if t.FakeWatcher == nil {
+		return errors.New("Error sending event on a tracker with no watch support")
+	}
+
+	if t.IsStopped() {
+		return errors.New("Error sending event on a stopped tracker")
+	}
+
+	t.FakeWatcher.Add(obj)
+	return nil
+}
+
+// Update recieves an update event with the object
+func (t *FakeObjectTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
+	if t.fakingEnabled {
+		err := t.RunFakeInvokations()
+		if err != nil {
+			return err
+		}
+	}
+
+	err := t.delegatee.Update(gvr, obj, ns)
+	if err != nil {
+		return err
+	}
+
+	if t.FakeWatcher == nil {
+		return errors.New("Error sending event on a tracker with no watch support")
+	}
+
+	if t.IsStopped() {
+		return errors.New("Error sending event on a stopped tracker")
+	}
+
+	t.FakeWatcher.Modify(obj)
+	return nil
+}
+
+// List recieves an list event with the object
+func (t *FakeObjectTracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string) (runtime.Object, error) {
+	if t.fakingEnabled {
+		err := t.RunFakeInvokations()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t.delegatee.List(gvr, gvk, ns)
+}
+
+// Delete recieves an delete event with the object
+func (t *FakeObjectTracker) Delete(gvr schema.GroupVersionResource, ns, name string) error {
+	if t.fakingEnabled {
+		err := t.RunFakeInvokations()
+		if err != nil {
+			return err
+		}
+	}
+
+	obj, errGet := t.delegatee.Get(gvr, ns, name)
+	err := t.delegatee.Delete(gvr, ns, name)
+	if err != nil {
+		return err
+	}
+
+	if errGet != nil {
+		return errGet
+	}
+
+	if t.FakeWatcher == nil {
+		return errors.New("Error sending event on a tracker with no watch support")
+	}
+
+	if t.IsStopped() {
+		return errors.New("Error sending event on a stopped tracker")
+	}
+
+	t.FakeWatcher.Delete(obj)
+	return nil
+}
+
+// Watch recieves an watch event with the object
+func (t *FakeObjectTracker) Watch(gvr schema.GroupVersionResource, name string) (watch.Interface, error) {
+	if t.fakingEnabled {
+		err := t.RunFakeInvokations()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return t.delegatee.Watch(gvr, name)
+}
+
+func (t *FakeObjectTracker) watchReactionfunc(action k8stesting.Action) (bool, watch.Interface, error) {
+	if t.FakeWatcher == nil {
+		return false, nil, errors.New("Cannot watch on a tracker with no watch support")
+	}
+
+	switch a := action.(type) {
+	case k8stesting.WatchAction:
+		w := &watcher{
+			FakeWatcher: watch.NewFake(),
+			action:      a,
+		}
+		go w.dispatchInitialObjects(a, t)
+		t.trackerMutex.Lock()
+		defer t.trackerMutex.Unlock()
+		t.watchers = append(t.watchers, w)
+		return true, w, nil
+	default:
+		return false, nil, fmt.Errorf("Expected WatchAction but got %v", action)
+	}
+}
+
+// Start begins tracking of an FakeObjectTracker
+func (t *FakeObjectTracker) Start() error {
+	if t.FakeWatcher == nil {
+		return errors.New("Tracker has no watch support")
+	}
+
+	for event := range t.ResultChan() {
+		t.dispatch(&event)
+	}
+
+	return nil
+}
+
+func (t *FakeObjectTracker) dispatch(event *watch.Event) {
+	for _, w := range t.watchers {
+		go w.dispatch(event)
+	}
+}
+
+// Stop terminates tracking of an FakeObjectTracker
+func (t *FakeObjectTracker) Stop() {
+	if t.FakeWatcher == nil {
+		panic(errors.New("Tracker has no watch support"))
+	}
+
+	t.trackerMutex.Lock()
+	defer t.trackerMutex.Unlock()
+
+	t.FakeWatcher.Stop()
+	for _, w := range t.watchers {
+		w.Stop()
+	}
+	t.watchers = []*watcher{}
+}
+
+type watcher struct {
+	*watch.FakeWatcher
+	action      k8stesting.WatchAction
+	updateMutex sync.Mutex
+}
+
+func (w *watcher) Stop() {
+	w.updateMutex.Lock()
+	defer w.updateMutex.Unlock()
+
+	w.FakeWatcher.Stop()
+}
+
+func (w *watcher) handles(event *watch.Event) bool {
+	if w.IsStopped() {
+		return false
+	}
+
+	t, err := meta.TypeAccessor(event.Object)
+	if err != nil {
+		return false
+	}
+
+	gvr, _ := meta.UnsafeGuessKindToResource(schema.FromAPIVersionAndKind(t.GetAPIVersion(), t.GetKind()))
+	if !(&k8stesting.SimpleWatchReactor{Resource: gvr.Resource}).Handles(w.action) {
+		return false
+	}
+
+	o, err := meta.Accessor(event.Object)
+	if err != nil {
+		return false
+	}
+
+	info := w.action.GetWatchRestrictions()
+	rv, fs, ls := info.ResourceVersion, info.Fields, info.Labels
+	if rv != "" && o.GetResourceVersion() != rv {
+		return false
+	}
+
+	if fs != nil && !fs.Matches(fields.Set{
+		"metadata.name":      o.GetName(),
+		"metadata.namespace": o.GetNamespace(),
+	}) {
+		return false
+	}
+
+	if ls != nil && !ls.Matches(labels.Set(o.GetLabels())) {
+		return false
+	}
+
+	return true
+}
+
+func (w *watcher) dispatch(event *watch.Event) {
+	w.updateMutex.Lock()
+	defer w.updateMutex.Unlock()
+
+	if !w.handles(event) {
+		return
+	}
+	w.Action(event.Type, event.Object)
+}
+
+func (w *watcher) dispatchInitialObjects(action k8stesting.WatchAction, t k8stesting.ObjectTracker) error {
+	listObj, err := t.List(action.GetResource(), action.GetResource().GroupVersion().WithKind(action.GetResource().Resource), action.GetNamespace())
+	if err != nil {
+		return err
+	}
+
+	itemsPtr, err := meta.GetItemsPtr(listObj)
+	if err != nil {
+		return err
+	}
+
+	items := itemsPtr.([]runtime.Object)
+	for _, o := range items {
+		w.dispatch(&watch.Event{
+			Type:   watch.Added,
+			Object: o,
+		})
+	}
+
+	return nil
+}
+
+// fakingOptions are options that can be set while trying to fake object tracker returns
+type fakingOptions struct {
+	fakingEnabled bool
+	errorMessage  string
+	delay         time.Duration
+}
+
+// SetDelay sets delay while invoking any interface exposed by standard ObjectTrackers
+func (o *fakingOptions) SetDelay(delay time.Duration) error {
+	o.fakingEnabled = true
+	o.delay = delay
+	return nil
+}
+
+// SetError sets up the errorMessage to be returned on further function calls
+func (o *fakingOptions) SetError(message string) error {
+	o.fakingEnabled = true
+	o.errorMessage = message
+	return nil
+}
+
+// ClearOptions clears any faking options that have been sets
+func (o *fakingOptions) ClearOptions(message string) error {
+	o.fakingEnabled = false
+	o.errorMessage = ""
+	o.delay = 0
+	return nil
+}
+
+// RunFakeInvokations runs any custom fake configurations/methods before invoking standard ObjectTrackers
+func (o *fakingOptions) RunFakeInvokations() error {
+	if o.delay != 0 {
+		time.Sleep(o.delay)
+	}
+	if o.errorMessage != "" {
+		return errors.New(o.errorMessage)
+	}
+
+	return nil
+}
+
+// NewMachineClientSet returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewMachineClientSet(objects ...runtime.Object) (*fakeuntyped.Clientset, *FakeObjectTracker) {
+	var scheme = runtime.NewScheme()
+	var codecs = serializer.NewCodecFactory(scheme)
+
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	fakeuntyped.AddToScheme(scheme)
+
+	o := &FakeObjectTracker{
+		FakeWatcher: watch.NewFake(),
+		delegatee:   k8stesting.NewObjectTracker(scheme, codecs.UniversalDecoder()),
+	}
+
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &fakeuntyped.Clientset{}
+	cs.Fake.AddReactor("*", "*", k8stesting.ObjectReaction(o))
+	cs.Fake.AddWatchReactor("*", o.watchReactionfunc)
+
+	return cs, o
+}
+
+// NewCoreClientSet returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
+func NewCoreClientSet(objects ...runtime.Object) (*k8sfake.Clientset, *FakeObjectTracker) {
+
+	var scheme = runtime.NewScheme()
+	var codecs = serializer.NewCodecFactory(scheme)
+
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	k8sfake.AddToScheme(scheme)
+
+	o := &FakeObjectTracker{
+		FakeWatcher: watch.NewFake(),
+		delegatee:   k8stesting.NewObjectTracker(scheme, codecs.UniversalDecoder()),
+	}
+
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &k8sfake.Clientset{}
+	cs.Fake.AddReactor("*", "*", k8stesting.ObjectReaction(o))
+	cs.Fake.AddWatchReactor("*", o.watchReactionfunc)
+
+	return cs, o
+}

--- a/pkg/fakeclient/client.go
+++ b/pkg/fakeclient/client.go
@@ -48,7 +48,7 @@ type FakeObjectTracker struct {
 // Add recieves an add event with the object
 func (t *FakeObjectTracker) Add(obj runtime.Object) error {
 	if t.fakingEnabled {
-		err := t.RunFakeInvokations()
+		err := t.RunFakeInvocations()
 		if err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ func (t *FakeObjectTracker) Add(obj runtime.Object) error {
 // Get recieves an get event with the object
 func (t *FakeObjectTracker) Get(gvr schema.GroupVersionResource, ns, name string) (runtime.Object, error) {
 	if t.fakingEnabled {
-		err := t.RunFakeInvokations()
+		err := t.RunFakeInvocations()
 		if err != nil {
 			return nil, err
 		}
@@ -72,7 +72,7 @@ func (t *FakeObjectTracker) Get(gvr schema.GroupVersionResource, ns, name string
 // Create recieves an create event with the object
 func (t *FakeObjectTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
 	if t.fakingEnabled {
-		err := t.RunFakeInvokations()
+		err := t.RunFakeInvocations()
 		if err != nil {
 			return err
 		}
@@ -98,7 +98,7 @@ func (t *FakeObjectTracker) Create(gvr schema.GroupVersionResource, obj runtime.
 // Update recieves an update event with the object
 func (t *FakeObjectTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {
 	if t.fakingEnabled {
-		err := t.RunFakeInvokations()
+		err := t.RunFakeInvocations()
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func (t *FakeObjectTracker) Update(gvr schema.GroupVersionResource, obj runtime.
 // List recieves an list event with the object
 func (t *FakeObjectTracker) List(gvr schema.GroupVersionResource, gvk schema.GroupVersionKind, ns string) (runtime.Object, error) {
 	if t.fakingEnabled {
-		err := t.RunFakeInvokations()
+		err := t.RunFakeInvocations()
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +135,7 @@ func (t *FakeObjectTracker) List(gvr schema.GroupVersionResource, gvk schema.Gro
 // Delete recieves an delete event with the object
 func (t *FakeObjectTracker) Delete(gvr schema.GroupVersionResource, ns, name string) error {
 	if t.fakingEnabled {
-		err := t.RunFakeInvokations()
+		err := t.RunFakeInvocations()
 		if err != nil {
 			return err
 		}
@@ -166,7 +166,7 @@ func (t *FakeObjectTracker) Delete(gvr schema.GroupVersionResource, ns, name str
 // Watch recieves an watch event with the object
 func (t *FakeObjectTracker) Watch(gvr schema.GroupVersionResource, name string) (watch.Interface, error) {
 	if t.fakingEnabled {
-		err := t.RunFakeInvokations()
+		err := t.RunFakeInvocations()
 		if err != nil {
 			return nil, err
 		}
@@ -345,8 +345,8 @@ func (o *fakingOptions) ClearOptions(message string) error {
 	return nil
 }
 
-// RunFakeInvokations runs any custom fake configurations/methods before invoking standard ObjectTrackers
-func (o *fakingOptions) RunFakeInvokations() error {
+// RunFakeInvocations runs any custom fake configurations/methods before invoking standard ObjectTrackers
+func (o *fakingOptions) RunFakeInvocations() error {
 	if o.delay != 0 {
 		time.Sleep(o.delay)
 	}
@@ -384,6 +384,41 @@ func NewMachineClientSet(objects ...runtime.Object) (*fakeuntyped.Clientset, *Fa
 	cs.Fake.AddWatchReactor("*", o.watchReactionfunc)
 
 	return cs, o
+}
+
+// FakeObjectTrackers is a struct containing all the controller fake object trackers
+type FakeObjectTrackers struct {
+	ControlMachine, ControlCore, TargetCore *FakeObjectTracker
+}
+
+// NewFakeObjectTrackers initialize's fakeObjectTrackers initializes the fake object trackers
+func NewFakeObjectTrackers(controlMachine, controlCore, targetCore *FakeObjectTracker) *FakeObjectTrackers {
+
+	fakeObjectTrackers := &FakeObjectTrackers{
+		ControlMachine: controlMachine,
+		ControlCore:    controlCore,
+		TargetCore:     targetCore,
+	}
+
+	return fakeObjectTrackers
+}
+
+// Start starts all object trackers as go routines
+func (o *FakeObjectTrackers) Start() error {
+	go o.ControlMachine.Start()
+	go o.ControlCore.Start()
+	go o.TargetCore.Start()
+
+	return nil
+}
+
+// Stop stops all object trackers
+func (o *FakeObjectTrackers) Stop() error {
+	o.ControlMachine.Stop()
+	o.ControlCore.Stop()
+	o.TargetCore.Stop()
+
+	return nil
 }
 
 // NewCoreClientSet returns a clientset that will respond with the provided objects.

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -111,10 +111,10 @@ type SafetyOptions struct {
 	MachineControllerFrozen bool
 	// Period (in duration) used to poll for APIServer's health
 	// by safety controller
-	MachineSafetyAPIServerStatusPeriod metav1.Duration
+	MachineSafetyAPIServerStatusCheckPeriod metav1.Duration
 	// Timeout (in duration) for which the APIServer can be down before
 	// declare the machine controller frozen by safety controller
-	MachineSafetyAPIServerStatusTimeout metav1.Duration
+	MachineSafetyAPIServerStatusCheckTimeout metav1.Duration
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -18,6 +18,8 @@ limitations under the License.
 package options
 
 import (
+	"time"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -100,6 +102,19 @@ type SafetyOptions struct {
 	// Period (in minutes) used to poll for overshooting
 	// of machine objects backing a machineSet by safety controller
 	MachineSafetyOvershootingPeriod int32
+
+	// APIserverInactiveStartTime to keep track of the
+	// start time of when the APIServers were not reachable
+	APIserverInactiveStartTime time.Time
+	// MachineControllerFrozen indicates if the machine controller
+	// is frozen due to Unreachable APIServers
+	MachineControllerFrozen bool
+	// Period (in duration) used to poll for APIServer's health
+	// by safety controller
+	MachineSafetyAPIServerStatusPeriod metav1.Duration
+	// Timeout (in duration) for which the APIServer can be down before
+	// declare the machine controller frozen by safety controller
+	MachineSafetyAPIServerStatusTimeout metav1.Duration
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election


### PR DESCRIPTION
**What this PR does / why we need it**:
We need to enhance the freeze logic of safety-controller when APIServers are not reachable to freeze the machine controller from doing any wrong/unwanted reconcilations

**Which issue(s) this PR fixes**:
Fixes #155 

**Special notes for your reviewer**:
The commits have been split into the following
1. (Un)freezing of machine controller based on APIServer availability - Actual logic for freezing
2. Controller test suite now supports control and target clients, Testing Framework now supports faking of object tracker returns/delays - Enhancements to testing framework
3. Added test cases for machine controller freezing - Adding unit test cases to test changes.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
(Un)freezing of machine controller based on APIServer availability 
```
