### PR TITLE
Update test image to use golang@1.12.6

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,11 +19,11 @@ machine-controller-manager:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
     steps:
       check:
-        image: 'golang:1.12.5'
+        image: 'golang:1.12.6'
       test:
-        image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.4.0'
+        image: 'eu.gcr.io/gardener-project/cc/job-image-golang:0.6.0'
       build:
-        image: 'golang:1.12.5'
+        image: 'golang:1.12.6'
         output_dir: 'binary'
   variants:
     head-update:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update test image to use golang@1.12.6. The pipeline_definition for a PR is taken from the master branch, not from the PR itself. 
Required for #280.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@ccwienk 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
