### PR TITLE
[WIP] Ensure packet tags are string array and not key-value map

### DIFF
--- a/kubernetes/machine_classes/packet-machine-class.yaml
+++ b/kubernetes/machine_classes/packet-machine-class.yaml
@@ -13,11 +13,11 @@ spec:
     - AMS1
   machineType: x1.small # Type of packet bare-metal machine
   tags:
-    Name: sample-machine-name # Name tag that can be used to identify a machine at Packet
-    kubernetes.io/cluster/YOUR_CLUSTER_NAME: "1" # This is mandatory as the safety controller uses this tag to identify VMs created by this controller.
-    kubernetes.io/role/YOUR_ROLE_NAME: "1" # This is mandatory as the safety controller uses this tag to identify VMs created by by this controller.
-    tag1: tag1-value # A set of additional tags attached to a machine (optional)
-    tag2: tag2-value # A set of additional tags attached to a machine (optional)
+    - "Name: sample-machine-name" # Name tag that can be used to identify a machine at Packet
+    - "kubernetes.io/cluster/YOUR_CLUSTER_NAME" # This is mandatory as the safety controller uses this tag to identify VMs created by this controller.
+    - "kubernetes.io/role/YOUR_ROLE_NAME" # This is mandatory as the safety controller uses this tag to identify VMs created by by this controller.
+    - "tag1-value" # A set of additional tags attached to a machine (optional)
+    - "tag2-value" # A set of additional tags attached to a machine (optional)
   secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
     namespace: default  # Namespace
     name: test-secret # Name of the secret

--- a/pkg/apis/machine/validation/packetmachineclass.go
+++ b/pkg/apis/machine/validation/packetmachineclass.go
@@ -84,16 +84,16 @@ func validatePacketMachineClassSpec(spec *machine.PacketMachineClassSpec, fldPat
 	return allErrs
 }
 
-func validatePacketClassSpecTags(tags map[string]string, fldPath *field.Path) field.ErrorList {
+func validatePacketClassSpecTags(tags []string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	clusterName := ""
 	nodeRole := ""
 
-	for key := range tags {
-		if strings.Contains(key, "kubernetes.io/cluster/") {
-			clusterName = key
-		} else if strings.Contains(key, "kubernetes.io/role/") {
-			nodeRole = key
+	for _, tag := range tags {
+		if strings.Contains(tag, "kubernetes.io/cluster/") {
+			clusterName = tag
+		} else if strings.Contains(tag, "kubernetes.io/role/") {
+			nodeRole = tag
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The packet tags were listed as a key/value map instead of array of strings. This fixes it.

**Special notes for your reviewer**:

Raised by @rfranzke in https://github.com/gardener/gardener/pull/916

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fixes error with packet tags
```