### PR TITLE
OpenStack: Ensure VMs are deleted after unsuccessful create operation

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -354,6 +354,13 @@ func (c *controller) machineCreate(machine *v1alpha1.Machine, driver driver.Driv
 			LastUpdateTime: metav1.Now(),
 		}
 		c.updateMachineStatus(machine, lastOperation, currentStatus)
+
+		// make sure that the failed machine doesn't exist
+		if e := driver.Delete(); e != nil {
+			message := fmt.Sprintf("Error deleting machine %s (%s) after unsuccessful create attempt: %s", machine.Name, e.Error(), err.Error())
+			return errors.New(message)
+		}
+
 		return err
 	}
 	glog.V(2).Infof("Created machine: %q, MachineID: %s", machine.Name, actualProviderID)

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -354,13 +354,6 @@ func (c *controller) machineCreate(machine *v1alpha1.Machine, driver driver.Driv
 			LastUpdateTime: metav1.Now(),
 		}
 		c.updateMachineStatus(machine, lastOperation, currentStatus)
-
-		// make sure that the failed machine doesn't exist
-		if e := driver.Delete(); e != nil {
-			message := fmt.Sprintf("Error deleting machine %s (%s) after unsuccessful create attempt: %s", machine.Name, e.Error(), err.Error())
-			return errors.New(message)
-		}
-
 		return err
 	}
 	glog.V(2).Infof("Created machine: %q, MachineID: %s", machine.Name, actualProviderID)

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -165,7 +165,7 @@ func (d *OpenStackDriver) Delete() error {
 	result := servers.Delete(client, machineID)
 	if result.Err == nil {
 		// waiting for the machine to be deleted to release consumed quota resources, 5 minutes should be enough
-		err = waitForStatus(client, machineID, []string{}, []string{"DELETED", "SOFT_DELETED"}, 300)
+		err = waitForStatus(client, machineID, nil, []string{"DELETED", "SOFT_DELETED"}, 300)
 		if err != nil {
 			return fmt.Errorf("error waiting for the %q server to be deleted: %s", machineID, err)
 		}
@@ -449,7 +449,7 @@ func waitForStatus(c *gophercloud.ServiceClient, id string, pending []string, ta
 		}
 
 		// if there is no pending statuses defined or current status is in the pending list, then continue polling
-		if len(pending) == 0 || strSliceContains(pending, current.Status) {
+		if pending == nil || len(pending) == 0 || strSliceContains(pending, current.Status) {
 			return false, nil
 		}
 

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -49,6 +49,15 @@ type OpenStackDriver struct {
 	MachineName           string
 }
 
+// deleteOnFail method is used to delete the VM, which was created with an error
+func (d *OpenStackDriver) deleteOnFail(err error) error {
+	// this method is called after the d.MachineID has been set
+	if e := d.Delete(); e != nil {
+		return fmt.Errorf("Error deleting machine %s (%s) after unsuccessful create attempt: %s", d.MachineID, e.Error(), err.Error())
+	}
+	return err
+}
+
 // Create method is used to create an OS machine
 func (d *OpenStackDriver) Create() (string, string, error) {
 
@@ -104,12 +113,12 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 
 	nwClient, err := d.createNeutronClient()
 	if err != nil {
-		return "", "", err
+		return "", "", d.deleteOnFail(err)
 	}
 
 	err = waitForStatus(client, server.ID, []string{"BUILD"}, []string{"ACTIVE"}, 600)
 	if err != nil {
-		return "", "", fmt.Errorf("error waiting for the %q server status: %s", server.ID, err)
+		return "", "", d.deleteOnFail(fmt.Errorf("error waiting for the %q server status: %s", server.ID, err))
 	}
 
 	listOpts := &ports.ListOpts{
@@ -120,17 +129,17 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	allPages, err := ports.List(nwClient, listOpts).AllPages()
 	if err != nil {
 		metrics.APIFailedRequestCount.With(prometheus.Labels{"provider": "openstack", "service": "neutron"}).Inc()
-		return "", "", fmt.Errorf("failed to get ports for network ID %s: %s", networkID, err)
+		return "", "", d.deleteOnFail(fmt.Errorf("failed to get ports for network ID %s: %s", networkID, err))
 	}
 	metrics.APIRequestCount.With(prometheus.Labels{"provider": "openstack", "service": "neutron"}).Inc()
 
 	allPorts, err := ports.ExtractPorts(allPages)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to extract ports for network ID %s: %s", networkID, err)
+		return "", "", d.deleteOnFail(fmt.Errorf("failed to extract ports for network ID %s: %s", networkID, err))
 	}
 
 	if len(allPorts) == 0 {
-		return "", "", fmt.Errorf("got an empty port list for network ID %s and server ID %s", networkID, server.ID)
+		return "", "", d.deleteOnFail(fmt.Errorf("got an empty port list for network ID %s and server ID %s", networkID, server.ID))
 	}
 
 	port, err := ports.Update(nwClient, allPorts[0].ID, ports.UpdateOpts{
@@ -138,7 +147,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	}).Extract()
 	if err != nil {
 		metrics.APIFailedRequestCount.With(prometheus.Labels{"provider": "openstack", "service": "neutron"}).Inc()
-		return "", "", fmt.Errorf("failed to update allowed address pair for port ID %s: %s", port.ID, err)
+		return "", "", d.deleteOnFail(fmt.Errorf("failed to update allowed address pair for port ID %s: %s", port.ID, err))
 	}
 	metrics.APIRequestCount.With(prometheus.Labels{"provider": "openstack", "service": "neutron"}).Inc()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

New logic ensures that the machine resources after the failed create process are purged. If there are no VMs, the `Delete()` method will return nil.

In addition in OpenStack environment, the `Delete()` method will wait until the machine resource is actually deleted, before creating a new machine. This can avoid quota limit exceptions.

**Which issue(s) this PR fixes**:
Fixes #355 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
- improvement: OpenStack: Ensure VMs are deleted after unsuccessful create operation
```
