### PR TITLE
Splitting of health timeout into creation and health timeouts

### DIFF
--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -103,9 +103,13 @@ function run_controller() {
         --port=$1 \
         --safety-up=2 \
         --safety-down=1 \
-        --machine-drain-timeout=5 \
-        --machine-health-timeout=10 \
-        --machine-set-scale-timeout=20 \
+        --machine-creation-timeout=20m \
+        --machine-drain-timeout=5m \
+        --machine-health-timeout=10m \
+        --machine-safety-apiserver-statuscheck-timeout=30s \
+        --machine-safety-apiserver-statuscheck-period=1m \
+        --machine-safety-orphan-vms-period=30m \
+        --machine-safety-overshooting-period=1m \
         --v=2 > logs/${provider}-mcm.out 2>&1 &
 }
 

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,10 @@ start:
 			--namespace=$(CONTROL_NAMESPACE) \
 			--safety-up=2 \
 			--safety-down=1 \
-			--machine-drain-timeout=5 \
-			--machine-health-timeout=10 \
-			--machine-set-scale-timeout=20 \
-			--machine-safety-orphan-vms-period=30 \
-			--machine-safety-overshooting-period=1 \
+			--machine-drain-timeout=5m \
+			--machine-health-timeout=10m \
+			--machine-safety-orphan-vms-period=30m \
+			--machine-safety-overshooting-period=1m \
 			--machine-safety-apiserver-period=1m \
 			--machine-safety-apiserver-timeout=30s \
 			--v=2

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,13 @@ start:
 			--namespace=$(CONTROL_NAMESPACE) \
 			--safety-up=2 \
 			--safety-down=1 \
+			--machine-creation-timeout=20m \
 			--machine-drain-timeout=5m \
 			--machine-health-timeout=10m \
+			--machine-safety-apiserver-statuscheck-timeout=30s \
+			--machine-safety-apiserver-statuscheck-period=1m \
 			--machine-safety-orphan-vms-period=30m \
 			--machine-safety-overshooting-period=1m \
-			--machine-safety-apiserver-period=1m \
-			--machine-safety-apiserver-timeout=30s \
 			--v=2
 
 #################################################################

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -63,6 +63,7 @@ func NewMCMServer() *MCMServer {
 			SafetyOptions: machineconfig.SafetyOptions{
 				SafetyUp:                                 2,
 				SafetyDown:                               1,
+				MachineCreationTimeout:                   metav1.Duration{Duration: 20 * time.Minute},
 				MachineHealthTimeout:                     metav1.Duration{Duration: 10 * time.Minute},
 				MachineDrainTimeout:                      metav1.Duration{Duration: 5 * time.Minute},
 				MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 30 * time.Minute},
@@ -96,7 +97,8 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&s.SafetyOptions.SafetyUp, "safety-up", s.SafetyOptions.SafetyUp, "The number of excess machine objects permitted for any machineSet/machineDeployment beyond its expected number of replicas based on desired and max-surge, we call this the upper-limit. When this upper-limit is reached, the objects are temporarily frozen until the number of objects reduce. upper-limit = desired + maxSurge (if applicable) + safetyUp.")
 	fs.Int32Var(&s.SafetyOptions.SafetyDown, "safety-down", s.SafetyOptions.SafetyDown, "Upper-limit minus safety-down value gives the lower-limit. This is the limits below which any temporarily frozen machineSet/machineDeployment object is unfrozen. lower-limit = desired + maxSurge (if applicable) + safetyUp - safetyDown.")
 
-	fs.DurationVar(&s.SafetyOptions.MachineHealthTimeout.Duration, "machine-health-timeout", s.SafetyOptions.MachineHealthTimeout.Duration, "Timeout (in durartion) used while joining (during creation) or re-joining (in case of temporary health issues) of machine before it is declared as failed.")
+	fs.DurationVar(&s.SafetyOptions.MachineCreationTimeout.Duration, "machine-creation-timeout", s.SafetyOptions.MachineCreationTimeout.Duration, "Timeout (in durartion) used while joining (during creation) of machine before it is declared as failed.")
+	fs.DurationVar(&s.SafetyOptions.MachineHealthTimeout.Duration, "machine-health-timeout", s.SafetyOptions.MachineHealthTimeout.Duration, "Timeout (in durartion) used while re-joining (in case of temporary health issues) of machine before it is declared as failed.")
 	fs.DurationVar(&s.SafetyOptions.MachineDrainTimeout.Duration, "machine-drain-timeout", s.SafetyOptions.MachineDrainTimeout.Duration, "Timeout (in durartion) used while draining of machine before deletion, beyond which MCM forcefully deletes machine.")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "machine-safety-apiserver-statuscheck-timeout", s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "Timeout (in duration) for which the APIServer can be down before declare the machine controller frozen by safety controller")
 

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -63,11 +63,10 @@ func NewMCMServer() *MCMServer {
 			SafetyOptions: machineconfig.SafetyOptions{
 				SafetyUp:                                 2,
 				SafetyDown:                               1,
-				MachineHealthTimeout:                     10,
-				MachineDrainTimeout:                      5,
-				MachineSetScaleTimeout:                   20,
-				MachineSafetyOrphanVMsPeriod:             30,
-				MachineSafetyOvershootingPeriod:          1,
+				MachineHealthTimeout:                     metav1.Duration{Duration: 10 * time.Minute},
+				MachineDrainTimeout:                      metav1.Duration{Duration: 5 * time.Minute},
+				MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 30 * time.Minute},
+				MachineSafetyOvershootingPeriod:          metav1.Duration{Duration: 1 * time.Minute},
 				MachineSafetyAPIServerStatusCheckPeriod:  metav1.Duration{Duration: 1 * time.Minute},
 				MachineSafetyAPIServerStatusCheckTimeout: metav1.Duration{Duration: 30 * time.Second},
 			},
@@ -96,14 +95,14 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 
 	fs.Int32Var(&s.SafetyOptions.SafetyUp, "safety-up", s.SafetyOptions.SafetyUp, "The number of excess machine objects permitted for any machineSet/machineDeployment beyond its expected number of replicas based on desired and max-surge, we call this the upper-limit. When this upper-limit is reached, the objects are temporarily frozen until the number of objects reduce. upper-limit = desired + maxSurge (if applicable) + safetyUp.")
 	fs.Int32Var(&s.SafetyOptions.SafetyDown, "safety-down", s.SafetyOptions.SafetyDown, "Upper-limit minus safety-down value gives the lower-limit. This is the limits below which any temporarily frozen machineSet/machineDeployment object is unfrozen. lower-limit = desired + maxSurge (if applicable) + safetyUp - safetyDown.")
-	fs.Int32Var(&s.SafetyOptions.MachineHealthTimeout, "machine-health-timeout", s.SafetyOptions.MachineHealthTimeout, "Timeout (in minutes) used while joining (during creation) or re-joining (in case of temporary health issues) of machine before it is declared as failed.")
-	fs.Int32Var(&s.SafetyOptions.MachineDrainTimeout, "machine-drain-timeout", s.SafetyOptions.MachineDrainTimeout, "Timeout (in minutes) used while draining of machine before deletion, beyond which MCM forcefully deletes machine.")
-	fs.Int32Var(&s.SafetyOptions.MachineSetScaleTimeout, "machine-set-scale-timeout", s.SafetyOptions.MachineSetScaleTimeout, "Timeout (in minutes) used while scaling machineSet if timeout occurs machineSet is frozen.")
-	fs.Int32Var(&s.SafetyOptions.MachineSafetyOrphanVMsPeriod, "machine-safety-orphan-vms-period", s.SafetyOptions.MachineSafetyOrphanVMsPeriod, "Time period (in minutes) used to poll for orphan VMs by safety controller.")
-	fs.Int32Var(&s.SafetyOptions.MachineSafetyOvershootingPeriod, "machine-safety-overshooting-period", s.SafetyOptions.MachineSafetyOvershootingPeriod, "Time period (in minutes) used to poll for overshooting of machine objects backing a machineSet by safety controller.")
 
+	fs.DurationVar(&s.SafetyOptions.MachineHealthTimeout.Duration, "machine-health-timeout", s.SafetyOptions.MachineHealthTimeout.Duration, "Timeout (in durartion) used while joining (during creation) or re-joining (in case of temporary health issues) of machine before it is declared as failed.")
+	fs.DurationVar(&s.SafetyOptions.MachineDrainTimeout.Duration, "machine-drain-timeout", s.SafetyOptions.MachineDrainTimeout.Duration, "Timeout (in durartion) used while draining of machine before deletion, beyond which MCM forcefully deletes machine.")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "machine-safety-apiserver-statuscheck-timeout", s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "Timeout (in duration) for which the APIServer can be down before declare the machine controller frozen by safety controller")
-	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "machine-safety-apiserver-statuscheck-period", s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "Period (in duration) used to poll for APIServer's health by safety controller")
+
+	fs.DurationVar(&s.SafetyOptions.MachineSafetyOrphanVMsPeriod.Duration, "machine-safety-orphan-vms-period", s.SafetyOptions.MachineSafetyOrphanVMsPeriod.Duration, "Time period (in durartion) used to poll for orphan VMs by safety controller.")
+	fs.DurationVar(&s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "machine-safety-overshooting-period", s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "Time period (in durartion) used to poll for overshooting of machine objects backing a machineSet by safety controller.")
+	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "machine-safety-apiserver-statuscheck-period", s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "Time period (in duration) used to poll for APIServer's health by safety controller")
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -266,11 +266,9 @@ func createController(stop <-chan struct{}, namespace string, controlMachineObje
 	safetyOptions := options.SafetyOptions{
 		SafetyUp:                                 2,
 		SafetyDown:                               1,
-		MachineDrainTimeout:                      5,
-		MachineHealthTimeout:                     10,
-		MachineSetScaleTimeout:                   2,
-		MachineSafetyOrphanVMsPeriod:             30,
-		MachineSafetyOvershootingPeriod:          1,
+		MachineHealthTimeout:                     metav1.Duration{Duration: 10 * time.Minute},
+		MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 30 * time.Minute},
+		MachineSafetyOvershootingPeriod:          metav1.Duration{Duration: 1 * time.Minute},
 		MachineSafetyAPIServerStatusCheckPeriod:  metav1.Duration{Duration: 1 * time.Minute},
 		MachineSafetyAPIServerStatusCheckTimeout: metav1.Duration{Duration: 30 * time.Second},
 	}

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -266,7 +266,9 @@ func createController(stop <-chan struct{}, namespace string, controlMachineObje
 	safetyOptions := options.SafetyOptions{
 		SafetyUp:                                 2,
 		SafetyDown:                               1,
+		MachineCreationTimeout:                   metav1.Duration{Duration: 20 * time.Minute},
 		MachineHealthTimeout:                     metav1.Duration{Duration: 10 * time.Minute},
+		MachineDrainTimeout:                      metav1.Duration{Duration: 5 * time.Minute},
 		MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 30 * time.Minute},
 		MachineSafetyOvershootingPeriod:          metav1.Duration{Duration: 1 * time.Minute},
 		MachineSafetyAPIServerStatusCheckPeriod:  metav1.Duration{Duration: 1 * time.Minute},

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -721,20 +721,27 @@ func (c *controller) checkMachineTimeout(machine *v1alpha1.Machine) {
 	if machine.Status.CurrentStatus.Phase != v1alpha1.MachineRunning {
 
 		var (
-			description   string
-			lastOperation v1alpha1.LastOperation
-			currentStatus v1alpha1.CurrentStatus
+			description     string
+			lastOperation   v1alpha1.LastOperation
+			currentStatus   v1alpha1.CurrentStatus
+			timeOutDuration time.Duration
 		)
 
-		timeOutDuration := c.safetyOptions.MachineHealthTimeout.Duration
+		checkCreationTimeout := machine.Status.CurrentStatus.Phase == v1alpha1.MachinePending
 		sleepTime := 1 * time.Minute
+
+		if checkCreationTimeout {
+			timeOutDuration = c.safetyOptions.MachineCreationTimeout.Duration
+		} else {
+			timeOutDuration = c.safetyOptions.MachineHealthTimeout.Duration
+		}
 
 		// Timeout value obtained by subtracting last operation with expected time out period
 		timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.Status.CurrentStatus.LastUpdateTime.Time)
 		if timeOut > 0 {
 			// Machine health timeout occurs while joining or rejoining of machine
 
-			if machine.Status.CurrentStatus.Phase == v1alpha1.MachinePending {
+			if checkCreationTimeout {
 				// Timeout occurred while machine creation
 				description = fmt.Sprintf(
 					"Machine %s failed to join the cluster in %s minutes.",

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -445,7 +445,7 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 		}
 
 		if machineID != "" {
-			timeOutDuration := time.Duration(c.safetyOptions.MachineDrainTimeout) * time.Minute
+			timeOutDuration := c.safetyOptions.MachineDrainTimeout.Duration
 			// Timeout value obtained by subtracting last operation with expected time out period
 			timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.Status.CurrentStatus.LastUpdateTime.Time)
 
@@ -726,7 +726,7 @@ func (c *controller) checkMachineTimeout(machine *v1alpha1.Machine) {
 			currentStatus v1alpha1.CurrentStatus
 		)
 
-		timeOutDuration := time.Duration(c.safetyOptions.MachineHealthTimeout) * time.Minute
+		timeOutDuration := c.safetyOptions.MachineHealthTimeout.Duration
 		sleepTime := 1 * time.Minute
 
 		// Timeout value obtained by subtracting last operation with expected time out period

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -587,9 +587,10 @@ var _ = Describe("machine", func() {
 		}
 
 		machineName := "machine-0"
-		timeOutOccurred := -11 * time.Minute
+		timeOutOccurred := -21 * time.Minute
 		timeOutNotOccurred := -5 * time.Minute
-		timeOut := 10 * time.Minute
+		creationTimeOut := 20 * time.Minute
+		healthTimeOut := 10 * time.Minute
 
 		DescribeTable("##Machine Timeout Scenarios",
 			func(data *data) {
@@ -728,7 +729,7 @@ var _ = Describe("machine", func() {
 							Description: fmt.Sprintf(
 								"Machine %s failed to join the cluster in %s minutes.",
 								machineName,
-								timeOut,
+								creationTimeOut,
 							),
 							State: machinev1.MachineStateFailed,
 							Type:  machinev1.MachineOperationCreate,
@@ -769,7 +770,7 @@ var _ = Describe("machine", func() {
 							Description: fmt.Sprintf(
 								"Machine %s is not healthy since %s minutes. Changing status to failed. Node Conditions: %+v",
 								machineName,
-								timeOut,
+								healthTimeOut,
 								[]corev1.NodeCondition{},
 							),
 							State: machinev1.MachineStateFailed,

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -87,21 +87,26 @@ type SafetyOptions struct {
 	SafetyUp int32
 	// SafetyDown
 	SafetyDown int32
-	// Timeout (in minutes) used while creation/failing of
+
+	// Timeout (in durartion) used while creation/failing of
 	// machine before it is declared as failed
-	MachineHealthTimeout int32
-	// Timeout (in minutes) used while draining of machine before deletion,
+	MachineHealthTimeout metav1.Duration
+	// Timeout (in durartion) used while draining of machine before deletion,
 	// beyond which it forcefully deletes machine
-	MachineDrainTimeout int32
-	// Timeout (in minutes) used while scaling machineSet
-	// if timeout occurs machineSet is permanently frozen
-	MachineSetScaleTimeout int32
-	// Period (in minutes) used to poll for orphan VMs
+	MachineDrainTimeout metav1.Duration
+	// Timeout (in duration) for which the APIServer can be down before
+	// declare the machine controller frozen by safety controller
+	MachineSafetyAPIServerStatusCheckTimeout metav1.Duration
+
+	// Period (in durartion) used to poll for orphan VMs
 	// by safety controller
-	MachineSafetyOrphanVMsPeriod int32
-	// Period (in minutes) used to poll for overshooting
+	MachineSafetyOrphanVMsPeriod metav1.Duration
+	// Period (in durartion) used to poll for overshooting
 	// of machine objects backing a machineSet by safety controller
-	MachineSafetyOvershootingPeriod int32
+	MachineSafetyOvershootingPeriod metav1.Duration
+	// Period (in duration) used to poll for APIServer's health
+	// by safety controller
+	MachineSafetyAPIServerStatusCheckPeriod metav1.Duration
 
 	// APIserverInactiveStartTime to keep track of the
 	// start time of when the APIServers were not reachable
@@ -109,12 +114,6 @@ type SafetyOptions struct {
 	// MachineControllerFrozen indicates if the machine controller
 	// is frozen due to Unreachable APIServers
 	MachineControllerFrozen bool
-	// Period (in duration) used to poll for APIServer's health
-	// by safety controller
-	MachineSafetyAPIServerStatusCheckPeriod metav1.Duration
-	// Timeout (in duration) for which the APIServer can be down before
-	// declare the machine controller frozen by safety controller
-	MachineSafetyAPIServerStatusCheckTimeout metav1.Duration
 }
 
 // LeaderElectionConfiguration defines the configuration of leader election

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -88,8 +88,11 @@ type SafetyOptions struct {
 	// SafetyDown
 	SafetyDown int32
 
-	// Timeout (in durartion) used while creation/failing of
-	// machine before it is declared as failed
+	// Timeout (in durartion) used while creation of
+	// a machine before it is declared as failed
+	MachineCreationTimeout metav1.Duration
+	// Timeout (in durartion) used while health-check of
+	// a machine before it is declared as failed
 	MachineHealthTimeout metav1.Duration
 	// Timeout (in durartion) used while draining of machine before deletion,
 	// beyond which it forcefully deletes machine


### PR DESCRIPTION
**What this PR does / why we need it**:
The machine-controller-manager used a single configurable knob (machine-health-timeout) to configure both creation and health timeouts. However, this reduced flexibility as both timeouts used a single knob. Now the creation and health timeouts have been split into two different configurable knobs.

**Which issue(s) this PR fixes**:
Fixes #176 

**Special notes for your reviewer**:
Commits have been split into 3 for easy of the reviewer. Only look at last 3 commits, as the rest are old commits from another PR which is in review.
1. Cleanup of existing timeouts from int to duration type
2. Actual changes to accommodate splitting of creation and health timeouts
3. Updated test cases to test changes correctly. No new tests were added, as there were already existing test-cases.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
Timeouts for creation and health check is split into two configurable knobs instead of a single one
```
