### PR TITLE
More frequent freeze checker during integration tests

### DIFF
--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -109,7 +109,7 @@ function run_controller() {
         --machine-safety-apiserver-statuscheck-timeout=30s \
         --machine-safety-apiserver-statuscheck-period=1m \
         --machine-safety-orphan-vms-period=30m \
-        --machine-safety-overshooting-period=1s \
+        --machine-safety-overshooting-period=300ms \
         --leader-elect-lease-duration=1m \
         --leader-elect-renew-deadline=30s \
         --leader-elect-retry-period=15s \


### PR DESCRIPTION
**What this PR does / why we need it**:
The integration tests fail when freeze event isn't caught. This makes freeze checking more often during integration tests

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
