### PR TITLE
Add support for zoned Azure machines

### DIFF
--- a/kubernetes/machine_classes/azure-machine-class.yaml
+++ b/kubernetes/machine_classes/azure-machine-class.yaml
@@ -41,5 +41,6 @@ spec:
           publicKeys:
             path: "/path/to/public-key/in/machine" # Path to public key
             keyData: "public-key-data" # Public key data
-    availabilitySet:
+    zone: 1 # Zone which the node will be deployed into. Either a zone or an AvailabilitySet can be specified.
+    availabilitySet: # AvailabilitySet which the node will be assigned to. Either a zone or an AvailabilitySet can be specified.
       id: "/subscriptions/subscription-id/resourceGroups/resource-group-name/providers/Microsoft.Compute/availabilitySets/availablity-set-name" # ID of availability set to attach the machine to

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -864,7 +864,8 @@ type AzureVirtualMachineProperties struct {
 	StorageProfile  AzureStorageProfile
 	OsProfile       AzureOSProfile
 	NetworkProfile  AzureNetworkProfile
-	AvailabilitySet AzureSubResource
+	AvailabilitySet *AzureSubResource
+	Zone            *int
 }
 
 // AzureHardwareProfile is specifies the hardware settings for the virtual machine.

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -945,7 +945,8 @@ type AzureVirtualMachineProperties struct {
 	StorageProfile  AzureStorageProfile  `json:"storageProfile,omitempty"`
 	OsProfile       AzureOSProfile       `json:"osProfile,omitempty"`
 	NetworkProfile  AzureNetworkProfile  `json:"networkProfile,omitempty"`
-	AvailabilitySet AzureSubResource     `json:"availabilitySet,omitempty"`
+	AvailabilitySet *AzureSubResource    `json:"availabilitySet,omitempty"`
+	Zone            *int                 `json:"zone,omitempty"`
 }
 
 // AzureHardwareProfile is specifies the hardware settings for the virtual machine.

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -1512,9 +1512,8 @@ func autoConvert_v1alpha1_AzureVirtualMachineProperties_To_machine_AzureVirtualM
 	if err := Convert_v1alpha1_AzureNetworkProfile_To_machine_AzureNetworkProfile(&in.NetworkProfile, &out.NetworkProfile, s); err != nil {
 		return err
 	}
-	if err := Convert_v1alpha1_AzureSubResource_To_machine_AzureSubResource(&in.AvailabilitySet, &out.AvailabilitySet, s); err != nil {
-		return err
-	}
+	out.AvailabilitySet = (*machine.AzureSubResource)(unsafe.Pointer(in.AvailabilitySet))
+	out.Zone = (*int)(unsafe.Pointer(in.Zone))
 	return nil
 }
 
@@ -1536,9 +1535,8 @@ func autoConvert_machine_AzureVirtualMachineProperties_To_v1alpha1_AzureVirtualM
 	if err := Convert_machine_AzureNetworkProfile_To_v1alpha1_AzureNetworkProfile(&in.NetworkProfile, &out.NetworkProfile, s); err != nil {
 		return err
 	}
-	if err := Convert_machine_AzureSubResource_To_v1alpha1_AzureSubResource(&in.AvailabilitySet, &out.AvailabilitySet, s); err != nil {
-		return err
-	}
+	out.AvailabilitySet = (*AzureSubResource)(unsafe.Pointer(in.AvailabilitySet))
+	out.Zone = (*int)(unsafe.Pointer(in.Zone))
 	return nil
 }
 

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -655,7 +655,16 @@ func (in *AzureVirtualMachineProperties) DeepCopyInto(out *AzureVirtualMachinePr
 	in.StorageProfile.DeepCopyInto(&out.StorageProfile)
 	out.OsProfile = in.OsProfile
 	in.NetworkProfile.DeepCopyInto(&out.NetworkProfile)
-	out.AvailabilitySet = in.AvailabilitySet
+	if in.AvailabilitySet != nil {
+		in, out := &in.AvailabilitySet, &out.AvailabilitySet
+		*out = new(AzureSubResource)
+		**out = **in
+	}
+	if in.Zone != nil {
+		in, out := &in.Zone, &out.Zone
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/machine/validation/azuremachineclass.go
+++ b/pkg/apis/machine/validation/azuremachineclass.go
@@ -137,6 +137,13 @@ func validateAzureProperties(properties machine.AzureVirtualMachineProperties, f
 		allErrs = append(allErrs, field.Required(fldPath.Child("osProfile.adminUsername"), "AdminUsername is required"))
 	}
 
+	if properties.Zone == nil && properties.AvailabilitySet == nil {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("zone|.availabilitySet"), "Machine need to be assigned to a zone or an AvailabilitySet"))
+	}
+	if properties.Zone != nil && properties.AvailabilitySet != nil {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("zone|.availabilitySet"), "Machine cannot be assigned to a zone and an AvailabilitySet in parallel"))
+	}
+
 	/*
 		if properties.OsProfile.LinuxConfiguration.SSH.PublicKeys.Path == "" {
 			allErrs = append(allErrs, field.Required(fldPath.Child("osProfile.linuxConfiguration.ssh.publicKeys.path"), "PublicKey path is required"))

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -655,7 +655,16 @@ func (in *AzureVirtualMachineProperties) DeepCopyInto(out *AzureVirtualMachinePr
 	in.StorageProfile.DeepCopyInto(&out.StorageProfile)
 	out.OsProfile = in.OsProfile
 	in.NetworkProfile.DeepCopyInto(&out.NetworkProfile)
-	out.AvailabilitySet = in.AvailabilitySet
+	if in.AvailabilitySet != nil {
+		in, out := &in.AvailabilitySet, &out.AvailabilitySet
+		*out = new(AzureSubResource)
+		**out = **in
+	}
+	if in.Zone != nil {
+		in, out := &in.Zone, &out.Zone
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -150,11 +151,16 @@ func (d *AzureDriver) getVMParameters(vmName string, networkInterfaceReferenceID
 					},
 				},
 			},
-			AvailabilitySet: &compute.SubResource{
-				ID: &d.AzureMachineClass.Spec.Properties.AvailabilitySet.ID,
-			},
 		},
 		Tags: tagList,
+	}
+
+	if d.AzureMachineClass.Spec.Properties.Zone != nil {
+		VMParameters.Zones = &[]string{strconv.Itoa(*d.AzureMachineClass.Spec.Properties.Zone)}
+	} else if d.AzureMachineClass.Spec.Properties.AvailabilitySet != nil {
+		VMParameters.VirtualMachineProperties.AvailabilitySet = &compute.SubResource{
+			ID: &d.AzureMachineClass.Spec.Properties.AvailabilitySet.ID,
+		}
 	}
 
 	return VMParameters

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1079,6 +1079,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureSubResource"),
 							},
 						},
+						"zone": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"integer"},
+								Format: "int32",
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Azure Machines can be deployed into a Zone OR an AvailabilitySet.
Both in parallel is not possible and will lead to an error.

**What this PR does / why we need it**:
To support zoned Azure Shoot clusters the MCM need to deploy and manage Azure machines in availability zones.

**Which issue(s) this PR fixes**:
Fixes #332

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
MCM supports now Azure machines deployed into availability zones. You can either deploy a machine into a zone or an AvailabilitySet.
```