### PR TITLE
Fix sample deployment.yaml

### DIFF
--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -28,7 +28,6 @@ spec:
           - --machine-set-scale-timeout=20 # Optional Parameter - Default value 20mins - Timeout (in minutes) used while scaling machineSet if timeout occurs machineSet is frozen.
           - --machine-safety-orphan-vms-period=30 # Optional Parameter - Default value 30mins - Time period (in minutes) used to poll for orphan VMs by safety controller.
           - --machine-safety-overshooting-period=1 # Optional Parameter - Default value 1min - Time period (in minutes) used to poll for overshooting of machine objects backing a machineSet by safety controller.
-          - --namespace=default
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
The sample deployment.yaml contained a --namespace=default parameter
that was overwriting the actual configured namespace.

**What this PR does / why we need it**:
The sample deployment.yaml has a parameter `--namespace=$(CONTROL_NAMESPACE)` where users can set the control namespace for the machine-controller-manager. But later in the file the parameter is statically set to `--namespace=default`, effectively overwriting the setting of the user. This is confusing and should probably be cleaned up.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```
NONE
```