### PR TITLE
makes MCM GCP driver to differentiate user-data from startup-script

### DIFF
--- a/pkg/driver/driver_gcp.go
+++ b/pkg/driver/driver_gcp.go
@@ -97,12 +97,9 @@ func (d *GCPDriver) Create() (string, string, error) {
 	}
 	instance.Disks = disks
 
-	var metadataItems = []*compute.MetadataItems{
-		{
-			Key:   "user-data",
-			Value: &d.UserData,
-		},
-	}
+	var metadataItems = []*compute.MetadataItems{}
+	metadataItems = append(metadataItems, d.getUserData())
+
 	for _, metadata := range d.GCPMachineClass.Spec.Metadata {
 		metadataItems = append(metadataItems, &compute.MetadataItems{
 			Key:   metadata.Key,
@@ -187,6 +184,20 @@ func (d *GCPDriver) Delete() error {
 	metrics.APIRequestCount.With(prometheus.Labels{"provider": "gcp", "service": "compute"}).Inc()
 
 	return waitUntilOperationCompleted(computeService, project, zone, operation.Name)
+}
+
+func (d *GCPDriver) getUserData() *compute.MetadataItems {
+	if strings.HasPrefix(d.UserData, "#cloud-config") {
+		return &compute.MetadataItems{
+			Key:   "user-data",
+			Value: &d.UserData,
+		}
+	}
+
+	return &compute.MetadataItems{
+		Key:   "startup-script",
+		Value: &d.UserData,
+	}
 }
 
 // GetExisting method is used to get machineID for existing GCP machine


### PR DESCRIPTION
**What this PR does / why we need it**:
Additional user data on GCP is added by passing key/value pairs. The key is the name of the data and the value is the actual data itself.At the moment no matter what is the type of the data (cloud-config or script) we always set the key to be "user-data". But when GCP see such key it assumes that is dedicated to cloud-init binary so passing a script as a user-data and the corresponding binary is missing the script will to be ran. By making the MCM to differentiate between cloud-config and script now we can set the corresponding key to be either "user-data" or "startup-script". Thus the script will be executed on each boot after the network is up.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
 MCM differentiates between cloud-config and script as user-data
```
