### PR TITLE
Regenerated API Types because the latest Version is not checked in

### DIFF
--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -9,7 +9,7 @@ import (
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
 	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
@@ -1983,7 +1983,7 @@ func Convert_machine_MachineDeploymentRollback_To_v1alpha1_MachineDeploymentRoll
 
 func autoConvert_v1alpha1_MachineDeploymentSpec_To_machine_MachineDeploymentSpec(in *MachineDeploymentSpec, out *machine.MachineDeploymentSpec, s conversion.Scope) error {
 	out.Replicas = in.Replicas
-	out.Selector = (*meta_v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := Convert_v1alpha1_MachineTemplateSpec_To_machine_MachineTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -2005,7 +2005,7 @@ func Convert_v1alpha1_MachineDeploymentSpec_To_machine_MachineDeploymentSpec(in 
 
 func autoConvert_machine_MachineDeploymentSpec_To_v1alpha1_MachineDeploymentSpec(in *machine.MachineDeploymentSpec, out *MachineDeploymentSpec, s conversion.Scope) error {
 	out.Replicas = in.Replicas
-	out.Selector = (*meta_v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := Convert_machine_MachineTemplateSpec_To_v1alpha1_MachineTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
@@ -2189,7 +2189,7 @@ func Convert_machine_MachineSetList_To_v1alpha1_MachineSetList(in *machine.Machi
 
 func autoConvert_v1alpha1_MachineSetSpec_To_machine_MachineSetSpec(in *MachineSetSpec, out *machine.MachineSetSpec, s conversion.Scope) error {
 	out.Replicas = in.Replicas
-	out.Selector = (*meta_v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := Convert_v1alpha1_ClassSpec_To_machine_ClassSpec(&in.MachineClass, &out.MachineClass, s); err != nil {
 		return err
 	}
@@ -2207,7 +2207,7 @@ func Convert_v1alpha1_MachineSetSpec_To_machine_MachineSetSpec(in *MachineSetSpe
 
 func autoConvert_machine_MachineSetSpec_To_v1alpha1_MachineSetSpec(in *machine.MachineSetSpec, out *MachineSetSpec, s conversion.Scope) error {
 	out.Replicas = in.Replicas
-	out.Selector = (*meta_v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	if err := Convert_machine_ClassSpec_To_v1alpha1_ClassSpec(&in.MachineClass, &out.MachineClass, s); err != nil {
 		return err
 	}
@@ -2719,7 +2719,7 @@ func Convert_machine_ScaleSpec_To_v1alpha1_ScaleSpec(in *machine.ScaleSpec, out 
 
 func autoConvert_v1alpha1_ScaleStatus_To_machine_ScaleStatus(in *ScaleStatus, out *machine.ScaleStatus, s conversion.Scope) error {
 	out.Replicas = in.Replicas
-	out.Selector = (*meta_v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.TargetSelector = in.TargetSelector
 	return nil
 }
@@ -2731,7 +2731,7 @@ func Convert_v1alpha1_ScaleStatus_To_machine_ScaleStatus(in *ScaleStatus, out *m
 
 func autoConvert_machine_ScaleStatus_To_v1alpha1_ScaleStatus(in *machine.ScaleStatus, out *ScaleStatus, s conversion.Scope) error {
 	out.Replicas = in.Replicas
-	out.Selector = (*meta_v1.LabelSelector)(unsafe.Pointer(in.Selector))
+	out.Selector = (*metav1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.TargetSelector = in.TargetSelector
 	return nil
 }

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package v1alpha1
 
 import (
 	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -161,12 +161,8 @@ func (in *AWSMachineClassSpec) DeepCopyInto(out *AWSMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -267,30 +263,18 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	*out = *in
 	if in.SystemDisk != nil {
 		in, out := &in.SystemDisk, &out.SystemDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AlicloudSystemDisk)
-			**out = **in
-		}
+		*out = new(AlicloudSystemDisk)
+		**out = **in
 	}
 	if in.InternetMaxBandwidthIn != nil {
 		in, out := &in.InternetMaxBandwidthIn, &out.InternetMaxBandwidthIn
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int)
-			**out = **in
-		}
+		*out = new(int)
+		**out = **in
 	}
 	if in.InternetMaxBandwidthOut != nil {
 		in, out := &in.InternetMaxBandwidthOut, &out.InternetMaxBandwidthOut
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int)
-			**out = **in
-		}
+		*out = new(int)
+		**out = **in
 	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
@@ -301,12 +285,8 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -460,12 +440,8 @@ func (in *AzureMachineClassSpec) DeepCopyInto(out *AzureMachineClassSpec) {
 	out.SubnetInfo = in.SubnetInfo
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -501,12 +477,8 @@ func (in *AzureNetworkInterfaceReference) DeepCopyInto(out *AzureNetworkInterfac
 	*out = *in
 	if in.AzureNetworkInterfaceReferenceProperties != nil {
 		in, out := &in.AzureNetworkInterfaceReferenceProperties, &out.AzureNetworkInterfaceReferenceProperties
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureNetworkInterfaceReferenceProperties)
-			**out = **in
-		}
+		*out = new(AzureNetworkInterfaceReferenceProperties)
+		**out = **in
 	}
 	return
 }
@@ -813,22 +785,17 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 	*out = *in
 	if in.Description != nil {
 		in, out := &in.Description, &out.Description
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.Disks != nil {
 		in, out := &in.Disks, &out.Disks
 		*out = make([]*GCPDisk, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(GCPDisk)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(GCPDisk)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -843,11 +810,10 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 		in, out := &in.Metadata, &out.Metadata
 		*out = make([]*GCPMetadata, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(GCPMetadata)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(GCPMetadata)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -855,23 +821,18 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
 		*out = make([]*GCPNetworkInterface, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(GCPNetworkInterface)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(GCPNetworkInterface)
+				**out = **in
 			}
 		}
 	}
 	out.Scheduling = in.Scheduling
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	if in.ServiceAccounts != nil {
 		in, out := &in.ServiceAccounts, &out.ServiceAccounts
@@ -903,12 +864,8 @@ func (in *GCPMetadata) DeepCopyInto(out *GCPMetadata) {
 	*out = *in
 	if in.Value != nil {
 		in, out := &in.Value, &out.Value
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -1138,41 +1095,25 @@ func (in *MachineDeploymentSpec) DeepCopyInto(out *MachineDeploymentSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.Strategy.DeepCopyInto(&out.Strategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.RollbackTo != nil {
 		in, out := &in.RollbackTo, &out.RollbackTo
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollbackConfig)
-			**out = **in
-		}
+		*out = new(RollbackConfig)
+		**out = **in
 	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1199,22 +1140,17 @@ func (in *MachineDeploymentStatus) DeepCopyInto(out *MachineDeploymentStatus) {
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.FailedMachines != nil {
 		in, out := &in.FailedMachines, &out.FailedMachines
 		*out = make([]*MachineSummary, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(MachineSummary)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(MachineSummary)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -1236,12 +1172,8 @@ func (in *MachineDeploymentStrategy) DeepCopyInto(out *MachineDeploymentStrategy
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateMachineDeployment)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateMachineDeployment)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1372,12 +1304,8 @@ func (in *MachineSetSpec) DeepCopyInto(out *MachineSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	out.MachineClass = in.MachineClass
 	in.Template.DeepCopyInto(&out.Template)
@@ -1407,16 +1335,12 @@ func (in *MachineSetStatus) DeepCopyInto(out *MachineSetStatus) {
 	in.LastOperation.DeepCopyInto(&out.LastOperation)
 	if in.FailedMachines != nil {
 		in, out := &in.FailedMachines, &out.FailedMachines
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]MachineSummary)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]MachineSummary, len(*in))
-				for i := range *in {
-					(*in)[i].DeepCopyInto(&(*out)[i])
-				}
+		*out = new([]MachineSummary)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]MachineSummary, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
 			}
 		}
 	}
@@ -1666,12 +1590,8 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -1766,12 +1686,8 @@ func (in *PacketMachineClassSpec) DeepCopyInto(out *PacketMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -1807,21 +1723,13 @@ func (in *RollingUpdateMachineDeployment) DeepCopyInto(out *RollingUpdateMachine
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -1885,12 +1793,8 @@ func (in *ScaleStatus) DeepCopyInto(out *ScaleStatus) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ package machine
 
 import (
 	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -161,12 +161,8 @@ func (in *AWSMachineClassSpec) DeepCopyInto(out *AWSMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -267,30 +263,18 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	*out = *in
 	if in.SystemDisk != nil {
 		in, out := &in.SystemDisk, &out.SystemDisk
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AlicloudSystemDisk)
-			**out = **in
-		}
+		*out = new(AlicloudSystemDisk)
+		**out = **in
 	}
 	if in.InternetMaxBandwidthIn != nil {
 		in, out := &in.InternetMaxBandwidthIn, &out.InternetMaxBandwidthIn
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int)
-			**out = **in
-		}
+		*out = new(int)
+		**out = **in
 	}
 	if in.InternetMaxBandwidthOut != nil {
 		in, out := &in.InternetMaxBandwidthOut, &out.InternetMaxBandwidthOut
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int)
-			**out = **in
-		}
+		*out = new(int)
+		**out = **in
 	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
@@ -301,12 +285,8 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -460,12 +440,8 @@ func (in *AzureMachineClassSpec) DeepCopyInto(out *AzureMachineClassSpec) {
 	out.SubnetInfo = in.SubnetInfo
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -501,12 +477,8 @@ func (in *AzureNetworkInterfaceReference) DeepCopyInto(out *AzureNetworkInterfac
 	*out = *in
 	if in.AzureNetworkInterfaceReferenceProperties != nil {
 		in, out := &in.AzureNetworkInterfaceReferenceProperties, &out.AzureNetworkInterfaceReferenceProperties
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(AzureNetworkInterfaceReferenceProperties)
-			**out = **in
-		}
+		*out = new(AzureNetworkInterfaceReferenceProperties)
+		**out = **in
 	}
 	return
 }
@@ -813,22 +785,17 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 	*out = *in
 	if in.Description != nil {
 		in, out := &in.Description, &out.Description
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	if in.Disks != nil {
 		in, out := &in.Disks, &out.Disks
 		*out = make([]*GCPDisk, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(GCPDisk)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(GCPDisk)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -843,11 +810,10 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 		in, out := &in.Metadata, &out.Metadata
 		*out = make([]*GCPMetadata, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(GCPMetadata)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(GCPMetadata)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -855,23 +821,18 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 		in, out := &in.NetworkInterfaces, &out.NetworkInterfaces
 		*out = make([]*GCPNetworkInterface, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(GCPNetworkInterface)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(GCPNetworkInterface)
+				**out = **in
 			}
 		}
 	}
 	out.Scheduling = in.Scheduling
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	if in.ServiceAccounts != nil {
 		in, out := &in.ServiceAccounts, &out.ServiceAccounts
@@ -903,12 +864,8 @@ func (in *GCPMetadata) DeepCopyInto(out *GCPMetadata) {
 	*out = *in
 	if in.Value != nil {
 		in, out := &in.Value, &out.Value
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(string)
-			**out = **in
-		}
+		*out = new(string)
+		**out = **in
 	}
 	return
 }
@@ -1138,41 +1095,25 @@ func (in *MachineDeploymentSpec) DeepCopyInto(out *MachineDeploymentSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	in.Template.DeepCopyInto(&out.Template)
 	in.Strategy.DeepCopyInto(&out.Strategy)
 	if in.RevisionHistoryLimit != nil {
 		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.RollbackTo != nil {
 		in, out := &in.RollbackTo, &out.RollbackTo
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollbackConfig)
-			**out = **in
-		}
+		*out = new(RollbackConfig)
+		**out = **in
 	}
 	if in.ProgressDeadlineSeconds != nil {
 		in, out := &in.ProgressDeadlineSeconds, &out.ProgressDeadlineSeconds
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	return
 }
@@ -1199,22 +1140,17 @@ func (in *MachineDeploymentStatus) DeepCopyInto(out *MachineDeploymentStatus) {
 	}
 	if in.CollisionCount != nil {
 		in, out := &in.CollisionCount, &out.CollisionCount
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(int32)
-			**out = **in
-		}
+		*out = new(int32)
+		**out = **in
 	}
 	if in.FailedMachines != nil {
 		in, out := &in.FailedMachines, &out.FailedMachines
 		*out = make([]*MachineSummary, len(*in))
 		for i := range *in {
-			if (*in)[i] == nil {
-				(*out)[i] = nil
-			} else {
-				(*out)[i] = new(MachineSummary)
-				(*in)[i].DeepCopyInto((*out)[i])
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(MachineSummary)
+				(*in).DeepCopyInto(*out)
 			}
 		}
 	}
@@ -1236,12 +1172,8 @@ func (in *MachineDeploymentStrategy) DeepCopyInto(out *MachineDeploymentStrategy
 	*out = *in
 	if in.RollingUpdate != nil {
 		in, out := &in.RollingUpdate, &out.RollingUpdate
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(RollingUpdateMachineDeployment)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(RollingUpdateMachineDeployment)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }
@@ -1372,12 +1304,8 @@ func (in *MachineSetSpec) DeepCopyInto(out *MachineSetSpec) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	out.MachineClass = in.MachineClass
 	in.Template.DeepCopyInto(&out.Template)
@@ -1407,16 +1335,12 @@ func (in *MachineSetStatus) DeepCopyInto(out *MachineSetStatus) {
 	in.LastOperation.DeepCopyInto(&out.LastOperation)
 	if in.FailedMachines != nil {
 		in, out := &in.FailedMachines, &out.FailedMachines
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new([]MachineSummary)
-			if **in != nil {
-				in, out := *in, *out
-				*out = make([]MachineSummary, len(*in))
-				for i := range *in {
-					(*in)[i].DeepCopyInto(&(*out)[i])
-				}
+		*out = new([]MachineSummary)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]MachineSummary, len(*in))
+			for i := range *in {
+				(*in)[i].DeepCopyInto(&(*out)[i])
 			}
 		}
 	}
@@ -1666,12 +1590,8 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -1766,12 +1686,8 @@ func (in *PacketMachineClassSpec) DeepCopyInto(out *PacketMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(v1.SecretReference)
-			**out = **in
-		}
+		*out = new(v1.SecretReference)
+		**out = **in
 	}
 	return
 }
@@ -1807,21 +1723,13 @@ func (in *RollingUpdateMachineDeployment) DeepCopyInto(out *RollingUpdateMachine
 	*out = *in
 	if in.MaxUnavailable != nil {
 		in, out := &in.MaxUnavailable, &out.MaxUnavailable
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	if in.MaxSurge != nil {
 		in, out := &in.MaxSurge, &out.MaxSurge
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(intstr.IntOrString)
-			**out = **in
-		}
+		*out = new(intstr.IntOrString)
+		**out = **in
 	}
 	return
 }
@@ -1885,12 +1793,8 @@ func (in *ScaleStatus) DeepCopyInto(out *ScaleStatus) {
 	*out = *in
 	if in.Selector != nil {
 		in, out := &in.Selector, &out.Selector
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(meta_v1.LabelSelector)
-			(*in).DeepCopyInto(*out)
-		}
+		*out = new(metav1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	return
 }

--- a/pkg/client/clientset/internalversion/fake/register.go
+++ b/pkg/client/clientset/internalversion/fake/register.go
@@ -8,7 +8,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	util_runtime "k8s.io/apimachinery/pkg/util/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var scheme = runtime.NewScheme()
@@ -36,5 +36,5 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
-	util_runtime.Must(AddToScheme(scheme))
+	utilruntime.Must(AddToScheme(scheme))
 }

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -8,7 +8,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	util_runtime "k8s.io/apimachinery/pkg/util/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var scheme = runtime.NewScheme()
@@ -36,5 +36,5 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
-	util_runtime.Must(AddToScheme(scheme))
+	utilruntime.Must(AddToScheme(scheme))
 }

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -8,7 +8,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	util_runtime "k8s.io/apimachinery/pkg/util/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 var Scheme = runtime.NewScheme()
@@ -36,5 +36,5 @@ var AddToScheme = localSchemeBuilder.AddToScheme
 
 func init() {
 	v1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
-	util_runtime.Must(AddToScheme(Scheme))
+	utilruntime.Must(AddToScheme(Scheme))
 }

--- a/pkg/client/informers/externalversions/machine/v1alpha1/alicloudmachineclass.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/alicloudmachineclass.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredAlicloudMachineClassInformer(client versioned.Interface, namespa
 				return client.MachineV1alpha1().AlicloudMachineClasses(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.AlicloudMachineClass{},
+		&machinev1alpha1.AlicloudMachineClass{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *alicloudMachineClassInformer) defaultInformer(client versioned.Interfac
 }
 
 func (f *alicloudMachineClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.AlicloudMachineClass{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.AlicloudMachineClass{}, f.defaultInformer)
 }
 
 func (f *alicloudMachineClassInformer) Lister() v1alpha1.AlicloudMachineClassLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/awsmachineclass.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/awsmachineclass.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredAWSMachineClassInformer(client versioned.Interface, namespace st
 				return client.MachineV1alpha1().AWSMachineClasses(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.AWSMachineClass{},
+		&machinev1alpha1.AWSMachineClass{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *aWSMachineClassInformer) defaultInformer(client versioned.Interface, re
 }
 
 func (f *aWSMachineClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.AWSMachineClass{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.AWSMachineClass{}, f.defaultInformer)
 }
 
 func (f *aWSMachineClassInformer) Lister() v1alpha1.AWSMachineClassLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/azuremachineclass.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/azuremachineclass.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredAzureMachineClassInformer(client versioned.Interface, namespace 
 				return client.MachineV1alpha1().AzureMachineClasses(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.AzureMachineClass{},
+		&machinev1alpha1.AzureMachineClass{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *azureMachineClassInformer) defaultInformer(client versioned.Interface, 
 }
 
 func (f *azureMachineClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.AzureMachineClass{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.AzureMachineClass{}, f.defaultInformer)
 }
 
 func (f *azureMachineClassInformer) Lister() v1alpha1.AzureMachineClassLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/gcpmachineclass.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/gcpmachineclass.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredGCPMachineClassInformer(client versioned.Interface, namespace st
 				return client.MachineV1alpha1().GCPMachineClasses(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.GCPMachineClass{},
+		&machinev1alpha1.GCPMachineClass{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *gCPMachineClassInformer) defaultInformer(client versioned.Interface, re
 }
 
 func (f *gCPMachineClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.GCPMachineClass{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.GCPMachineClass{}, f.defaultInformer)
 }
 
 func (f *gCPMachineClassInformer) Lister() v1alpha1.GCPMachineClassLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/machine.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/machine.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredMachineInformer(client versioned.Interface, namespace string, re
 				return client.MachineV1alpha1().Machines(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.Machine{},
+		&machinev1alpha1.Machine{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *machineInformer) defaultInformer(client versioned.Interface, resyncPeri
 }
 
 func (f *machineInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.Machine{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.Machine{}, f.defaultInformer)
 }
 
 func (f *machineInformer) Lister() v1alpha1.MachineLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/machinedeployment.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/machinedeployment.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredMachineDeploymentInformer(client versioned.Interface, namespace 
 				return client.MachineV1alpha1().MachineDeployments(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.MachineDeployment{},
+		&machinev1alpha1.MachineDeployment{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *machineDeploymentInformer) defaultInformer(client versioned.Interface, 
 }
 
 func (f *machineDeploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.MachineDeployment{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.MachineDeployment{}, f.defaultInformer)
 }
 
 func (f *machineDeploymentInformer) Lister() v1alpha1.MachineDeploymentLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/machineset.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/machineset.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredMachineSetInformer(client versioned.Interface, namespace string,
 				return client.MachineV1alpha1().MachineSets(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.MachineSet{},
+		&machinev1alpha1.MachineSet{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *machineSetInformer) defaultInformer(client versioned.Interface, resyncP
 }
 
 func (f *machineSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.MachineSet{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.MachineSet{}, f.defaultInformer)
 }
 
 func (f *machineSetInformer) Lister() v1alpha1.MachineSetLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/machinetemplate.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/machinetemplate.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredMachineTemplateInformer(client versioned.Interface, namespace st
 				return client.MachineV1alpha1().MachineTemplates(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.MachineTemplate{},
+		&machinev1alpha1.MachineTemplate{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *machineTemplateInformer) defaultInformer(client versioned.Interface, re
 }
 
 func (f *machineTemplateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.MachineTemplate{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.MachineTemplate{}, f.defaultInformer)
 }
 
 func (f *machineTemplateInformer) Lister() v1alpha1.MachineTemplateLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/openstackmachineclass.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/openstackmachineclass.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredOpenStackMachineClassInformer(client versioned.Interface, namesp
 				return client.MachineV1alpha1().OpenStackMachineClasses(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.OpenStackMachineClass{},
+		&machinev1alpha1.OpenStackMachineClass{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *openStackMachineClassInformer) defaultInformer(client versioned.Interfa
 }
 
 func (f *openStackMachineClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.OpenStackMachineClass{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.OpenStackMachineClass{}, f.defaultInformer)
 }
 
 func (f *openStackMachineClassInformer) Lister() v1alpha1.OpenStackMachineClassLister {

--- a/pkg/client/informers/externalversions/machine/v1alpha1/packetmachineclass.go
+++ b/pkg/client/informers/externalversions/machine/v1alpha1/packetmachineclass.go
@@ -5,7 +5,7 @@ package v1alpha1
 import (
 	time "time"
 
-	machine_v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	versioned "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1"
@@ -54,7 +54,7 @@ func NewFilteredPacketMachineClassInformer(client versioned.Interface, namespace
 				return client.MachineV1alpha1().PacketMachineClasses(namespace).Watch(options)
 			},
 		},
-		&machine_v1alpha1.PacketMachineClass{},
+		&machinev1alpha1.PacketMachineClass{},
 		resyncPeriod,
 		indexers,
 	)
@@ -65,7 +65,7 @@ func (f *packetMachineClassInformer) defaultInformer(client versioned.Interface,
 }
 
 func (f *packetMachineClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&machine_v1alpha1.PacketMachineClass{}, f.defaultInformer)
+	return f.factory.InformerFor(&machinev1alpha1.PacketMachineClass{}, f.defaultInformer)
 }
 
 func (f *packetMachineClassInformer) Lister() v1alpha1.PacketMachineClassLister {

--- a/pkg/client/informers/internalversion/machine/internalversion/alicloudmachineclass.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/alicloudmachineclass.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type alicloudMachineClassInformer struct {
 // NewAlicloudMachineClassInformer constructs a new informer for AlicloudMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewAlicloudMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewAlicloudMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredAlicloudMachineClassInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredAlicloudMachineClassInformer constructs a new informer for AlicloudMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredAlicloudMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredAlicloudMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredAlicloudMachineClassInformer(client clientset_internalversion.In
 	)
 }
 
-func (f *alicloudMachineClassInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *alicloudMachineClassInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredAlicloudMachineClassInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/awsmachineclass.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/awsmachineclass.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type aWSMachineClassInformer struct {
 // NewAWSMachineClassInformer constructs a new informer for AWSMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewAWSMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewAWSMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredAWSMachineClassInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredAWSMachineClassInformer constructs a new informer for AWSMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredAWSMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredAWSMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredAWSMachineClassInformer(client clientset_internalversion.Interfa
 	)
 }
 
-func (f *aWSMachineClassInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *aWSMachineClassInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredAWSMachineClassInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/azuremachineclass.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/azuremachineclass.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type azureMachineClassInformer struct {
 // NewAzureMachineClassInformer constructs a new informer for AzureMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewAzureMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewAzureMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredAzureMachineClassInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredAzureMachineClassInformer constructs a new informer for AzureMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredAzureMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredAzureMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredAzureMachineClassInformer(client clientset_internalversion.Inter
 	)
 }
 
-func (f *azureMachineClassInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *azureMachineClassInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredAzureMachineClassInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/gcpmachineclass.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/gcpmachineclass.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type gCPMachineClassInformer struct {
 // NewGCPMachineClassInformer constructs a new informer for GCPMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewGCPMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewGCPMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredGCPMachineClassInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredGCPMachineClassInformer constructs a new informer for GCPMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredGCPMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredGCPMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredGCPMachineClassInformer(client clientset_internalversion.Interfa
 	)
 }
 
-func (f *gCPMachineClassInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *gCPMachineClassInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredGCPMachineClassInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/machine.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/machine.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type machineInformer struct {
 // NewMachineInformer constructs a new informer for Machine type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewMachineInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewMachineInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredMachineInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredMachineInformer constructs a new informer for Machine type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredMachineInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredMachineInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredMachineInformer(client clientset_internalversion.Interface, name
 	)
 }
 
-func (f *machineInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *machineInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredMachineInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/machinedeployment.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/machinedeployment.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type machineDeploymentInformer struct {
 // NewMachineDeploymentInformer constructs a new informer for MachineDeployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewMachineDeploymentInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewMachineDeploymentInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredMachineDeploymentInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredMachineDeploymentInformer constructs a new informer for MachineDeployment type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredMachineDeploymentInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredMachineDeploymentInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredMachineDeploymentInformer(client clientset_internalversion.Inter
 	)
 }
 
-func (f *machineDeploymentInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *machineDeploymentInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredMachineDeploymentInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/machineset.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/machineset.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type machineSetInformer struct {
 // NewMachineSetInformer constructs a new informer for MachineSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewMachineSetInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewMachineSetInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredMachineSetInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredMachineSetInformer constructs a new informer for MachineSet type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredMachineSetInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredMachineSetInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredMachineSetInformer(client clientset_internalversion.Interface, n
 	)
 }
 
-func (f *machineSetInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *machineSetInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredMachineSetInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/machinetemplate.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/machinetemplate.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type machineTemplateInformer struct {
 // NewMachineTemplateInformer constructs a new informer for MachineTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewMachineTemplateInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewMachineTemplateInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredMachineTemplateInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredMachineTemplateInformer constructs a new informer for MachineTemplate type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredMachineTemplateInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredMachineTemplateInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredMachineTemplateInformer(client clientset_internalversion.Interfa
 	)
 }
 
-func (f *machineTemplateInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *machineTemplateInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredMachineTemplateInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/openstackmachineclass.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/openstackmachineclass.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type openStackMachineClassInformer struct {
 // NewOpenStackMachineClassInformer constructs a new informer for OpenStackMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewOpenStackMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewOpenStackMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredOpenStackMachineClassInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredOpenStackMachineClassInformer constructs a new informer for OpenStackMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredOpenStackMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredOpenStackMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredOpenStackMachineClassInformer(client clientset_internalversion.I
 	)
 }
 
-func (f *openStackMachineClassInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *openStackMachineClassInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredOpenStackMachineClassInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 

--- a/pkg/client/informers/internalversion/machine/internalversion/packetmachineclass.go
+++ b/pkg/client/informers/internalversion/machine/internalversion/packetmachineclass.go
@@ -6,7 +6,7 @@ import (
 	time "time"
 
 	machine "github.com/gardener/machine-controller-manager/pkg/apis/machine"
-	clientset_internalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
+	clientsetinternalversion "github.com/gardener/machine-controller-manager/pkg/client/clientset/internalversion"
 	internalinterfaces "github.com/gardener/machine-controller-manager/pkg/client/informers/internalversion/internalinterfaces"
 	internalversion "github.com/gardener/machine-controller-manager/pkg/client/listers/machine/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,14 +31,14 @@ type packetMachineClassInformer struct {
 // NewPacketMachineClassInformer constructs a new informer for PacketMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewPacketMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+func NewPacketMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
 	return NewFilteredPacketMachineClassInformer(client, namespace, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredPacketMachineClassInformer constructs a new informer for PacketMachineClass type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredPacketMachineClassInformer(client clientset_internalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredPacketMachineClassInformer(client clientsetinternalversion.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
@@ -60,7 +60,7 @@ func NewFilteredPacketMachineClassInformer(client clientset_internalversion.Inte
 	)
 }
 
-func (f *packetMachineClassInformer) defaultInformer(client clientset_internalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func (f *packetMachineClassInformer) defaultInformer(client clientsetinternalversion.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
 	return NewFilteredPacketMachineClassInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Not sure if this is intended, but `hack/generate-code` on `master` regenerates all the types for me. Is this just my setup?

Environment:
```
go version go1.12.7 darwin/amd64
```

**Release note**:
```improvement operator
NONE
```
