### PR TITLE
Bugfix/azure wait for disk detach

### DIFF
--- a/pkg/controller/drain.go
+++ b/pkg/controller/drain.go
@@ -303,10 +303,9 @@ func (o *DrainOptions) getPodsForDeletion() (pods []api.Pod, err error) {
 
 func (o *DrainOptions) deletePod(pod api.Pod) error {
 	deleteOptions := &metav1.DeleteOptions{}
-	if o.GracePeriodSeconds >= 0 {
-		gracePeriodSeconds := int64(o.GracePeriodSeconds)
-		deleteOptions.GracePeriodSeconds = &gracePeriodSeconds
-	}
+	gracePeriodSeconds := int64(0)
+	deleteOptions.GracePeriodSeconds = &gracePeriodSeconds
+
 	return o.client.Core().Pods(pod.Namespace).Delete(pod.Name, deleteOptions)
 }
 
@@ -347,7 +346,12 @@ func (o *DrainOptions) deleteOrEvictPods(pods []api.Pod) error {
 	}
 
 	if len(policyGroupVersion) > 0 {
-		return o.evictPods(pods, policyGroupVersion, getPodFn)
+		err := o.evictPods(pods, policyGroupVersion, getPodFn)
+		if err != nil {
+			glog.Warningf("Pod eviction was timed out, Error: %v. \nHowever, drain will continue to forcefully delete the pods by setting graceful termination period to 0s", err)
+		} else {
+			return nil
+		}
 	}
 	return o.deletePods(pods, getPodFn)
 }

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -470,7 +470,7 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 					c.targetCoreClient,
 					timeOutDuration, // TODO: Will need to configure timeout
 					nodeName,
-					-1,
+					int(timeOutDuration.Seconds()),
 					true,
 					true,
 					true,

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -244,10 +244,10 @@ func (d *AzureDriver) Delete() error {
 			return err
 		}
 		metrics.APIRequestCount.With(prometheus.Labels{"provider": "azure", "service": "virtual_machine"}).Inc()
-		glog.V(2).Infof("VM deletion was successful for %s", vmName)
+		glog.V(2).Infof("VM deletion was successful for %q", vmName)
 
 	} else {
-		glog.Warningf("VM was not found for %s", vmName)
+		glog.Warningf("VM was not found for %q", vmName)
 	}
 
 	listOfResources = make(map[string]string)
@@ -260,9 +260,9 @@ func (d *AzureDriver) Delete() error {
 			return err
 		}
 		metrics.APIRequestCount.With(prometheus.Labels{"provider": "azure", "service": "network_interfaces"}).Inc()
-		glog.V(2).Infof("NIC deletion was successful for %s", nicName)
+		glog.V(2).Infof("NIC deletion was successful for %q", nicName)
 	} else {
-		glog.Warningf("NIC was not found for %s", nicName)
+		glog.Warningf("NIC was not found for %q", nicName)
 	}
 
 	listOfResources = make(map[string]string)
@@ -275,9 +275,9 @@ func (d *AzureDriver) Delete() error {
 			return err
 		}
 		metrics.APIRequestCount.With(prometheus.Labels{"provider": "azure", "service": "disks"}).Inc()
-		glog.V(2).Infof("OS-Disk deletion was successful for %s", diskName)
+		glog.V(2).Infof("OS-Disk deletion was successful for %q", diskName)
 	} else {
-		glog.Warningf("OS-Disk was not found for %s", diskName)
+		glog.Warningf("OS-Disk was not found for %q", diskName)
 	}
 
 	return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR attempts to fix the Azure issue of VMs stuck in deletion state. Now Azure waits for disks being detached and drains to complete before deleting the VM.

**Which issue(s) this PR fixes**:
Fixes #242 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy user
The drain is always invoked even the case of forceful deletion
```
```noteworthy user
Drain now tries to evict pods and if eviction fails, it forcefully deletes the pods
```
```improvement operator
Azure explicitly detaches data disks before VM deletion
```