### PR TITLE
indicate proper path to managevm cli

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -96,7 +96,7 @@ The Machine Controller Manager should now be ready to manage the VMs in your kub
 To test the creation/deletion of a single instance for one particular machine class you can use the `managevm` cli. The corresponding `INFRASTRUCTURE-machine-class.yaml` and the `INFRASTRUCTURE-secret.yaml` need to be defined upfront. To build and run it
 
 ```bash
-go build cmd/machine-controller-manager/cli/managevm.go
+go build -o managevm cmd/machine-controller-manager-cli/main.go
 # create machine
 ./managevm --secret PATH_TO/INFRASTRUCTURE-secret.yaml --machineclass PATH_TO/INFRASTRUCTURE-machine-class.yaml --classkind INFRASTRUCTURE --machinename test
 # delete machine


### PR DESCRIPTION
**What this PR does / why we need it**:

The doc for local setup has the wrong path to managevm, which, apparently, was renamed.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement user
Fixes documentation while running CLI client
```