### PR TITLE
Openstack: handle invalid server status while waiting

### DIFF
--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -106,7 +106,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 		return "", "", err
 	}
 
-	err = waitForStatus(client, server.ID, []string{"BUILD"}, []string{"ACTIVE"}, 300)
+	err = waitForStatus(client, server.ID, []string{"BUILD"}, []string{"ACTIVE"}, 600)
 	if err != nil {
 		return "", "", fmt.Errorf("error waiting for the %q server status: %s", server.ID, err)
 	}

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -472,7 +472,7 @@ func (d *OpenStackDriver) GetVolNames(specs []corev1.PersistentVolumeSpec) ([]st
 	return names, nil
 }
 
-func waitForStatus(c *gophercloud.ServiceClient, id, pending []string, target []string, secs int) error {
+func waitForStatus(c *gophercloud.ServiceClient, id string, pending []string, target []string, secs int) error {
 	return gophercloud.WaitFor(secs, func() (bool, error) {
 		current, err := servers.Get(c, id).Extract()
 		if err != nil {

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -487,7 +487,7 @@ func waitForStatus(c *gophercloud.ServiceClient, id, pending []string, target []
 			return false, nil
 		}
 
-		return false, fmt.Errorf("unexpected status '%s', wanted target '%s'", current.Status, strings.Join(target, ", "))
+		return false, fmt.Errorf("unexpected status %q, wanted target %q", current.Status, strings.Join(target, ", "))
 	})
 }
 

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -95,7 +95,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	server, err := servers.Create(client, createOpts).Extract()
 	if err != nil {
 		metrics.APIFailedRequestCount.With(prometheus.Labels{"provider": "openstack", "service": "nova"}).Inc()
-		return "", "", err
+		return "", "", fmt.Errorf("error creating the server: %s", err)
 	}
 	metrics.APIRequestCount.With(prometheus.Labels{"provider": "openstack", "service": "nova"}).Inc()
 
@@ -108,7 +108,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 
 	err = waitForStatus(client, server.ID, []string{"BUILD"}, []string{"ACTIVE"}, 300)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("error waiting for the %q server status: %s", server.ID, err)
 	}
 
 	listOpts := &ports.ListOpts{
@@ -141,7 +141,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	}
 	metrics.APIRequestCount.With(prometheus.Labels{"provider": "openstack", "service": "neutron"}).Inc()
 
-	return d.MachineID, d.MachineName, err
+	return d.MachineID, d.MachineName, nil
 }
 
 // Delete method is used to delete an OS machine


### PR DESCRIPTION
**What this PR does / why we need it**:

Handle broken VM status, when they are in non-active state, e.g.

```
$ openstack server list --limit 3
+--------------------------------------+---------------------------------------------------+--------+--------------------------------+---------------------+----------+
| ID                                   | Name                                              | Status | Networks                       | Image               | Flavor   |
+--------------------------------------+---------------------------------------------------+--------+--------------------------------+---------------------+----------+
| c7892fcc-9ac9-4317-9e44-5672dbbdac23 | shoot--garden--soil-cpu-worker-z1-b8dbfbfd5-nk8gw | ERROR  |                                | coreos-stable-amd64 | m1.large |
| 56304573-d218-4874-8d8e-2708e21e563b | shoot--garden--soil-cpu-worker-z1-b8dbfbfd5-r2kp4 | ERROR  |                                | coreos-stable-amd64 | m1.large |
| 203e22ec-014e-4aa0-8885-ce4cbd8dc435 | shoot--garden--soil-cpu-worker-z1-b8dbfbfd5-q8fnt | ACTIVE | shoot--garden--soil=10.180.1.4 | coreos-stable-amd64 | m1.large |
+--------------------------------------+---------------------------------------------------+--------+--------------------------------+---------------------+----------
```

**Release note**:
```improvement operator
Increased OpenStack server status wait for a timeout during server creation from 5 to 10 mins.
```
```improvement operator
Improved the server status handling - It no longer waits for the timeout if the server status is different from `BUILD` during server creation.
```