### PR TITLE
Use -mod=vendor

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -45,16 +45,18 @@ cd "${SOURCE_PATH}"
 # If no LOCAL_BUILD environment variable is set, we configure the `go build` command
 # to build for linux OS, amd64 architectures and without CGO enablement.
 if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
     -a \
     -v \
+    -mod=vendor \
     -o ${BINARY_PATH}/rel/machine-controller-manager \
     cmd/machine-controller-manager/controller_manager.go
 
 # If the LOCAL_BUILD environment variable is set, we simply run `go build`.
 else
-  go build \
+  GO111MODULE=on go build \
     -v \
+    -mod=vendor \
     -o ${BINARY_PATH}/machine-controller-manager \
     cmd/machine-controller-manager/controller_manager.go
 fi

--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -84,7 +84,7 @@ function setup_environment() {
     fi
 
     printf "\nBuilding MCM binary\n"
-    if go build -i cmd/machine-controller-manager/controller_manager.go; then
+    if GO111MODULE=on go build -mod=vendor -i cmd/machine-controller-manager/controller_manager.go; then
         printf "Go build Successful\n"
     else
         printf "Go build Failure\n"

--- a/.ci/test
+++ b/.ci/test
@@ -44,12 +44,12 @@ function test_with_coverage() {
   local output_dir=test/output
   local coverprofile_file=coverprofile.out
   mkdir -p test/output
-  ginkgo $GINKGO_COMMON_FLAGS --coverprofile ${coverprofile_file} -covermode=set -outputdir ${output_dir} ${TEST_PACKAGES}
+  GO111MODULE=on ginkgo $GINKGO_COMMON_FLAGS --coverprofile ${coverprofile_file} -covermode=set -outputdir ${output_dir} ${TEST_PACKAGES}
 
   sed -i -e '/mode: set/d' ${output_dir}/${coverprofile_file}
   {( echo "mode: set"; cat ${output_dir}/${coverprofile_file} )} > ${output_dir}/${coverprofile_file}.temp
   mv ${output_dir}/${coverprofile_file}.temp ${output_dir}/${coverprofile_file}
-  go tool cover -func ${output_dir}/${coverprofile_file}
+  GO111MODULE=on GOFLAGS="-mod=vendor" go tool cover -func ${output_dir}/${coverprofile_file}
 }
 
 ###############################################################################
@@ -59,7 +59,7 @@ if [[ "${SKIP_UNIT_TESTS}" != "" ]]; then
 else
   echo ">>>>> Invoking unit tests"
   TEST_PACKAGES="cmd pkg"
-  GINKGO_COMMON_FLAGS="-r -timeout=1h0m0s --randomizeAllSpecs --randomizeSuites --failOnPending  --progress"
+  GINKGO_COMMON_FLAGS="-r -timeout=1h0m0s --randomizeAllSpecs --randomizeSuites --failOnPending  --progress -mod=vendor"
   test_with_coverage
   echo ">>>>> Finished executing unit tests"
 fi

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ TARGET_KUBECONFIG  := dev/target-kubeconfig.yaml
 
 .PHONY: start
 start:
-	@go run cmd/machine-controller-manager/controller_manager.go \
+	@GO111MODULE=on go run \
+			-mod=vendor \
+			cmd/machine-controller-manager/controller_manager.go \
 			--control-kubeconfig=$(CONTROL_KUBECONFIG) \
 			--target-kubeconfig=$(TARGET_KUBECONFIG) \
 			--namespace=$(CONTROL_NAMESPACE) \

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -86,7 +86,7 @@ The Machine Controller Manager should now be ready to manage the VMs in your kub
 To test the creation/deletion of a single instance for one particular machine class you can use the `managevm` cli. The corresponding `INFRASTRUCTURE-machine-class.yaml` and the `INFRASTRUCTURE-secret.yaml` need to be defined upfront. To build and run it
 
 ```bash
-go build -o managevm cmd/machine-controller-manager-cli/main.go
+go build -mod=vendor -o managevm cmd/machine-controller-manager-cli/main.go
 # create machine
 ./managevm --secret PATH_TO/INFRASTRUCTURE-secret.yaml --machineclass PATH_TO/INFRASTRUCTURE-machine-class.yaml --classkind INFRASTRUCTURE --machinename test
 # delete machine


### PR DESCRIPTION
**What this PR does / why we need it**:
For cmd/go the default behaviour in go modules is to look up the proper modules through the network. `-mod=vendor` prevents that and forces the use of `vendor/`.
Ref golang/go#27227

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
