### PR TITLE
Remove deprecated fields publisher,offer,sku,version

### DIFF
--- a/kubernetes/machine_classes/azure-machine-class.yaml
+++ b/kubernetes/machine_classes/azure-machine-class.yaml
@@ -24,10 +24,6 @@ spec:
       vmSize: "sample-azure-vm-size" # VMsize based on azure machine kinds (Eg- Standard_DS1_V2)
     storageProfile:
       imageReference:
-        publisher: "image-reference-publisher" # DEPRECATED: Image reference publisher (Eg- CoreOS)
-        offer: "image-reference-offer" # DEPRECATED: Image reference offer (Eg- CoreOS)
-        sku: "image-reference-sku" # DEPRECATED: Image reference sku (Eg- Beta)
-        version: "image-reference-version" # DEPRECATED: Image reference version (Eg- 1000.0.0)
         urn: "image-reference-urn" # Image reference urn, it has the format 'publisher:offer:sku:version' (Eg- "CoreOS:CoreOS:Beta:1000.0.0")
       osDisk:
         caching: "None" # Caching Strategy (None/ReadOnly/ReadWrite)

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -884,12 +884,8 @@ type AzureStorageProfile struct {
 // marketplace images, or virtual machine images. This element is required when you want to use a platform image,
 // marketplace image, or virtual machine image, but is not used in other creation operations.
 type AzureImageReference struct {
-	ID        string
-	Publisher string
-	Offer     string
-	Sku       string
-	Version   string
-	URN       *string
+	ID  string
+	URN *string
 }
 
 // AzureOSDisk is specifies information about the operating system disk used by the virtual machine. <br><br> For more

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -966,14 +966,6 @@ type AzureStorageProfile struct {
 // marketplace image, or virtual machine image, but is not used in other creation operations.
 type AzureImageReference struct {
 	ID string `json:"id,omitempty"`
-	// DEPRECATED: This field will be removed in a future version.
-	Publisher string `json:"publisher,omitempty"`
-	// DEPRECATED: This field will be removed in a future version.
-	Offer string `json:"offer,omitempty"`
-	// DEPRECATED: This field will be removed in a future version.
-	Sku string `json:"sku,omitempty"`
-	// DEPRECATED: This field will be removed in a future version.
-	Version string `json:"version,omitempty"`
 	// Uniform Resource Name of the OS image to be used , it has the format 'publisher:offer:sku:version'
 	URN *string `json:"urn,omitempty"`
 }

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -1089,10 +1089,6 @@ func Convert_machine_AzureHardwareProfile_To_v1alpha1_AzureHardwareProfile(in *m
 
 func autoConvert_v1alpha1_AzureImageReference_To_machine_AzureImageReference(in *AzureImageReference, out *machine.AzureImageReference, s conversion.Scope) error {
 	out.ID = in.ID
-	out.Publisher = in.Publisher
-	out.Offer = in.Offer
-	out.Sku = in.Sku
-	out.Version = in.Version
 	out.URN = (*string)(unsafe.Pointer(in.URN))
 	return nil
 }
@@ -1104,10 +1100,6 @@ func Convert_v1alpha1_AzureImageReference_To_machine_AzureImageReference(in *Azu
 
 func autoConvert_machine_AzureImageReference_To_v1alpha1_AzureImageReference(in *machine.AzureImageReference, out *AzureImageReference, s conversion.Scope) error {
 	out.ID = in.ID
-	out.Publisher = in.Publisher
-	out.Offer = in.Offer
-	out.Sku = in.Sku
-	out.Version = in.Version
 	out.URN = (*string)(unsafe.Pointer(in.URN))
 	return nil
 }

--- a/pkg/apis/machine/validation/azuremachineclass.go
+++ b/pkg/apis/machine/validation/azuremachineclass.go
@@ -98,18 +98,7 @@ func validateAzureProperties(properties machine.AzureVirtualMachineProperties, f
 	}
 
 	if properties.StorageProfile.ImageReference.URN == nil || *properties.StorageProfile.ImageReference.URN == "" {
-		if properties.StorageProfile.ImageReference.Publisher == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference.publisher"), "Image publisher is required"))
-		}
-		if properties.StorageProfile.ImageReference.Offer == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference.offer"), "Image offer is required"))
-		}
-		if properties.StorageProfile.ImageReference.Sku == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference.sku"), "Image sku is required"))
-		}
-		if properties.StorageProfile.ImageReference.Version == "" {
-			allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference.version"), "Image version is required"))
-		}
+		allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference.urn"), "Empty urn"))
 	} else {
 		splits := strings.Split(*properties.StorageProfile.ImageReference.URN, ":")
 		if len(splits) != 4 {

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -166,24 +166,12 @@ func (d *AzureDriver) getVMParameters(vmName string, networkInterfaceReferenceID
 	return VMParameters
 }
 
-func isUrnProvided(d *AzureDriver) bool {
-	return d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.URN != nil &&
-		*d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.URN != ""
-}
-
 func getAzureImageDetails(d *AzureDriver) (publisher, offer, sku, version string) {
-	if isUrnProvided(d) {
-		splits := strings.Split(*d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.URN, ":")
-		publisher = splits[0]
-		offer = splits[1]
-		sku = splits[2]
-		version = splits[3]
-		return
-	}
-	publisher = d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.Publisher
-	offer = d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.Offer
-	sku = d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.Sku
-	version = d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.Version
+	splits := strings.Split(*d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.URN, ":")
+	publisher = splits[0]
+	offer = splits[1]
+	sku = splits[2]
+	version = splits[3]
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -606,34 +606,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format: "",
 							},
 						},
-						"publisher": {
-							SchemaProps: spec.SchemaProps{
-								Description: "DEPRECATED: This field will be removed in a future version.",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
-						"offer": {
-							SchemaProps: spec.SchemaProps{
-								Description: "DEPRECATED: This field will be removed in a future version.",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
-						"sku": {
-							SchemaProps: spec.SchemaProps{
-								Description: "DEPRECATED: This field will be removed in a future version.",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
-						"version": {
-							SchemaProps: spec.SchemaProps{
-								Description: "DEPRECATED: This field will be removed in a future version.",
-								Type:        []string{"string"},
-								Format:      "",
-							},
-						},
 						"urn": {
 							SchemaProps: spec.SchemaProps{
 								Description: "Uniform Resource Name of the OS image to be used , it has the format 'publisher:offer:sku:version'",


### PR DESCRIPTION
**What this PR does / why we need it**:
As follow up on #326, remove deprecated fields.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```action user
Since version `0.22.0` the fields `Spec.Properties.StorageProfile.ImageReference.[Publisher|Offer|Sku|Version]` in the `AzureMachineClass have been deprecated and now they are completely removed. Please switch to `Spec.Properties.StorageProfile.ImageReference.URN` before upgrading to this version or higher.
```
