### PR TITLE
Fix unit-tests

### DIFF
--- a/pkg/controller/deployment_rollback_test.go
+++ b/pkg/controller/deployment_rollback_test.go
@@ -118,7 +118,7 @@ var _ = Describe("deployment_rollback", func() {
 				for _, expectedNode := range data.expect.nodes {
 					actualNode, err := controller.targetCoreClient.CoreV1().Nodes().Get(expectedNode.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					Expect(actualNode.Spec.Taints).Should(Equal(expectedNode.Spec.Taints))
+					Expect(actualNode.Spec.Taints).Should(ConsistOf(expectedNode.Spec.Taints))
 				}
 
 			},

--- a/pkg/controller/deployment_rolling_test.go
+++ b/pkg/controller/deployment_rolling_test.go
@@ -116,7 +116,7 @@ var _ = Describe("deployment_rolling", func() {
 				for _, expectedNode := range data.expect.nodes {
 					actualNode, err := controller.targetCoreClient.CoreV1().Nodes().Get(expectedNode.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
-					Expect(actualNode.Spec.Taints).Should(Equal(expectedNode.Spec.Taints))
+					Expect(actualNode.Spec.Taints).Should(ConsistOf(expectedNode.Spec.Taints))
 				}
 
 			},

--- a/pkg/controller/machine_util_test.go
+++ b/pkg/controller/machine_util_test.go
@@ -17,7 +17,6 @@ package controller
 
 import (
 	"encoding/json"
-	"reflect"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	machinev1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -82,7 +81,7 @@ var _ = Describe("machine_util", func() {
 				updatedNodeObject, _ := c.targetCoreClient.Core().Nodes().Get(nodeObject.Name, metav1.GetOptions{})
 
 				if data.expect.node != nil {
-					Expect(updatedNodeObject.Spec.Taints).Should(Equal(data.expect.node.Spec.Taints))
+					Expect(updatedNodeObject.Spec.Taints).Should(ConsistOf(data.expect.node.Spec.Taints))
 					Expect(updatedNodeObject.Labels).Should(Equal(data.expect.node.Labels))
 
 					// ignore LastAppliedALTAnnotataion
@@ -1099,7 +1098,7 @@ var _ = Describe("machine_util", func() {
 
 				waitForCacheSync(stop, c)
 
-				Expect(reflect.DeepEqual(testNode.Spec.Taints, expectedNode.Spec.Taints)).To(Equal(true))
+				Expect(testNode.Spec.Taints).Should(ConsistOf(expectedNode.Spec.Taints))
 				Expect(taintsChanged).To(Equal(data.expect.taintsChanged))
 			},
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Unit-tests seems to be flaking because current taint-support does not guarantee the order of taints. This PR fixes a couple of tests which are assuming the ordered taints.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator

```
