### PR TITLE
Added missing user_domain_id secret field

### DIFF
--- a/kubernetes/Secrets/openstack-secret.yaml
+++ b/kubernetes/Secrets/openstack-secret.yaml
@@ -9,14 +9,15 @@ data: # base64 encoded
   userData: <cloud_init> # Cloud init file for used by the machines
   authURL: <auth_URL> # Keystone auth endpoint address
   username: <username> # Keystone username
-  password: <password> # Keystone password 
+  password: <password> # Keystone password
   domainName: <domain_name> # Keystone domain name
   # domainID: <domain_id> # Keystone domaine id (optional)
   tenantName: <tenant_name> # Keystone tenant name
   # tenantID: <tenant_id> # Keystone tenant id (optional)
   # userDomainName: <user_domain_name> # Keystone user domain name (optional)
-  insecure: "true" | "false" # optional: if running against a self signed OpenStack endpoints 
-  # optional certificate/autherization block  
+  # userDomainID: <user_domain_id> # Keystone user domain id (optional)
+  insecure: "true" # | "false" # optional: if running against a self signed OpenStack endpoints
+  # optional certificate/autherization block
   caCert: <caCert> # Custom certificate of your OpenStack endpoints
   clientCert: <clientCert> # Client certificate
   clientKey: <clientKey> # Client jey

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -1164,6 +1164,8 @@ const (
 	OpenStackTenantID string = "tenantID"
 	// OpenStackUserDomainName is a constant for a key name that is part of the OpenStack cloud credentials.
 	OpenStackUserDomainName string = "userDomainName"
+	// OpenStackUserDomainID is a constant for a key name that is part of the OpenStack cloud credentials.
+	OpenStackUserDomainID string = "userDomainID"
 	// OpenStackUsername is a constant for a key name that is part of the OpenStack cloud credentials.
 	OpenStackUsername string = "username"
 	// OpenStackPassword is a constant for a key name that is part of the OpenStack cloud credentials.
@@ -1273,14 +1275,14 @@ type PacketMachineClassList struct {
 
 // PacketMachineClassSpec is the specification of a cluster.
 type PacketMachineClassSpec struct {
-	Facility     []string           `json:"facility"`
-	MachineType  string             `json:"machineType"`
-	BillingCycle string             `json:"billingCycle"`
-	OS           string             `json:"OS"`
-	ProjectID    string             `json:"projectID"`
-	Tags         []string  `json:"tags,omitempty"`
+	Facility     []string `json:"facility"`
+	MachineType  string   `json:"machineType"`
+	BillingCycle string   `json:"billingCycle"`
+	OS           string   `json:"OS"`
+	ProjectID    string   `json:"projectID"`
+	Tags         []string `json:"tags,omitempty"`
 	SSHKeys      []string `json:"sshKeys,omitempty"`
-	UserData     string             `json:"userdata,omitempty"`
+	UserData     string   `json:"userdata,omitempty"`
 
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 }

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -285,6 +285,8 @@ func (d *OpenStackDriver) createOpenStackClient() (*gophercloud.ProviderClient, 
 
 	// optional OS_USER_DOMAIN_NAME
 	userDomainName := d.CloudConfig.Data[v1alpha1.OpenStackUserDomainName]
+	// optional OS_USER_DOMAIN_ID
+	userDomainID := d.CloudConfig.Data[v1alpha1.OpenStackUserDomainID]
 
 	domainName, ok := d.CloudConfig.Data[v1alpha1.OpenStackDomainName]
 	domainID, ok2 := d.CloudConfig.Data[v1alpha1.OpenStackDomainID]
@@ -338,6 +340,7 @@ func (d *OpenStackDriver) createOpenStackClient() (*gophercloud.ProviderClient, 
 		ProjectName:    strings.TrimSpace(string(tenantName)),
 		ProjectID:      strings.TrimSpace(string(tenantID)),
 		UserDomainName: strings.TrimSpace(string(userDomainName)),
+		UserDomainID:   strings.TrimSpace(string(userDomainID)),
 	}
 	clientOpts.AuthInfo = authInfo
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the support for `userDomainID` as an authentication parameter.

**Which issue(s) this PR fixes**:
Relates to #311 

**Release note**:
```improvement operator
Added missing user_domain_id secret field for OpenStack driver
```
