### PR TITLE
Removed optional annotation in internal types

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -65,23 +65,18 @@ type MachineList struct {
 type MachineSpec struct {
 
 	// Class contains the machineclass attributes of a machine
-	// +optional
 	Class ClassSpec
 
 	// ProviderID represents the provider's unique ID given to a machine
-	// +optional
 	ProviderID string
 
-	// +optional
 	NodeTemplateSpec NodeTemplateSpec
 }
 
 // NodeTemplateSpec describes the data a node should have when created from a template
 type NodeTemplateSpec struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	Spec corev1.NodeSpec
 }
 
@@ -89,12 +84,10 @@ type NodeTemplateSpec struct {
 type MachineTemplateSpec struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-	// +optional
 	metav1.ObjectMeta
 
 	// Specification of the desired behavior of the machine.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
-	// +optional
 	Spec MachineSpec
 }
 
@@ -107,12 +100,10 @@ type MachineTemplate struct {
 
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-	// +optional
 	metav1.ObjectMeta
 
 	// Template defines the machines that will be created from this machine template.
 	// https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
-	// +optional
 	Template MachineTemplateSpec
 }
 
@@ -124,7 +115,6 @@ type MachineTemplateList struct {
 
 	// Standard list metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
-	// +optional
 	metav1.ListMeta
 
 	// List of machine templates
@@ -263,16 +253,12 @@ const (
 
 // MachineSet TODO
 type MachineSet struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	Spec MachineSetSpec
 
-	// +optional
 	Status MachineSetStatus
 }
 
@@ -280,31 +266,23 @@ type MachineSet struct {
 
 // MachineSetList is a collection of MachineSet.
 type MachineSetList struct {
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	metav1.ListMeta
 
-	// +optional
 	Items []MachineSet
 }
 
 // MachineSetSpec is the specification of a cluster.
 type MachineSetSpec struct {
-	// +optional
 	Replicas int32
 
-	// +optional
 	Selector *metav1.LabelSelector
 
-	// +optional
 	MachineClass ClassSpec
 
-	// +optional
 	Template MachineTemplateSpec
 
-	// +optional
 	MinReadySeconds int32
 }
 
@@ -330,15 +308,12 @@ type MachineSetCondition struct {
 	Status ConditionStatus
 
 	// The last time the condition transitioned from one status to another.
-	// +optional
 	LastTransitionTime metav1.Time
 
 	// The reason for the condition's last transition.
-	// +optional
 	Reason string
 
 	// A human readable message indicating details about the transition.
-	// +optional
 	Message string
 }
 
@@ -348,30 +323,24 @@ type MachineSetStatus struct {
 	Replicas int32
 
 	// The number of pods that have labels matching the labels of the pod template of the replicaset.
-	// +optional
 	FullyLabeledReplicas int32
 
 	// The number of ready replicas for this replica set.
-	// +optional
 	ReadyReplicas int32
 
 	// The number of available replicas (ready for at least minReadySeconds) for this replica set.
-	// +optional
 	AvailableReplicas int32
 
 	// ObservedGeneration is the most recent generation observed by the controller.
-	// +optional
 	ObservedGeneration int64
 
 	// Represents the latest available observations of a replica set's current state.
-	// +optional
 	Conditions []MachineSetCondition
 
 	// LastOperation performed
 	LastOperation LastOperation
 
 	// FailedMachines has summary of machines on which lastOperation Failed
-	// +optional
 	FailedMachines *[]MachineSummary
 }
 
@@ -401,15 +370,12 @@ type MachineSummary struct {
 type MachineDeployment struct {
 	metav1.TypeMeta
 	// Standard object metadata.
-	// +optional
 	metav1.ObjectMeta
 
 	// Specification of the desired behavior of the MachineDeployment.
-	// +optional
 	Spec MachineDeploymentSpec
 
 	// Most recently observed status of the MachineDeployment.
-	// +optional
 	Status MachineDeploymentStatus
 }
 
@@ -417,41 +383,34 @@ type MachineDeployment struct {
 type MachineDeploymentSpec struct {
 	// Number of desired machines. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
-	// +optional
 	Replicas int32
 
 	// Label selector for machines. Existing MachineSets whose machines are
 	// selected by this will be the ones affected by this MachineDeployment.
-	// +optional
 	Selector *metav1.LabelSelector
 
 	// Template describes the machines that will be created.
 	Template MachineTemplateSpec
 
 	// The MachineDeployment strategy to use to replace existing machines with new ones.
-	// +optional
 	// +patchStrategy=retainKeys
 	Strategy MachineDeploymentStrategy
 
 	// Minimum number of seconds for which a newly created machine should be ready
 	// without any of its container crashing, for it to be considered available.
 	// Defaults to 0 (machine will be considered available as soon as it is ready)
-	// +optional
 	MinReadySeconds int32
 
 	// The number of old MachineSets to retain to allow rollback.
 	// This is a pointer to distinguish between explicit zero and not specified.
-	// +optional
 	RevisionHistoryLimit *int32
 
 	// Indicates that the MachineDeployment is paused and will not be processed by the
 	// MachineDeployment controller.
-	// +optional
 	Paused bool
 
 	// DEPRECATED.
 	// The config this MachineDeployment is rolling back to. Will be cleared after rollback is done.
-	// +optional
 	RollbackTo *RollbackConfig
 
 	// The maximum time in seconds for a MachineDeployment to make progress before it
@@ -460,7 +419,6 @@ type MachineDeploymentSpec struct {
 	// reason will be surfaced in the MachineDeployment status. Note that progress will
 	// not be estimated during the time a MachineDeployment is paused. This is not set
 	// by default.
-	// +optional
 	ProgressDeadlineSeconds *int32
 }
 
@@ -475,7 +433,6 @@ type MachineDeploymentRollback struct {
 	Name string
 
 	// The annotations to be updated to a MachineDeployment
-	// +optional
 	UpdatedAnnotations map[string]string
 
 	// The config of this MachineDeployment rollback.
@@ -484,7 +441,6 @@ type MachineDeploymentRollback struct {
 
 type RollbackConfig struct {
 	// The revision to rollback to. If set to 0, rollback to the last revision.
-	// +optional
 	Revision int64
 }
 
@@ -498,7 +454,6 @@ const (
 // MachineDeploymentStrategy describes how to replace existing machines with new ones.
 type MachineDeploymentStrategy struct {
 	// Type of MachineDeployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
-	// +optional
 	Type MachineDeploymentStrategyType
 
 	// Rolling update config params. Present only if MachineDeploymentStrategyType =
@@ -506,7 +461,6 @@ type MachineDeploymentStrategy struct {
 	//---
 	// TODO: Update this to follow our convention for oneOf, whatever we decide it
 	// to be.
-	// +optional
 	RollingUpdate *RollingUpdateMachineDeployment
 }
 
@@ -532,7 +486,6 @@ type RollingUpdateMachineDeployment struct {
 	// can be scaled down further, followed by scaling up the new MC, ensuring
 	// that the total number of machines available at all times during the update is at
 	// least 70% of desired machines.
-	// +optional
 	MaxUnavailable *intstr.IntOrString
 
 	// The maximum number of machines that can be scheduled above the desired number of
@@ -546,36 +499,29 @@ type RollingUpdateMachineDeployment struct {
 	// 130% of desired machines. Once old machines have been killed,
 	// new MC can be scaled up further, ensuring that total number of machines running
 	// at any time during the update is atmost 130% of desired machines.
-	// +optional
 	MaxSurge *intstr.IntOrString
 }
 
 // MachineDeploymentStatus is the most recently observed status of the MachineDeployment.
 type MachineDeploymentStatus struct {
 	// The generation observed by the MachineDeployment controller.
-	// +optional
 	ObservedGeneration int64
 
 	// Total number of non-terminated machines targeted by this MachineDeployment (their labels match the selector).
-	// +optional
 	Replicas int32
 
 	// Total number of non-terminated machines targeted by this MachineDeployment that have the desired template spec.
-	// +optional
 	UpdatedReplicas int32
 
 	// Total number of ready machines targeted by this MachineDeployment.
-	// +optional
 	ReadyReplicas int32
 
 	// Total number of available machines (ready for at least minReadySeconds) targeted by this MachineDeployment.
-	// +optional
 	AvailableReplicas int32
 
 	// Total number of unavailable machines targeted by this MachineDeployment. This is the total number of
 	// machines that are still required for the MachineDeployment to have 100% available capacity. They may
 	// either be machines that are running but not yet available or machines that still have not been created.
-	// +optional
 	UnavailableReplicas int32
 
 	// Represents the latest available observations of a MachineDeployment's current state.
@@ -586,11 +532,9 @@ type MachineDeploymentStatus struct {
 	// Count of hash collisions for the MachineDeployment. The MachineDeployment controller uses this
 	// field as a collision avoidance mechanism when it needs to create the name for the
 	// newest MachineSet.
-	// +optional
 	CollisionCount *int32
 
 	// FailedMachines has summary of machines on which lastOperation Failed
-	// +optional
 	FailedMachines []*MachineSummary
 }
 
@@ -644,7 +588,6 @@ type MachineDeploymentCondition struct {
 type MachineDeploymentList struct {
 	metav1.TypeMeta
 	// Standard list metadata.
-	// +optional
 	metav1.ListMeta
 
 	// Items is the list of MachineDeployments.
@@ -654,7 +597,6 @@ type MachineDeploymentList struct {
 // describes the attributes of a scale subresource
 type ScaleSpec struct {
 	// desired number of machines for the scaled object.
-	// +optional
 	Replicas int32
 }
 
@@ -664,7 +606,6 @@ type ScaleStatus struct {
 	Replicas int32
 
 	// label query over machines that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
-	// +optional
 	Selector *metav1.LabelSelector
 
 	// label selector for machines that should match the replicas count. This is a serializated
@@ -673,7 +614,6 @@ type ScaleStatus struct {
 	// query-param syntax. If the target type only supports map-based selectors, both this
 	// field and map-based selector field are populated.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
-	// +optional
 	TargetSelector string
 }
 
@@ -685,15 +625,12 @@ type ScaleStatus struct {
 type Scale struct {
 	metav1.TypeMeta
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
-	// +optional
 	metav1.ObjectMeta
 
 	// defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.
-	// +optional
 	Spec ScaleSpec
 
 	// current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.
-	// +optional
 	Status ScaleStatus
 }
 
@@ -704,13 +641,10 @@ type Scale struct {
 
 // OpenStackMachineClass TODO
 type OpenStackMachineClass struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	Spec OpenStackMachineClassSpec
 }
 
@@ -718,13 +652,10 @@ type OpenStackMachineClass struct {
 
 // OpenStackMachineClassList is a collection of OpenStackMachineClasses.
 type OpenStackMachineClassList struct {
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	metav1.ListMeta
 
-	// +optional
 	Items []OpenStackMachineClass
 }
 
@@ -749,13 +680,10 @@ type OpenStackMachineClassSpec struct {
 
 // AWSMachineClass TODO
 type AWSMachineClass struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	Spec AWSMachineClassSpec
 }
 
@@ -763,13 +691,10 @@ type AWSMachineClass struct {
 
 // AWSMachineClassList is a collection of AWSMachineClasses.
 type AWSMachineClassList struct {
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	metav1.ListMeta
 
-	// +optional
 	Items []AWSMachineClass
 }
 
@@ -905,13 +830,10 @@ type AWSNetworkInterfaceSpec struct {
 
 // AzureMachineClass TODO
 type AzureMachineClass struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	Spec AzureMachineClassSpec
 }
 
@@ -919,13 +841,10 @@ type AzureMachineClass struct {
 
 // AzureMachineClassList is a collection of AzureMachineClasses.
 type AzureMachineClassList struct {
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	metav1.ListMeta
 
-	// +optional
 	Items []AzureMachineClass
 }
 
@@ -1053,13 +972,10 @@ type AzureSubnetInfo struct {
 
 // GCPMachineClass TODO
 type GCPMachineClass struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	Spec GCPMachineClassSpec
 }
 
@@ -1067,13 +983,10 @@ type GCPMachineClass struct {
 
 // GCPMachineClassList is a collection of GCPMachineClasses.
 type GCPMachineClassList struct {
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	metav1.ListMeta
 
-	// +optional
 	Items []GCPMachineClass
 }
 
@@ -1137,13 +1050,10 @@ type GCPServiceAccount struct {
 
 // AlicloudMachineClass
 type AlicloudMachineClass struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	Spec AlicloudMachineClassSpec
 }
 
@@ -1151,13 +1061,10 @@ type AlicloudMachineClass struct {
 
 // AlicloudMachineClassList is a collection of AlicloudMachineClasses.
 type AlicloudMachineClassList struct {
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	metav1.ListMeta
 
-	// +optional
 	Items []AlicloudMachineClass
 }
 
@@ -1195,13 +1102,10 @@ type AlicloudSystemDisk struct {
 
 // PacketMachineClass TODO
 type PacketMachineClass struct {
-	// +optional
 	metav1.ObjectMeta
 
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	Spec PacketMachineClassSpec
 }
 
@@ -1209,13 +1113,10 @@ type PacketMachineClass struct {
 
 // PacketMachineClassList is a collection of PacketMachineClasses.
 type PacketMachineClassList struct {
-	// +optional
 	metav1.TypeMeta
 
-	// +optional
 	metav1.ListMeta
 
-	// +optional
 	Items []PacketMachineClass
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed `+optional` from internal API types since it is not needed there.

**Release note**:
```improvement operator
NONE
```
