### PR TITLE
Updated pipeline definition to use Golang 1.11.2

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,11 +19,11 @@ machine-controller-manager:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
     steps:
       check:
-        image: 'golang:1.9.4'
+        image: 'golang:1.11.2'
       test:
-        image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.1.0'
+        image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.2.0'
       build:
-        image: 'golang:1.9.4'
+        image: 'golang:1.11.2'
         output_dir: 'binary'
   variants:
     head-update:


### PR DESCRIPTION
The CI pipelines now use Golang version 1.11.2

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator

```
