### PR TITLE
Add missing install pkg

### DIFF
--- a/pkg/apis/machine/install/install.go
+++ b/pkg/apis/machine/install/install.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package install
+
+import (
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine"
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// Install registers the API group and adds types to a scheme.
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(machine.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(scheme.SetVersionPriority(v1alpha1.SchemeGroupVersion))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The generated `pkg/client/clientset/internalversion/scheme/register.go`

https://github.com/gardener/machine-controller-manager/blob/f08fa09972caae2df8e407f2737645f085c9e7e6/pkg/client/clientset/internalversion/scheme/register.go#L5-L11

has import to package `pkg/apis/machine/install` which is currently missing. That's why the vendoring currently with go@1.13 fails.


g/g has this install.go - https://github.com/gardener/gardener/blob/0.31.2/pkg/apis/garden/install/install.go
k/sample-apiserver has this install.go - https://github.com/kubernetes/sample-apiserver/blob/kubernetes-1.16.3/pkg/apis/wardle/install/install.go

**Which issue(s) this PR fixes**:
Ref #358 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
