### PR TITLE
Add linefeed

### DIFF
--- a/cmd/machine-controller-manager-cli/main.go
+++ b/cmd/machine-controller-manager-cli/main.go
@@ -101,8 +101,8 @@ func main() {
 		if err != nil {
 			log.Fatalf("Could not create %s : %s", machineName, err)
 		}
-		fmt.Printf("Machine id: %s", id)
-		fmt.Printf("Name: %s", name)
+		fmt.Printf("Machine id: %s\n", id)
+		fmt.Printf("Name: %s\n", name)
 	} else {
 		err = driver.Delete()
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The output from the `managevm` CLI didn't have space between the machine ID and Name, mixing them together. This fixes it.

Before:

```
$ managevm ...
Machine id: packet:///75b74ee6-d7af-4a65-82ca-73c895cd50a9/ff1c19e9-550f-4cce-b80a-eabca6a86a97Name: ff1c19e9.packethost.net
```

After:

```
$ managevm ...
Machine id: packet:///75b74ee6-d7af-4a65-82ca-73c895cd50a9/ff1c19e9-550f-4cce-b80a-eabca6a86a97
Name: ff1c19e9.packethost.net
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
