### PR TITLE
Fix make check

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -49,7 +49,11 @@ if [[ "${SOURCE_PATH}" != *"src/github.com/gardener/gardener" ]]; then
 fi
 
 # Install Golint (linting tool).
-go get -u github.com/golang/lint/golint
+if ! which golint 1>/dev/null; then
+  echo -n "Installing golint... "
+  go get -u golang.org/x/lint/golint
+  echo "done."
+fi
 
 ###############################################################################
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `$ make check` fails with:
```
package github.com/golang/lint/golint: code in directory /tmp/build/d56d9853/git-gardener_machine-controller-manager-master_master/tmp/src/github.com/golang/lint/golint expects import "golang.org/x/lint/golint"
```

`github.com/golang/lint/golint` is replaced by `golang.org/x/lint/golint`. See [golang/lint#45](https://github.com/golang/lint/issues/415).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
