### PR TITLE
Error handling during openstack create() call. Fixes #181

### DIFF
--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -89,6 +89,9 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 
 	glog.V(3).Infof("creating machine")
 	server, err := servers.Create(client, createOpts).Extract()
+	if err != nil {
+		return "", "", err
+	}
 
 	d.MachineID = d.encodeMachineID(d.OpenStackMachineClass.Spec.Region, server.ID)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the error is not handled for the create call to openstack. Added fix for the same.

**Which issue(s) this PR fixes**:
Fixes #181 

**Special notes for your reviewer**:
Tested by injecting dummy error instead of actual landscape because of its unavailability.

**Release note**:
<!--  NONE
-->
```improvement operator

```
