### PR TITLE
Make node-conditions configurable

### DIFF
--- a/cmd/machine-controller-manager/app/controllermanager.go
+++ b/cmd/machine-controller-manager/app/controllermanager.go
@@ -268,6 +268,7 @@ func StartControllers(s *options.MCMServer,
 			machineSharedInformers.MachineDeployments(),
 			recorder,
 			s.SafetyOptions,
+			s.NodeConditions,
 		)
 		if err != nil {
 			return err

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -111,7 +111,7 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyOrphanVMsPeriod.Duration, "machine-safety-orphan-vms-period", s.SafetyOptions.MachineSafetyOrphanVMsPeriod.Duration, "Time period (in durartion) used to poll for orphan VMs by safety controller.")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "machine-safety-overshooting-period", s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "Time period (in durartion) used to poll for overshooting of machine objects backing a machineSet by safety controller.")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "machine-safety-apiserver-statuscheck-period", s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "Time period (in duration) used to poll for APIServer's health by safety controller")
-	fs.StringVar(&s.NodeConditions, "node-conditions", s.NodeConditions, "List of comma-separated/case-sensitive node-conditions which are if set to True, MCM would replace the machine after MachineHealthTimeout duration")
+	fs.StringVar(&s.NodeConditions, "node-conditions", s.NodeConditions, "List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.")
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -56,6 +56,7 @@ func NewMCMServer() *MCMServer {
 			Address:                 "0.0.0.0",
 			ConcurrentNodeSyncs:     5,
 			ContentType:             "application/vnd.kubernetes.protobuf",
+			NodeConditions:          "KernelDeadlock,ReadonlyFilesystem,DiskPressure",
 			MinResyncPeriod:         metav1.Duration{Duration: 12 * time.Hour},
 			KubeAPIQPS:              20.0,
 			KubeAPIBurst:            30,
@@ -110,6 +111,7 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyOrphanVMsPeriod.Duration, "machine-safety-orphan-vms-period", s.SafetyOptions.MachineSafetyOrphanVMsPeriod.Duration, "Time period (in durartion) used to poll for orphan VMs by safety controller.")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "machine-safety-overshooting-period", s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "Time period (in durartion) used to poll for overshooting of machine objects backing a machineSet by safety controller.")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "machine-safety-apiserver-statuscheck-period", s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "Time period (in duration) used to poll for APIServer's health by safety controller")
+	fs.StringVar(&s.NodeConditions, "node-conditions", s.NodeConditions, "List of comma-separated/case-sensitive node-conditions which are if set to True, MCM would replace the machine after MachineHealthTimeout duration")
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190227213309-4f5b463f9597 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.42.0 // indirect

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           - --machine-set-scale-timeout=20 # Optional Parameter - Default value 20mins - Timeout (in minutes) used while scaling machineSet if timeout occurs machineSet is frozen.
           - --machine-safety-orphan-vms-period=30 # Optional Parameter - Default value 30mins - Time period (in minutes) used to poll for orphan VMs by safety controller.
           - --machine-safety-overshooting-period=1 # Optional Parameter - Default value 1min - Time period (in minutes) used to poll for overshooting of machine objects backing a machineSet by safety controller.
-          - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # If any of these NodeConditions are set on a node-object for configurable timeout, than machine will be declared failed and will be replaced.
+          - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kubernetes/deployment/deployment.yaml
+++ b/kubernetes/deployment/deployment.yaml
@@ -28,6 +28,7 @@ spec:
           - --machine-set-scale-timeout=20 # Optional Parameter - Default value 20mins - Timeout (in minutes) used while scaling machineSet if timeout occurs machineSet is frozen.
           - --machine-safety-orphan-vms-period=30 # Optional Parameter - Default value 30mins - Time period (in minutes) used to poll for orphan VMs by safety controller.
           - --machine-safety-overshooting-period=1 # Optional Parameter - Default value 1min - Time period (in minutes) used to poll for overshooting of machine objects backing a machineSet by safety controller.
+          - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # If any of these NodeConditions are set on a node-object for configurable timeout, than machine will be declared failed and will be replaced.
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -81,6 +81,7 @@ func NewController(
 	machineDeploymentInformer machineinformers.MachineDeploymentInformer,
 	recorder record.EventRecorder,
 	safetyOptions options.SafetyOptions,
+	nodeConditions string,
 ) (Controller, error) {
 	controller := &controller{
 		namespace:                      namespace,
@@ -104,6 +105,7 @@ func NewController(
 		machineSafetyOvershootingQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyovershooting"),
 		machineSafetyAPIServerQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyapiserver"),
 		safetyOptions:                  safetyOptions,
+		nodeConditions:                 nodeConditions,
 	}
 
 	controller.internalExternalScheme = runtime.NewScheme()
@@ -395,7 +397,8 @@ type Controller interface {
 
 // controller is a concrete Controller.
 type controller struct {
-	namespace string
+	namespace      string
+	nodeConditions string
 
 	controlMachineClient machineapi.MachineV1alpha1Interface
 	controlCoreClient    kubernetes.Interface

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -793,9 +794,12 @@ func (c *controller) isHealthy(machine *v1alpha1.Machine) bool {
 		if condition.Type == v1.NodeReady && condition.Status != v1.ConditionTrue {
 			// If Kubelet is not ready
 			return false
-		} else if condition.Type == v1.NodeDiskPressure && condition.Status != v1.ConditionFalse {
-			// If DiskPressure has occurred on node
-			return false
+		}
+		conditions := strings.Split(c.nodeConditions, ",")
+		for _, c := range conditions {
+			if string(condition.Type) == c && condition.Status != v1.ConditionFalse {
+				return false
+			}
 		}
 	}
 	return true

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -139,6 +139,7 @@ var _ = Describe("machine", func() {
 			}
 			c = &controller{
 				controlMachineClient: fakeMachineClient,
+				nodeConditions:       "ReadonlyFilesystem,KernelDeadlock,DiskPressure",
 			}
 		})
 

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -78,6 +78,9 @@ type MachineControllerManagerConfiguration struct {
 
 	// SafetyOptions is the set of options to set to ensure safety of controller
 	SafetyOptions SafetyOptions
+
+	//NodeCondition is the string of known NodeConditions. If any of these NodeCondition is set for a timeout period, the machine  will be declared failed and will replaced.
+	NodeConditions string
 }
 
 // SafetyOptions are used to configure the upper-limit and lower-limit


### PR DESCRIPTION
**What this PR does / why we need it**: This PR makes the node-conditions configurable, based on which machines are replaced.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Node-conditions are configurable via flag. Users can provide the list of node-conditions based on which machines are replaced if set to true for health-timeout period.
```
