### PR TITLE
Enhancement/force deletion

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -511,26 +511,27 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 				errBuf,
 			)
 			err = drainOptions.RunDrain()
-			if err != nil {
+			if err == nil {
+				// Drain successful
+				glog.V(2).Infof("Drain successful for machine %q. \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
 
-				if machine.Labels["force-deletion"] == "True" {
-					// Continue with the deletion of VM without draining
-				} else {
-					// If it's not a force-deletion return error
-					lastOperation := v1alpha1.LastOperation{
-						Description:    "Drain failed - " + err.Error(),
-						State:          v1alpha1.MachineStateFailed,
-						Type:           v1alpha1.MachineOperationDelete,
-						LastUpdateTime: metav1.Now(),
-					}
-					c.updateMachineStatus(machine, lastOperation, machine.Status.CurrentStatus)
+			} else if err != nil && machine.Labels["force-deletion"] == "True" {
+				// Drain failed on force deletion
+				glog.Warningf("Drain failed for machine %q. However, since it's a force deletion shall continue deletion of VM. \nBuf:%v \nErrBuf:%v \nErr-Message:%v", machine.Name, buf, errBuf, err)
 
-					// Machine still tries to terminate after drain failure
-					glog.Warningf("Drain failed for machine %q \nBuf:%v \nErrBuf:%v \nErr-Message:%v", machine.Name, buf, errBuf, err)
-					return err
+			} else {
+				// Drain failed on normal (non-force) deletion, return error for retry
+				lastOperation := v1alpha1.LastOperation{
+					Description:    "Drain failed - " + err.Error(),
+					State:          v1alpha1.MachineStateFailed,
+					Type:           v1alpha1.MachineOperationDelete,
+					LastUpdateTime: metav1.Now(),
 				}
+				c.updateMachineStatus(machine, lastOperation, machine.Status.CurrentStatus)
+
+				glog.Warningf("Drain failed for machine %q. \nBuf:%v \nErrBuf:%v \nErr-Message:%v", machine.Name, buf, errBuf, err)
+				return err
 			}
-			glog.V(2).Infof("Drain successful for machine %q \nBuf:%v \nErrBuf:%v", machine.Name, buf, errBuf)
 
 			err = driver.Delete()
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR always allows deletion of machines with `force-delete` labels. This avoids failure of deletion calls for clusters where the APIServer is not reachable.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/machine-controller-manager/issues/281

**Special notes for your reviewer**:
I have divided the commits for ease of review

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Force deletion of machine succeeds even on drain failures
```
