### PR TITLE
GCP VM's Public IP attachment is now optional

### DIFF
--- a/kubernetes/machine_classes/gcp-machine-class.yaml
+++ b/kubernetes/machine_classes/gcp-machine-class.yaml
@@ -24,7 +24,8 @@ spec:
   - key: my-key
     value: my-value
   networkInterfaces:
-  - network: network-name # Network name to attach the instance to
+  - disableExternalIP: false # If external IP is not required for the NIC, set this to true
+    network: network-name # Network name to attach the instance to
     subnetwork: sub-net-name # Subnet name to attach the instance to
   scheduling:
     automaticRestart: true # Automatic restart of instance

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -1029,9 +1029,9 @@ type GCPMetadata struct {
 
 // GCPNetworkInterface describes network interfaces for GCP
 type GCPNetworkInterface struct {
-	AttachExternalIP bool
-	Network          string
-	Subnetwork       string
+	DisableExternalIP bool
+	Network           string
+	Subnetwork        string
 }
 
 // GCPScheduling describes scheduling configuration for GCP.

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -1029,8 +1029,9 @@ type GCPMetadata struct {
 
 // GCPNetworkInterface describes network interfaces for GCP
 type GCPNetworkInterface struct {
-	Network    string
-	Subnetwork string
+	AttachExternalIP bool
+	Network          string
+	Subnetwork       string
 }
 
 // GCPScheduling describes scheduling configuration for GCP.

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -1121,9 +1121,9 @@ type GCPMetadata struct {
 
 // GCPNetworkInterface describes network interfaces for GCP
 type GCPNetworkInterface struct {
-	AttachExternalIP bool   `json:"attachExternalIP,omitempty"`
-	Network          string `json:"network,omitempty"`
-	Subnetwork       string `json:"subnetwork,omitempty"`
+	DisableExternalIP bool   `json:"disableExternalIP,omitempty"`
+	Network           string `json:"network,omitempty"`
+	Subnetwork        string `json:"subnetwork,omitempty"`
 }
 
 // GCPScheduling describes scheduling configuration for GCP.

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -1121,8 +1121,9 @@ type GCPMetadata struct {
 
 // GCPNetworkInterface describes network interfaces for GCP
 type GCPNetworkInterface struct {
-	Network    string `json:"network,omitempty"`
-	Subnetwork string `json:"subnetwork,omitempty"`
+	AttachExternalIP bool   `json:"attachExternalIP,omitempty"`
+	Network          string `json:"network,omitempty"`
+	Subnetwork       string `json:"subnetwork,omitempty"`
 }
 
 // GCPScheduling describes scheduling configuration for GCP.

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -1746,7 +1746,7 @@ func Convert_machine_GCPMetadata_To_v1alpha1_GCPMetadata(in *machine.GCPMetadata
 }
 
 func autoConvert_v1alpha1_GCPNetworkInterface_To_machine_GCPNetworkInterface(in *GCPNetworkInterface, out *machine.GCPNetworkInterface, s conversion.Scope) error {
-	out.AttachExternalIP = in.AttachExternalIP
+	out.DisableExternalIP = in.DisableExternalIP
 	out.Network = in.Network
 	out.Subnetwork = in.Subnetwork
 	return nil
@@ -1758,7 +1758,7 @@ func Convert_v1alpha1_GCPNetworkInterface_To_machine_GCPNetworkInterface(in *GCP
 }
 
 func autoConvert_machine_GCPNetworkInterface_To_v1alpha1_GCPNetworkInterface(in *machine.GCPNetworkInterface, out *GCPNetworkInterface, s conversion.Scope) error {
-	out.AttachExternalIP = in.AttachExternalIP
+	out.DisableExternalIP = in.DisableExternalIP
 	out.Network = in.Network
 	out.Subnetwork = in.Subnetwork
 	return nil

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -1746,6 +1746,7 @@ func Convert_machine_GCPMetadata_To_v1alpha1_GCPMetadata(in *machine.GCPMetadata
 }
 
 func autoConvert_v1alpha1_GCPNetworkInterface_To_machine_GCPNetworkInterface(in *GCPNetworkInterface, out *machine.GCPNetworkInterface, s conversion.Scope) error {
+	out.AttachExternalIP = in.AttachExternalIP
 	out.Network = in.Network
 	out.Subnetwork = in.Subnetwork
 	return nil
@@ -1757,6 +1758,7 @@ func Convert_v1alpha1_GCPNetworkInterface_To_machine_GCPNetworkInterface(in *GCP
 }
 
 func autoConvert_machine_GCPNetworkInterface_To_v1alpha1_GCPNetworkInterface(in *machine.GCPNetworkInterface, out *GCPNetworkInterface, s conversion.Scope) error {
+	out.AttachExternalIP = in.AttachExternalIP
 	out.Network = in.Network
 	out.Subnetwork = in.Subnetwork
 	return nil

--- a/pkg/driver/driver_gcp.go
+++ b/pkg/driver/driver_gcp.go
@@ -114,7 +114,8 @@ func (d *GCPDriver) Create() (string, string, error) {
 	for _, nic := range d.GCPMachineClass.Spec.NetworkInterfaces {
 		computeNIC := &compute.NetworkInterface{}
 
-		if nic.AttachExternalIP == true {
+		if nic.DisableExternalIP == false {
+			// When DisableExternalIP is false, implies Attach an external IP to VM
 			computeNIC.AccessConfigs = []*compute.AccessConfig{{}}
 		}
 		if len(nic.Network) != 0 {

--- a/pkg/driver/driver_gcp.go
+++ b/pkg/driver/driver_gcp.go
@@ -112,8 +112,10 @@ func (d *GCPDriver) Create() (string, string, error) {
 
 	var networkInterfaces = []*compute.NetworkInterface{}
 	for _, nic := range d.GCPMachineClass.Spec.NetworkInterfaces {
-		computeNIC := &compute.NetworkInterface{
-			AccessConfigs: []*compute.AccessConfig{{}},
+		computeNIC := &compute.NetworkInterface{}
+
+		if nic.AttachExternalIP == true {
+			computeNIC.AccessConfigs = []*compute.AccessConfig{{}}
 		}
 		if len(nic.Network) != 0 {
 			computeNIC.Network = fmt.Sprintf("projects/%s/global/networks/%s", project, nic.Network)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1450,6 +1450,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "GCPNetworkInterface describes network interfaces for GCP",
 					Properties: map[string]spec.Schema{
+						"attachExternalIP": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"boolean"},
+								Format: "",
+							},
+						},
 						"network": {
 							SchemaProps: spec.SchemaProps{
 								Type:   []string{"string"},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1450,7 +1450,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "GCPNetworkInterface describes network interfaces for GCP",
 					Properties: map[string]spec.Schema{
-						"attachExternalIP": {
+						"disableExternalIP": {
 							SchemaProps: spec.SchemaProps{
 								Type:   []string{"boolean"},
 								Format: "",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #339 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy operator
⚠️ GCP VM's Public IP attachment is now optional. Default behaviour is that public IP attachment is enabled. To disable this, refer to [this example here](https://github.com/gardener/machine-controller-manager/blob/master/kubernetes/machine_classes/gcp-machine-class.yaml#L27)
```