### PR TITLE
Add additionalPrinterColumns to example CRDs

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,11 +19,11 @@ machine-controller-manager:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
     steps:
       check:
-        image: 'golang:1.12.0'
+        image: 'golang:1.12.5'
       test:
         image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.4.0'
       build:
-        image: 'golang:1.12.0'
+        image: 'golang:1.12.5'
         output_dir: 'binary'
   variants:
     head-update:

--- a/docs/development/testing_and_dependencies.md
+++ b/docs/development/testing_and_dependencies.md
@@ -4,7 +4,7 @@ We use [Dep](https://github.com/golang/dep) to manage golang dependencies.. In o
 
 ### Updating dependencies
 
-The `Makefile` contains a rule called `revendor` which performs a `dep ensure -update` and a `dep prune` command. This updates all the dependencies to its latest versions (respecting the constraints specified in the `Gopkg.toml` file). The command also installs the packages which do not yet exist in the `vendor` folder but are specified in the `Gopkg.toml` (in case you have added new ones).
+The `Makefile` contains a rule called `revendor` which performs a `dep ensure -update`. This updates all the dependencies to its latest versions (respecting the constraints specified in the `Gopkg.toml` file). The command also installs the packages which do not yet exist in the `vendor` folder but are specified in the `Gopkg.toml` (in case you have added new ones).
 
 ```bash
 $ make revendor

--- a/docs/usage/machine.md
+++ b/docs/usage/machine.md
@@ -33,7 +33,8 @@ You should notice that the Machine Controller Manager has immediately picked up 
 
 ```bash
 $ kubectl get machine
-test-machine Machine.v1alpha1.machine.sapcloud.io
+NAME           STATUS    AGE
+test-machine   Running   5m
 ```
 
 A new machine is created with the name provided in the `kubernetes/machine_objects/machine.yaml` file.

--- a/docs/usage/machine_deployment.md
+++ b/docs/usage/machine_deployment.md
@@ -43,8 +43,8 @@ Now the Machine Controller Manager picks up the manifest immediately and starts 
 
 ```bash
 $ kubectl get machinedeployment
-NAME                       KIND
-test-machine-deployment   MachineDeployment.v1alpha1.machine.sapcloud.io
+NAME                      READY   DESIRED   UP-TO-DATE   AVAILABLE   AGE
+test-machine-deployment   3       3         3            0           10m
 ```
 
 You will notice a new machine-deployment with your given name
@@ -53,8 +53,8 @@ You will notice a new machine-deployment with your given name
 
 ```bash
 $ kubectl get machineset
-NAME                                  KIND
-test-machine-deployment-5bc6dd7c8f   MachineSet.v1alpha1.machine.sapcloud.io
+NAME                                 DESIRED   CURRENT   READY   AGE
+test-machine-deployment-5bc6dd7c8f   3         3         0       10m
 ```
 
 You will notice a new machine-set backing your machine-deployment
@@ -63,10 +63,10 @@ You will notice a new machine-set backing your machine-deployment
 
 ```bash
 $ kubectl get machine
-NAME                                        KIND
-test-machine-deployment-5bc6dd7c8f-5d24b   Machine.v1alpha1.machine.sapcloud.io
-test-machine-deployment-5bc6dd7c8f-6mpn4   Machine.v1alpha1.machine.sapcloud.io
-test-machine-deployment-5bc6dd7c8f-dpt2q   Machine.v1alpha1.machine.sapcloud.io
+NAME                                       STATUS    AGE
+test-machine-deployment-5bc6dd7c8f-5d24b   Pending   5m
+test-machine-deployment-5bc6dd7c8f-6mpn4   Pending   5m
+test-machine-deployment-5bc6dd7c8f-dpt2q   Pending   5m
 ```
 
 Now you will notice N (number of replicas specified in the manifest) new machines whose name are prefixed with the machine-deployment object name that you created.
@@ -151,7 +151,7 @@ Health monitor is also applied similar to how it's described for [machine-sets](
 
 ## Update your machines
 
-Let us consider the scenario where you wish to update all nodes of your cluster from t2.xlarge machines to m4.xlarge machines. Assume that your current *test-aws* has its **spec.machineType: t2.xlarge** and your deployment *test-machine-deployment* points to this AWSMachineClass. 
+Let us consider the scenario where you wish to update all nodes of your cluster from t2.xlarge machines to m5.xlarge machines. Assume that your current *test-aws* has its **spec.machineType: t2.xlarge** and your deployment *test-machine-deployment* points to this AWSMachineClass. 
 
 #### Inspect existing cluster configuration
 
@@ -169,15 +169,15 @@ ip-10-250-31-80.eu-west-1.compute.internal    Ready     1m        v1.8.0
 
 ```bash
 $ kubectl get machineset
-NAME                                  KIND
-test-machine-deployment-5bc6dd7c8f   MachineSet.v1alpha1.machine.sapcloud.io
+NAME                                 DESIRED   CURRENT   READY   AGE
+test-machine-deployment-5bc6dd7c8f   3         3         3       10m
 ```
 
 - Login to your cloud provider (AWS). In the VM management console, you will find N VMs created of type t2.xlarge.
 
 #### Perform a rolling update
 
-To update this machine-deployment VMs to m4.xlarge, we would do the following:
+To update this machine-deployment VMs to `m5.xlarge`, we would do the following:
 
 - Copy your existing aws-machine-class.yaml
 
@@ -185,7 +185,7 @@ To update this machine-deployment VMs to m4.xlarge, we would do the following:
 cp kubernetes/machine_classes/aws-machine-class.yaml kubernetes/machine_classes/aws-machine-class-new.yaml
 ```
 
-- Modify aws-machine-class-new.yaml, and update its *metadata.name: test-aws2* and  *spec.machineType: m4.xlarge*
+- Modify aws-machine-class-new.yaml, and update its *metadata.name: test-aws2* and  *spec.machineType: m5.xlarge*
 - Now create this modified MachineClass
 
 ```bash
@@ -202,7 +202,7 @@ kubectl edit machinedeployment test-machine-deployment
 
 #### Re-check cluster configuration
 
-After a few minutes (~ 3mins)
+After a few minutes (~3mins)
 
 - Check nodes present in cluster now. They are different nodes.
 
@@ -218,14 +218,14 @@ ip-10-250-31-81.eu-west-1.compute.internal    Ready     5m        v1.8.0
 
 ```bash
 $ kubectl get machineset
-NAME                                  KIND
-test-machine-deployment-5bc6dd7c8f   MachineSet.v1alpha1.machine.sapcloud.io
-test-machine-deployment-86ff45cc5    MachineSet.v1alpha1.machine.sapcloud.io
+NAME                                 DESIRED   CURRENT   READY   AGE
+test-machine-deployment-5bc6dd7c8f   0         0         0       1h
+test-machine-deployment-86ff45cc5    3         3         3       20m
 ```
 
-- Login to your cloud provider (AWS). In the VM management console, you will find N VMs created of type t2.xlarge in terminated state, and N new VMs of type m4.xlarge in running state.
+- Login to your cloud provider (AWS). In the VM management console, you will find N VMs created of type t2.xlarge in terminated state, and N new VMs of type m5.xlarge in running state.
 
-This shows how a rolling update of a cluster from nodes with t2.xlarge to m4.xlarge went through.
+This shows how a rolling update of a cluster from nodes with t2.xlarge to m5.xlarge went through.
 
 #### More variants of updates
 

--- a/docs/usage/machine_set.md
+++ b/docs/usage/machine_set.md
@@ -34,19 +34,18 @@ You should notice that the Machine Controller Manager has immediately picked up 
 
 ```bash
 $ kubectl get machineset
-NAME                KIND
-test-machine-set   MachineSet.v1alpha1.machine.sapcloud.io
+NAME               DESIRED   CURRENT   READY   AGE
+test-machine-set   3         3         0       1m
 ```
 You will see a new machine-set with your given name
 
 - Check Machine Controller Manager machines in the cluster:
-
 ```bash
 $ kubectl get machine
-NAME                      KIND
-test-machine-set-b57zs   Machine.v1alpha1.machine.sapcloud.io
-test-machine-set-c4bg8   Machine.v1alpha1.machine.sapcloud.io
-test-machine-set-kvskg   Machine.v1alpha1.machine.sapcloud.io
+NAME                     STATUS    AGE
+test-machine-set-b57zs   Pending   5m
+test-machine-set-c4bg8   Pending   5m
+test-machine-set-kvskg   Pending   5m
 ```
 
 Now you will see N (number of replicas specified in the manifest) new machines whose names are prefixed with the machine-set object name that you created.

--- a/docs/usage/prerequisite.md
+++ b/docs/usage/prerequisite.md
@@ -63,8 +63,8 @@ Get to know the current cluster state using the following commands,
 
 ```bash
 $ kubectl get awsmachineclass
-NAME       KIND
-test-aws   AWSMachineClass.v1alpha1.machine.sapcloud.io
+NAME       MACHINE TYPE   AMI          AGE
+test-aws   t2.large       ami-123456   5m
 ```
 
 - Checking kubernetes secrets in the cluster

--- a/kubernetes/crds.yaml
+++ b/kubernetes/crds.yaml
@@ -16,6 +16,25 @@ spec:
     - oscls
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Flavor
+    type: string
+    JSONPath: .spec.flavorName
+  - name: Image
+    type: string
+    JSONPath: .spec.imageName
+  - name: Region
+    type: string
+    priority: 1
+    JSONPath: .spec.region
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp
 
 ---
 
@@ -35,6 +54,25 @@ spec:
     - awscls
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Machine Type
+    type: string
+    JSONPath: .spec.machineType
+  - name: AMI
+    type: string
+    JSONPath: .spec.ami
+  - name: Region
+    type: string
+    priority: 1
+    JSONPath: .spec.region
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp
 
 ---
 
@@ -54,6 +92,22 @@ spec:
     - azurecls
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: VM size
+    type: string
+    JSONPath: .spec.properties.hardwareProfile.vmSize
+  - name: Location
+    type: string
+    priority: 1
+    JSONPath: .spec.location
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp
 
 ---
 
@@ -73,6 +127,22 @@ spec:
     - gcpcls
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Machine Type
+    type: string
+    JSONPath: .spec.machineType
+  - name: Region
+    type: string
+    priority: 1
+    JSONPath: .spec.region
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp
 
 ---
 
@@ -92,6 +162,22 @@ spec:
     - alicloudcls
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Instance Type
+    type: string
+    JSONPath: .spec.instanceType
+  - name: Region
+    type: string
+    priority: 1
+    JSONPath: .spec.region
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp
 
 ---
 
@@ -130,6 +216,19 @@ spec:
     - mach
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Status
+    type: string
+    description: Current status of the machine.
+    JSONPath: .status.currentStatus.phase
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp
 
 ---
 
@@ -149,6 +248,27 @@ spec:
     - machset
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Desired
+    type: integer
+    description: Number of desired replicas.
+    JSONPath: .spec.replicas
+  - name: Current
+    type: integer
+    description: Number of actual replicas.
+    JSONPath: .status.replicas
+  - name: Ready
+    type: integer
+    description: Number of ready replicas for this machine set.
+    JSONPath: .status.readyReplicas
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp
 
 ---
 
@@ -168,3 +288,28 @@ spec:
     - machdeploy
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: integer
+    description: Total number of ready machines targeted by this machine deployment.
+    JSONPath: .status.readyReplicas
+  - name: Desired
+    type: integer
+    description: Number of desired machines.
+    JSONPath: .spec.replicas
+  - name: Up-to-date
+    type: integer
+    description: Total number of non-terminated machines targeted by this machine deployment that have the desired template spec.
+    JSONPath: .status.updatedReplicas
+  - name: Available
+    type: integer
+    description: Total number of available machines (ready for at least minReadySeconds) targeted by this machine deployment.
+    JSONPath: .status.availableReplicas
+  - name: Age
+    type: date
+    description: >
+      CreationTimestamp is a timestamp representing the server time when this object was created.
+      It is not guaranteed to be set in happens-before order across separate operations.
+      Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    JSONPath: .metadata.creationTimestamp

--- a/pkg/controller/deployment_machineset_util.go
+++ b/pkg/controller/deployment_machineset_util.go
@@ -117,7 +117,7 @@ func calculateMachineSetStatus(is *v1alpha1.MachineSet, filteredMachines []*v1al
 			machineSummary.Name = machine.Name
 			machineSummary.ProviderID = machine.Spec.ProviderID
 			machineSummary.LastOperation = machine.Status.LastOperation
-			//ownerRef populated here, so that deployment controller doesn't have to add it seperately
+			//ownerRef populated here, so that deployment controller doesn't have to add it separately
 			if controller := metav1.GetControllerOf(machine); controller != nil {
 				machineSummary.OwnerRef = controller.Name
 			}

--- a/pkg/controller/machine_util.go
+++ b/pkg/controller/machine_util.go
@@ -212,7 +212,7 @@ func (c *controller) validateMachineClass(classSpec *v1alpha1.ClassSpec) (interf
 		internalAlicloudMachineClass := &machineapi.AlicloudMachineClass{}
 		err = c.internalExternalScheme.Convert(AlicloudMachineClass, internalAlicloudMachineClass, nil)
 		if err != nil {
-			glog.V(2).Info("Error in scheme convertion")
+			glog.V(2).Info("Error in scheme conversion")
 			return MachineClass, secretRef, err
 		}
 

--- a/pkg/controller/machine_util_test.go
+++ b/pkg/controller/machine_util_test.go
@@ -788,7 +788,7 @@ var _ = Describe("machine_util", func() {
 
 				waitForCacheSync(stop, c)
 
-				// ignore LastAppliedALTAnnotation for comparision
+				// ignore LastAppliedALTAnnotation for comparison
 				delete(testNode.Annotations, LastAppliedALTAnnotation)
 				Expect(testNode.Annotations).Should(Equal(expectedNode.Annotations))
 				Expect(annotationsChanged).To(Equal(data.expect.annotationsChanged))


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add additionalPrinterColumns to example CRDs. I also want to add them to the CRDs in gardener/gardener-extensions (gardener/gardener-extensions#99). It will be useful to have them for faster ops.
- Update golang to 1.12.5

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
