### PR TITLE
Bugfix: Allows force deletion of pods who have no controllers backing them (#300)

### DIFF
--- a/pkg/controller/drain_test.go
+++ b/pkg/controller/drain_test.go
@@ -118,20 +118,21 @@ var _ = Describe("drain", func() {
 			maxEvictRetries = 3
 		}
 		d := &DrainOptions{
-			DeleteLocalData:    true,
-			Driver:             &drainDriver{},
-			ErrOut:             GinkgoWriter,
-			Force:              setup.force,
-			GracePeriodSeconds: 30,
-			IgnoreDaemonsets:   true,
-			MaxEvictRetries:    maxEvictRetries,
-			Out:                GinkgoWriter,
-			PvDetachTimeout:    3 * time.Minute,
-			Timeout:            time.Minute,
-			client:             c.targetCoreClient,
-			nodeName:           testNodeName,
-			pvcLister:          c.pvcLister,
-			pvLister:           c.pvLister,
+			DeleteLocalData:              true,
+			Driver:                       &drainDriver{},
+			ErrOut:                       GinkgoWriter,
+			ForceDeletePods:              setup.force,
+			IgnorePodsWithoutControllers: true,
+			GracePeriodSeconds:           30,
+			IgnoreDaemonsets:             true,
+			MaxEvictRetries:              maxEvictRetries,
+			Out:                          GinkgoWriter,
+			PvDetachTimeout:              3 * time.Minute,
+			Timeout:                      time.Minute,
+			client:                       c.targetCoreClient,
+			nodeName:                     testNodeName,
+			pvcLister:                    c.pvcLister,
+			pvLister:                     c.pvLister,
 		}
 
 		// Get the pod directly from the ObjectTracker to avoid locking issues in the Fake object.

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -488,13 +488,13 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 			timeOutDuration := c.safetyOptions.MachineDrainTimeout.Duration
 			// Timeout value obtained by subtracting last operation with expected time out period
 			timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.Status.CurrentStatus.LastUpdateTime.Time)
-			force := false
+			forceDeletePods := false
 
 			// To perform forceful drain either one of the below conditions must be satified
 			// 1. force-deletion: "True" label must be present
 			// 2. Deletion operation is more than drain-timeout minutes old
 			if machine.Labels["force-deletion"] == "True" || timeOut > 0 {
-				force = true
+				forceDeletePods = true
 				timeOutDuration = 30 * time.Second
 				maxEvictRetries = 1
 				glog.V(2).Infof("Force deletion has been triggerred for machine %q", machine.Name)
@@ -511,7 +511,8 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 				pvDetachTimeOut,
 				nodeName,
 				-1,
-				force,
+				forceDeletePods,
+				true,
 				true,
 				true,
 				buf,


### PR DESCRIPTION
**What this PR does / why we need it**:
Split drain force flag into two - forceDeletePods, ignorePodsWithoutControllers

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Bugfix: Allows force deletion of pods who have no controllers backing them
```
