### PR TITLE
Added safety controller cases in integration tests

### DIFF
--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -109,7 +109,7 @@ function run_controller() {
         --machine-safety-apiserver-statuscheck-timeout=30s \
         --machine-safety-apiserver-statuscheck-period=1m \
         --machine-safety-orphan-vms-period=30m \
-        --machine-safety-overshooting-period=1m \
+        --machine-safety-overshooting-period=1s \
         --leader-elect-lease-duration=1m \
         --leader-elect-renew-deadline=30s \
         --leader-elect-retry-period=15s \
@@ -210,6 +210,20 @@ function hf_wait_on() {
     done
 }
 
+function hf_check_ms_freeze() {
+    freeze_count=$(cat logs/${provider}-mcm.out | grep ' Froze MachineSet' | wc -l)
+    if [[ freeze_count -eq 0 ]]; then
+        printf "\tFailed: Freezing of machineSet failed. Exiting Test to avoid further conflicts.\n"
+        terminate_script
+    fi
+
+    unfreeze_count=$(cat logs/${provider}-mcm.out | grep ' Unfroze MachineSet' | wc -l)
+    if [[ unfreeze_count -eq 0 ]]; then
+        printf "\tFailed: Unfreezing of machineSet failed. Exiting Test to avoid further conflicts.\n"
+        terminate_script
+    fi
+}
+
 function terminate_script() {
     printf "\n\t\t\t----- Start of MCM Logs for $provider -----------\n"
     cat logs/${provider}-mcm.out
@@ -246,6 +260,11 @@ function tc_machine_deployment() {
     printf "\n\tWaiting 1800s for 3 machines to join the cluster"
     hf_wait_on "hf_num_of_ready_nodes" nodes 3 1800
 
+    # Scale up the number of nodes to 6 and rapidly scale back to 2
+    hf_object_configure $provider/md-scale-up.yaml
+    printf "\n\tScale up the number of nodes to 6 and rapidly scale back to 2 leading to a freezing and unfreezing"
+    sleep 20
+
     # Scale down the number of nodes to 2
     hf_object_configure $provider/md-scale-down.yaml
     printf "\n\tWaiting 1800s for machines to scale-down to 2"
@@ -260,6 +279,11 @@ function tc_machine_deployment() {
     hf_object_delete $provider/md.yaml
     printf "\n\tWaiting 1800s for machine to be deleted"
     hf_wait_on "hf_num_of_objects" machdeploy 0 1800
+
+    # Scaling from 6 to 2 should lead to freezing and unfreezing of machine-set
+    printf "\n\tCheck for freezing and unfreezing of machine-set due to rapid scaleUp and scaleDown"
+    hf_check_ms_freeze
+    printf "\n\tFreezing and unfreezing of machineSet was observed"
 
     printf "\nCompleted TestCase\n"
 }

--- a/.ci/sample-objects/aws/md-scale-up.yaml
+++ b/.ci/sample-objects/aws/md-scale-up.yaml
@@ -1,0 +1,27 @@
+# Sample machine-deploy object
+
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: test-md # Name of the machine deploy
+  namespace: aws
+spec:
+  replicas: 6 # Number of healthy replicas that should always be healthy
+  minReadySeconds: 500 # Minimum time to wait for machine to be ready
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate # Strategy for update RollingUpdate/Recreate
+    rollingUpdate:
+      maxSurge: 0 # Maximum addition machines that spawned over the desired replicas during update
+      maxUnavailable: 1 # Maximum unavailable machines that the cluster can tolerate
+  selector:
+    matchLabels:
+      test-label: test-label # Label to match the template (XXXXX)
+  template:
+    metadata:
+      labels:
+        test-label: test-label # Label to match with selector (XXXXX)
+    spec:
+      class:
+        kind: AWSMachineClass # Machine class template used to create machine, could be AWS/GCP/Azure/Other-cloud-providers
+        name: mc-v1 # Name of the machine class

--- a/.ci/sample-objects/az/md-scale-up.yaml
+++ b/.ci/sample-objects/az/md-scale-up.yaml
@@ -1,0 +1,27 @@
+# Sample machine-deploy object
+
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: test-md # Name of the machine deploy
+  namespace: az
+spec:
+  replicas: 6 # Number of healthy replicas that should always be healthy
+  minReadySeconds: 500 # Minimum time to wait for machine to be ready
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate # Strategy for update RollingUpdate/Recreate
+    rollingUpdate:
+      maxSurge: 0 # Maximum addition machines that spawned over the desired replicas during update
+      maxUnavailable: 1 # Maximum unavailable machines that the cluster can tolerate
+  selector:
+    matchLabels:
+      test-label: test-label # Label to match the template (XXXXX)
+  template:
+    metadata:
+      labels:
+        test-label: test-label # Label to match with selector (XXXXX)
+    spec:
+      class:
+        kind: AzureMachineClass # Machine class template used to create machine, could be AWS/GCP/Azure/Other-cloud-providers
+        name: mc-v1 # Name of the machine class

--- a/.ci/sample-objects/gcp/md-scale-up.yaml
+++ b/.ci/sample-objects/gcp/md-scale-up.yaml
@@ -1,0 +1,27 @@
+# Sample machine-deploy object
+
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: test-md # Name of the machine deploy
+  namespace: gcp
+spec:
+  replicas: 6 # Number of healthy replicas that should always be healthy
+  minReadySeconds: 500 # Minimum time to wait for machine to be ready
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate # Strategy for update RollingUpdate/Recreate
+    rollingUpdate:
+      maxSurge: 0 # Maximum addition machines that spawned over the desired replicas during update
+      maxUnavailable: 1 # Maximum unavailable machines that the cluster can tolerate
+  selector:
+    matchLabels:
+      test-label: test-label # Label to match the template (XXXXX)
+  template:
+    metadata:
+      labels:
+        test-label: test-label # Label to match with selector (XXXXX)
+    spec:
+      class:
+        kind: GCPMachineClass # Machine class template used to create machine, could be AWS/GCP/Azure/Other-cloud-providers
+        name: mc-v1 # Name of the machine class

--- a/.ci/sample-objects/os/md-scale-up.yaml
+++ b/.ci/sample-objects/os/md-scale-up.yaml
@@ -1,0 +1,27 @@
+# Sample machine-deploy object
+
+apiVersion: machine.sapcloud.io/v1alpha1
+kind: MachineDeployment
+metadata:
+  name: test-md # Name of the machine deploy
+  namespace: os
+spec:
+  replicas: 6 # Number of healthy replicas that should always be healthy
+  minReadySeconds: 500 # Minimum time to wait for machine to be ready
+  progressDeadlineSeconds: 1200
+  strategy:
+    type: RollingUpdate # Strategy for update RollingUpdate/Recreate
+    rollingUpdate:
+      maxSurge: 0 # Maximum addition machines that spawned over the desired replicas during update
+      maxUnavailable: 1 # Maximum unavailable machines that the cluster can tolerate
+  selector:
+    matchLabels:
+      test-label: test-label # Label to match the template (XXXXX)
+  template:
+    metadata:
+      labels:
+        test-label: test-label # Label to match with selector (XXXXX)
+    spec:
+      class:
+        kind: OpenStackMachineClass # Machine class template used to create machine, could be AWS/GCP/Azure/Other-cloud-providers
+        name: mc-v1 # Name of the machine class

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -710,8 +710,11 @@ func (c *controller) freezeMachineSetAndDeployment(machineSet *v1alpha1.MachineS
 				return err
 			}
 
+			glog.V(2).Infof("SafetyController: Froze MachineDeployment %q due to overshooting of replicas", machineSet.Name)
 		}
 	}
+
+	glog.V(2).Infof("SafetyController: Froze MachineSet %q due to overshooting of replicas", machineSet.Name)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Integration tests now checks for freezing and unfreezing of machine-sets due to overshooting replicas

**Which issue(s) this PR fixes**:
Fixes #246 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Added safety controller cases in integration tests
```
