### PR TITLE
Fixes merge conflicts in unit tests for machines

### DIFF
--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -302,6 +302,14 @@ func newMachines(
 	labels map[string]string,
 ) []*v1alpha1.Machine {
 	machines := make([]*v1alpha1.Machine, machineCount)
+
+	if annotations == nil {
+		annotations = make(map[string]string, 0)
+	}
+	if labels == nil {
+		labels = make(map[string]string, 0)
+	}
+
 	for i := range machines {
 		m := &v1alpha1.Machine{
 			TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -740,7 +740,7 @@ var _ = Describe("machine", func() {
 								Name: "machine-0",
 							},
 						},
-					}, nil, nil),
+					}, nil, nil, nil, nil),
 				},
 				action: action{
 					machine:        "machine-0",
@@ -775,7 +775,7 @@ var _ = Describe("machine", func() {
 								Name: "machine-0",
 							},
 						},
-					}, nil, nil),
+					}, nil, nil, nil, nil),
 				},
 				action: action{
 					machine:        "machine-0",


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes merge conflicts in unit tests for machine

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
