### PR TITLE
Updated Kubectl to v1.16.0

### DIFF
--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -77,7 +77,7 @@ function setup_environment() {
     # If not a local test then install kubectl
     if [ -z "$LOCAL_TEST" ]; then
         printf "\nDownloading and installing kubectl\n"
-        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.10.0/bin/linux/amd64/kubectl
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
         chmod +x ./kubectl
         mv ./kubectl /usr/local/bin/kubectl
         printf "Successfully installed kubectl\n"


### PR DESCRIPTION
**What this PR does / why we need it**:
The IT fails currently due to an older version of Kubectl being used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Updated Integration Tests kubectl to `v1.16.0`
```
