### PR TITLE
Fix panic in AWS driver if AMI not found.

### DIFF
--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -70,6 +70,10 @@ func (d *AWSDriver) Create() (string, string, error) {
 	}
 	metrics.APIRequestCount.With(prometheus.Labels{"provider": "aws", "service": "ecs"}).Inc()
 
+	if len(output.Images) < 1 {
+		return "Error", "Error", fmt.Errorf("Image %s not found", *imageID)
+	}
+
 	var blkDeviceMappings []*ec2.BlockDeviceMapping
 	deviceName := output.Images[0].RootDeviceName
 	volumeSize := d.AWSMachineClass.Spec.BlockDevices[0].Ebs.VolumeSize


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid panic in the AWS driver if invalid AMI is supplied.

**Which issue(s) this PR fixes**:
Fixes #278 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Fix panic in AWS driver if AMI not found.
```
