### PR TITLE
Update golang to 1.12.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,11 +19,11 @@ machine-controller-manager:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
     steps:
       check:
-        image: 'golang:1.11.5'
+        image: 'golang:1.12.0'
       test:
         image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.4.0'
       build:
-        image: 'golang:1.11.5'
+        image: 'golang:1.12.0'
         output_dir: 'binary'
   variants:
     head-update:


### PR DESCRIPTION
**What this PR does / why we need it**:
https://golang.org/doc/go1.12

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
The golang version has been upgraded to `v1.12.0`.
```
