### PR TITLE
Bugfix: Improve the management of finalizers and re-enqueue-mechanism for MachineClasses and Secrets

### DIFF
--- a/pkg/controller/alicloudmachineclass.go
+++ b/pkg/controller/alicloudmachineclass.go
@@ -129,7 +129,10 @@ func (c *controller) reconcileClusterAlicloudMachineClass(class *v1alpha1.Aliclo
 
 	// Manipulate finalizers
 	if class.DeletionTimestamp == nil {
-		c.addAlicloudMachineClassFinalizers(class)
+		err = c.addAlicloudMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
 	}
 
 	machines, err := c.findMachinesForClass(AlicloudMachineClassKind, class.Name)
@@ -151,8 +154,7 @@ func (c *controller) reconcileClusterAlicloudMachineClass(class *v1alpha1.Aliclo
 			return err
 		}
 		if len(machineDeployments) == 0 && len(machineSets) == 0 && len(machines) == 0 {
-			c.deleteAlicloudMachineClassFinalizers(class)
-			return nil
+			return c.deleteAlicloudMachineClassFinalizers(class)
 		}
 
 		glog.V(3).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
@@ -170,39 +172,42 @@ func (c *controller) reconcileClusterAlicloudMachineClass(class *v1alpha1.Aliclo
 	Manipulate Finalizers
 */
 
-func (c *controller) addAlicloudMachineClassFinalizers(class *v1alpha1.AlicloudMachineClass) {
+func (c *controller) addAlicloudMachineClassFinalizers(class *v1alpha1.AlicloudMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); !finalizers.Has(DeleteFinalizerName) {
 		finalizers.Insert(DeleteFinalizerName)
-		c.updateAlicloudMachineClassFinalizers(clone, finalizers.List())
+		return c.updateAlicloudMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) deleteAlicloudMachineClassFinalizers(class *v1alpha1.AlicloudMachineClass) {
+func (c *controller) deleteAlicloudMachineClassFinalizers(class *v1alpha1.AlicloudMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); finalizers.Has(DeleteFinalizerName) {
 		finalizers.Delete(DeleteFinalizerName)
-		c.updateAlicloudMachineClassFinalizers(clone, finalizers.List())
+		return c.updateAlicloudMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) updateAlicloudMachineClassFinalizers(class *v1alpha1.AlicloudMachineClass, finalizers []string) {
+func (c *controller) updateAlicloudMachineClassFinalizers(class *v1alpha1.AlicloudMachineClass, finalizers []string) error {
 	// Get the latest version of the class so that we can avoid conflicts
 	class, err := c.controlMachineClient.AlicloudMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
-		return
+		return err
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
 	_, err = c.controlMachineClient.AlicloudMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
-		// Keep retrying until update goes through
-		glog.Warning("Updated failed, retrying: ", err)
-		c.updateAlicloudMachineClassFinalizers(class, finalizers)
+		glog.Warning("Updating AlicloudMachineClass failed, retrying. ", class.Name, err)
+		return err
 	}
+	glog.V(3).Infof("Successfully added/removed finalizer on the alicloudmachineclass %q", class.Name)
+	return err
 }
 
 func (c *controller) enqueueAlicloudMachineClassAfter(obj interface{}, after time.Duration) {

--- a/pkg/controller/awsmachineclass.go
+++ b/pkg/controller/awsmachineclass.go
@@ -18,6 +18,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -107,6 +109,12 @@ func (c *controller) reconcileClusterAWSMachineClassKey(key string) error {
 }
 
 func (c *controller) reconcileClusterAWSMachineClass(class *v1alpha1.AWSMachineClass) error {
+	glog.V(4).Info("Start Reconciling awsmachineclass: ", class.Name)
+	defer func() {
+		c.enqueueAwsMachineClassAfter(class, 10*time.Minute)
+		glog.V(4).Info("Stop Reconciling awsmachineclass: ", class.Name)
+	}()
+
 	internalClass := &machine.AWSMachineClass{}
 	err := c.internalExternalScheme.Convert(class, internalClass, nil)
 	if err != nil {
@@ -147,7 +155,7 @@ func (c *controller) reconcileClusterAWSMachineClass(class *v1alpha1.AWSMachineC
 			return nil
 		}
 
-		glog.V(4).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
+		glog.V(3).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
 		return nil
 	}
 
@@ -195,4 +203,12 @@ func (c *controller) updateAWSMachineClassFinalizers(class *v1alpha1.AWSMachineC
 		glog.Warning("Updated failed, retrying: ", err)
 		c.updateAWSMachineClassFinalizers(class, finalizers)
 	}
+}
+
+func (c *controller) enqueueAwsMachineClassAfter(obj interface{}, after time.Duration) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	c.awsMachineClassQueue.AddAfter(key, after)
 }

--- a/pkg/controller/awsmachineclass.go
+++ b/pkg/controller/awsmachineclass.go
@@ -129,7 +129,10 @@ func (c *controller) reconcileClusterAWSMachineClass(class *v1alpha1.AWSMachineC
 
 	// Manipulate finalizers
 	if class.DeletionTimestamp == nil {
-		c.addAWSMachineClassFinalizers(class)
+		err = c.addAWSMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
 	}
 
 	machines, err := c.findMachinesForClass(AWSMachineClassKind, class.Name)
@@ -151,8 +154,7 @@ func (c *controller) reconcileClusterAWSMachineClass(class *v1alpha1.AWSMachineC
 			return err
 		}
 		if len(machineDeployments) == 0 && len(machineSets) == 0 && len(machines) == 0 {
-			c.deleteAWSMachineClassFinalizers(class)
-			return nil
+			return c.deleteAWSMachineClassFinalizers(class)
 		}
 
 		glog.V(3).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
@@ -170,39 +172,42 @@ func (c *controller) reconcileClusterAWSMachineClass(class *v1alpha1.AWSMachineC
 	Manipulate Finalizers
 */
 
-func (c *controller) addAWSMachineClassFinalizers(class *v1alpha1.AWSMachineClass) {
+func (c *controller) addAWSMachineClassFinalizers(class *v1alpha1.AWSMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); !finalizers.Has(DeleteFinalizerName) {
 		finalizers.Insert(DeleteFinalizerName)
-		c.updateAWSMachineClassFinalizers(clone, finalizers.List())
+		return c.updateAWSMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) deleteAWSMachineClassFinalizers(class *v1alpha1.AWSMachineClass) {
+func (c *controller) deleteAWSMachineClassFinalizers(class *v1alpha1.AWSMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); finalizers.Has(DeleteFinalizerName) {
 		finalizers.Delete(DeleteFinalizerName)
-		c.updateAWSMachineClassFinalizers(clone, finalizers.List())
+		return c.updateAWSMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) updateAWSMachineClassFinalizers(class *v1alpha1.AWSMachineClass, finalizers []string) {
+func (c *controller) updateAWSMachineClassFinalizers(class *v1alpha1.AWSMachineClass, finalizers []string) error {
 	// Get the latest version of the class so that we can avoid conflicts
 	class, err := c.controlMachineClient.AWSMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
-		return
+		return err
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
 	_, err = c.controlMachineClient.AWSMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
-		// Keep retrying until update goes through
-		glog.Warning("Updated failed, retrying: ", err)
-		c.updateAWSMachineClassFinalizers(class, finalizers)
+		glog.Warning("Updating AWSMachineClass failed, retrying. ", class.Name, err)
+		return err
 	}
+	glog.V(3).Infof("Successfully added/removed finalizer on the awsmachineclass %q", class.Name)
+	return err
 }
 
 func (c *controller) enqueueAwsMachineClassAfter(obj interface{}, after time.Duration) {

--- a/pkg/controller/azuremachineclass.go
+++ b/pkg/controller/azuremachineclass.go
@@ -18,6 +18,8 @@ limitations under the License.
 package controller
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -108,6 +110,12 @@ func (c *controller) reconcileClusterAzureMachineClassKey(key string) error {
 }
 
 func (c *controller) reconcileClusterAzureMachineClass(class *v1alpha1.AzureMachineClass) error {
+	glog.V(4).Info("Start Reconciling azuremachineclass: ", class.Name)
+	defer func() {
+		c.enqueueAzureMachineClassAfter(class, 10*time.Minute)
+		glog.V(4).Info("Stop Reconciling azuremachineclass: ", class.Name)
+	}()
+
 	internalClass := &machine.AzureMachineClass{}
 	err := c.internalExternalScheme.Convert(class, internalClass, nil)
 	if err != nil {
@@ -148,7 +156,7 @@ func (c *controller) reconcileClusterAzureMachineClass(class *v1alpha1.AzureMach
 			return nil
 		}
 
-		glog.V(4).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
+		glog.V(3).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
 		return nil
 	}
 
@@ -196,4 +204,12 @@ func (c *controller) updateAzureMachineClassFinalizers(class *v1alpha1.AzureMach
 		glog.Warning("Updated failed, retrying")
 		c.updateAzureMachineClassFinalizers(class, finalizers)
 	}
+}
+
+func (c *controller) enqueueAzureMachineClassAfter(obj interface{}, after time.Duration) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	c.azureMachineClassQueue.AddAfter(key, after)
 }

--- a/pkg/controller/azuremachineclass.go
+++ b/pkg/controller/azuremachineclass.go
@@ -130,7 +130,10 @@ func (c *controller) reconcileClusterAzureMachineClass(class *v1alpha1.AzureMach
 
 	// Manipulate finalizers
 	if class.DeletionTimestamp == nil {
-		c.addAzureMachineClassFinalizers(class)
+		err = c.addAzureMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
 	}
 
 	machines, err := c.findMachinesForClass(AzureMachineClassKind, class.Name)
@@ -152,8 +155,7 @@ func (c *controller) reconcileClusterAzureMachineClass(class *v1alpha1.AzureMach
 			return err
 		}
 		if len(machineDeployments) == 0 && len(machineSets) == 0 && len(machines) == 0 {
-			c.deleteAzureMachineClassFinalizers(class)
-			return nil
+			return c.deleteAzureMachineClassFinalizers(class)
 		}
 
 		glog.V(3).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
@@ -171,39 +173,42 @@ func (c *controller) reconcileClusterAzureMachineClass(class *v1alpha1.AzureMach
 	Manipulate Finalizers
 */
 
-func (c *controller) addAzureMachineClassFinalizers(class *v1alpha1.AzureMachineClass) {
+func (c *controller) addAzureMachineClassFinalizers(class *v1alpha1.AzureMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); !finalizers.Has(DeleteFinalizerName) {
 		finalizers.Insert(DeleteFinalizerName)
-		c.updateAzureMachineClassFinalizers(clone, finalizers.List())
+		return c.updateAzureMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) deleteAzureMachineClassFinalizers(class *v1alpha1.AzureMachineClass) {
+func (c *controller) deleteAzureMachineClassFinalizers(class *v1alpha1.AzureMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); finalizers.Has(DeleteFinalizerName) {
 		finalizers.Delete(DeleteFinalizerName)
-		c.updateAzureMachineClassFinalizers(clone, finalizers.List())
+		return c.updateAzureMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) updateAzureMachineClassFinalizers(class *v1alpha1.AzureMachineClass, finalizers []string) {
+func (c *controller) updateAzureMachineClassFinalizers(class *v1alpha1.AzureMachineClass, finalizers []string) error {
 	// Get the latest version of the class so that we can avoid conflicts
 	class, err := c.controlMachineClient.AzureMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
-		return
+		return err
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
 	_, err = c.controlMachineClient.AzureMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
-		// Keep retrying until update goes through
-		glog.Warning("Updated failed, retrying")
-		c.updateAzureMachineClassFinalizers(class, finalizers)
+		glog.Warning("Updating AzureMachineClass failed, retrying. ", class.Name, err)
+		return err
 	}
+	glog.V(3).Infof("Successfully added/removed finalizer on the azuremachineclass %q", class.Name)
+	return err
 }
 
 func (c *controller) enqueueAzureMachineClassAfter(obj interface{}, after time.Duration) {

--- a/pkg/controller/gcpmachineclass.go
+++ b/pkg/controller/gcpmachineclass.go
@@ -131,7 +131,10 @@ func (c *controller) reconcileClusterGCPMachineClass(class *v1alpha1.GCPMachineC
 
 	// Manipulate finalizers
 	if class.DeletionTimestamp == nil {
-		c.addGCPMachineClassFinalizers(class)
+		err = c.addGCPMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
 	}
 
 	machines, err := c.findMachinesForClass(GCPMachineClassKind, class.Name)
@@ -153,8 +156,7 @@ func (c *controller) reconcileClusterGCPMachineClass(class *v1alpha1.GCPMachineC
 			return err
 		}
 		if len(machineDeployments) == 0 && len(machineSets) == 0 && len(machines) == 0 {
-			c.deleteGCPMachineClassFinalizers(class)
-			return nil
+			return c.deleteGCPMachineClassFinalizers(class)
 		}
 
 		glog.V(3).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
@@ -172,39 +174,42 @@ func (c *controller) reconcileClusterGCPMachineClass(class *v1alpha1.GCPMachineC
 	Manipulate Finalizers
 */
 
-func (c *controller) addGCPMachineClassFinalizers(class *v1alpha1.GCPMachineClass) {
+func (c *controller) addGCPMachineClassFinalizers(class *v1alpha1.GCPMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); !finalizers.Has(DeleteFinalizerName) {
 		finalizers.Insert(DeleteFinalizerName)
-		c.updateGCPMachineClassFinalizers(clone, finalizers.List())
+		return c.updateGCPMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) deleteGCPMachineClassFinalizers(class *v1alpha1.GCPMachineClass) {
+func (c *controller) deleteGCPMachineClassFinalizers(class *v1alpha1.GCPMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); finalizers.Has(DeleteFinalizerName) {
 		finalizers.Delete(DeleteFinalizerName)
-		c.updateGCPMachineClassFinalizers(clone, finalizers.List())
+		return c.updateGCPMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) updateGCPMachineClassFinalizers(class *v1alpha1.GCPMachineClass, finalizers []string) {
+func (c *controller) updateGCPMachineClassFinalizers(class *v1alpha1.GCPMachineClass, finalizers []string) error {
 	// Get the latest version of the class so that we can avoid conflicts
 	class, err := c.controlMachineClient.GCPMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
-		return
+		return err
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
 	_, err = c.controlMachineClient.GCPMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
-		// Keep retrying until update goes through
-		glog.Warning("Updated failed, retrying: ", err)
-		c.updateGCPMachineClassFinalizers(class, finalizers)
+		glog.Warning("Updating GCPMachineClass failed, retrying. ", class.Name, err)
+		return err
 	}
+	glog.V(3).Infof("Successfully added/removed finalizer on the gcpmachineclass %q", class.Name)
+	return err
 }
 
 func (c *controller) enqueueGcpMachineClassAfter(obj interface{}, after time.Duration) {

--- a/pkg/controller/packetcloudmachineclass.go
+++ b/pkg/controller/packetcloudmachineclass.go
@@ -127,7 +127,10 @@ func (c *controller) reconcileClusterPacketMachineClass(class *v1alpha1.PacketMa
 
 	// Manipulate finalizers
 	if class.DeletionTimestamp == nil {
-		c.addPacketMachineClassFinalizers(class)
+		err = c.addPacketMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
 	}
 
 	machines, err := c.findMachinesForClass(PacketMachineClassKind, class.Name)
@@ -149,8 +152,7 @@ func (c *controller) reconcileClusterPacketMachineClass(class *v1alpha1.PacketMa
 			return err
 		}
 		if len(machineDeployments) == 0 && len(machineSets) == 0 && len(machines) == 0 {
-			c.deletePacketMachineClassFinalizers(class)
-			return nil
+			return c.deletePacketMachineClassFinalizers(class)
 		}
 
 		glog.V(3).Infof("Cannot remove finalizer of %s because still Machine[s|Sets|Deployments] are referencing it", class.Name)
@@ -168,39 +170,42 @@ func (c *controller) reconcileClusterPacketMachineClass(class *v1alpha1.PacketMa
 	Manipulate Finalizers
 */
 
-func (c *controller) addPacketMachineClassFinalizers(class *v1alpha1.PacketMachineClass) {
+func (c *controller) addPacketMachineClassFinalizers(class *v1alpha1.PacketMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); !finalizers.Has(DeleteFinalizerName) {
 		finalizers.Insert(DeleteFinalizerName)
-		c.updatePacketMachineClassFinalizers(clone, finalizers.List())
+		return c.updatePacketMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) deletePacketMachineClassFinalizers(class *v1alpha1.PacketMachineClass) {
+func (c *controller) deletePacketMachineClassFinalizers(class *v1alpha1.PacketMachineClass) error {
 	clone := class.DeepCopy()
 
 	if finalizers := sets.NewString(clone.Finalizers...); finalizers.Has(DeleteFinalizerName) {
 		finalizers.Delete(DeleteFinalizerName)
-		c.updatePacketMachineClassFinalizers(clone, finalizers.List())
+		return c.updatePacketMachineClassFinalizers(clone, finalizers.List())
 	}
+	return nil
 }
 
-func (c *controller) updatePacketMachineClassFinalizers(class *v1alpha1.PacketMachineClass, finalizers []string) {
+func (c *controller) updatePacketMachineClassFinalizers(class *v1alpha1.PacketMachineClass, finalizers []string) error {
 	// Get the latest version of the class so that we can avoid conflicts
 	class, err := c.controlMachineClient.PacketMachineClasses(class.Namespace).Get(class.Name, metav1.GetOptions{})
 	if err != nil {
-		return
+		return err
 	}
 
 	clone := class.DeepCopy()
 	clone.Finalizers = finalizers
 	_, err = c.controlMachineClient.PacketMachineClasses(class.Namespace).Update(clone)
 	if err != nil {
-		// Keep retrying until update goes through
-		glog.Warningf("Updated failed, retrying: %v", err)
-		c.updatePacketMachineClassFinalizers(class, finalizers)
+		glog.Warning("Updating PacketMachineClass failed, retrying. ", class.Name, err)
+		return err
 	}
+	glog.V(3).Infof("Successfully added/removed finalizer on the packetmachineclass %q", class.Name)
+	return err
 }
 
 func (c *controller) enqueuePacketMachineClassAfter(obj interface{}, after time.Duration) {

--- a/pkg/controller/secret.go
+++ b/pkg/controller/secret.go
@@ -60,6 +60,7 @@ func (c *controller) reconcileClusterSecret(secret *v1.Secret) error {
 
 	glog.V(4).Infof("Start syncing %q", secret.Name)
 	defer func() {
+		c.enqueueSecretAfter(secret, 10*time.Minute)
 		glog.V(4).Infof("Finished syncing %q (%v)", secret.Name, time.Since(startTime))
 	}()
 
@@ -139,6 +140,14 @@ func (c *controller) secretAdd(obj interface{}) {
 
 func (c *controller) secretDelete(obj interface{}) {
 	c.secretAdd(obj)
+}
+
+func (c *controller) enqueueSecretAfter(obj interface{}, after time.Duration) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	c.secretQueue.AddAfter(key, after)
 }
 
 func (c *controller) openStackMachineClassToSecretAdd(obj interface{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:  This PR attempts to solve the reported issue of orphan MachienClasses/Secrets and MachineDeployments. 

MCM uses finalizers to make sure :
- MachineClass/Secrets are not deleted before referring MachineDeployments are deleted.
- MachineClasses/Secrets are removed timely after all the referring MachineDeployments are deleted.

We had observed the bug in both cases mentioned above, where sometimes Machineclasses/Secrets or Machinedeployments being orphaned/not-deleted while shoot-deletion.

Bug above has not been actively re-produced but certain observations below on healthy-clusters made the guesstimation of root-causes more clearer.
- Finalizer was found missing in few machine-classes in healthy clusters.
- In few cases restarting the MCM re-enqueued the objects, which eventually solved the issue.

This PR solves the overall bug by -
- Periodically re-enqueueing the machineclasses/secrets.
- Better error-handling while managing the finalizers for the concerned objects.

**Which issue(s) this PR fixes**:
Fixes #259 

**Special notes for your reviewer**:  

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy operator
Fixes consistency issues with machine-deployments, machine-classes, and secrets.
```
```improvement operator
Better error handling while adding/removing the finalizers on machine classes & secrets.
```
```improvement operator
Re-enqueues the machine classes and secrets periodically(~10mins).
```
