### PR TITLE
Increase MaxEvictRetries and PodEvictionRetryInterval

### DIFF
--- a/pkg/controller/drain_test.go
+++ b/pkg/controller/drain_test.go
@@ -159,7 +159,7 @@ var _ = Describe("drain", func() {
 			}
 
 			if err != nil {
-				fmt.Fprintf(GinkgoWriter, "Error simulating evition for the pod %s/%s: %s", pod.Namespace, pod.Name, err)
+				fmt.Fprintf(GinkgoWriter, "Error simulating eviction for the pod %s/%s: %s", pod.Namespace, pod.Name, err)
 			}
 		}
 
@@ -642,7 +642,7 @@ var _ = Describe("drain", func() {
 				},
 				attemptEviction:        false,
 				terminationGracePeriod: terminationGracePeriodShort,
-				force:                  true,
+				force: true,
 			},
 			nil,
 			&expectation{
@@ -668,7 +668,7 @@ var _ = Describe("drain", func() {
 				},
 				attemptEviction:        true,
 				terminationGracePeriod: terminationGracePeriodShort,
-				force:                  true,
+				force: true,
 			},
 			[]podDrainHandler{deletePod},
 			&expectation{
@@ -695,8 +695,8 @@ var _ = Describe("drain", func() {
 				maxEvictRetries:        1,
 				attemptEviction:        true,
 				terminationGracePeriod: terminationGracePeriodShort,
-				force:                  true,
-				evictError:             apierrors.NewTooManyRequestsError(""),
+				force:      true,
+				evictError: apierrors.NewTooManyRequestsError(""),
 			},
 			nil,
 			&expectation{
@@ -707,7 +707,7 @@ var _ = Describe("drain", func() {
 					nPodsWithExclusiveAndSharedPV: 0,
 				},
 				timeout:          terminationGracePeriodMedium,
-				drainTimeout:     false,
+				drainTimeout:     true,
 				drainError:       nil,
 				nEvictions:       0,
 				minDrainDuration: 0,

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -491,7 +492,7 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 				forceDeletePods         = false
 				forceDeleteMachine      = false
 				timeOutOccurred         = false
-				maxEvictRetries         = c.safetyOptions.MaxEvictRetries
+				maxEvictRetries         = int32(math.Min(float64(c.safetyOptions.MaxEvictRetries), c.safetyOptions.MachineDrainTimeout.Duration.Seconds()/PodEvictionRetryInterval.Seconds()))
 				pvDetachTimeOut         = c.safetyOptions.PvDetachTimeout.Duration
 				timeOutDuration         = c.safetyOptions.MachineDrainTimeout.Duration
 				forceDeleteLabelPresent = machine.Labels["force-deletion"] == "True"


### PR DESCRIPTION
**What this PR does / why we need it**: This PR further improves the drain logic by increasing PodEvictionRetryInterval to 20s and MaxEvictRetries till drain-timeout occurs.
- We have identified, PDBs could be violated if eviction retries are capped to a smaller value.

**Which issue(s) this PR fixes**:
Partially solves:  [#1673](https://github.com/gardener/gardener/issues/1673)

**Special notes for your reviewer**: 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Drain logic now attempts to evict the pod till drain-timeout has occurred. The interval between consecutive attempts to evict the pod has been increased to 20s.
```
