### PR TITLE
Avoid force-deleting if previous drain has failed

### DIFF
--- a/pkg/controller/drain.go
+++ b/pkg/controller/drain.go
@@ -175,6 +175,7 @@ func (o *DrainOptions) RunDrain() error {
 	}()
 
 	if err := o.RunCordonOrUncordon(true); err != nil {
+		glog.Errorf("Drain Error: Cordoninig of node failed with error: %v", err)
 		return err
 	}
 
@@ -942,7 +943,7 @@ func (o *DrainOptions) RunCordonOrUncordon(desired bool) error {
 	}
 	unsched := node.Spec.Unschedulable
 	if unsched == desired {
-		glog.V(3).Info("Already desired")
+		glog.V(3).Infof("Already desired state of cordoning or uncordoning for node: %q", node.Name)
 	} else {
 		clone := node.DeepCopy()
 		clone.Spec.Unschedulable = desired

--- a/pkg/controller/drain.go
+++ b/pkg/controller/drain.go
@@ -175,7 +175,7 @@ func (o *DrainOptions) RunDrain() error {
 	}()
 
 	if err := o.RunCordonOrUncordon(true); err != nil {
-		glog.Errorf("Drain Error: Cordoninig of node failed with error: %v", err)
+		glog.Errorf("Drain Error: Cordoning of node failed with error: %v", err)
 		return err
 	}
 
@@ -943,7 +943,7 @@ func (o *DrainOptions) RunCordonOrUncordon(desired bool) error {
 	}
 	unsched := node.Spec.Unschedulable
 	if unsched == desired {
-		glog.V(3).Infof("Already desired state of cordoning or uncordoning for node: %q", node.Name)
+		glog.V(3).Infof("Scheduling state for node %q is already in desired state", node.Name)
 	} else {
 		clone := node.DeepCopy()
 		clone.Spec.Unschedulable = desired

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -503,7 +503,7 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 			timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.Status.CurrentStatus.LastUpdateTime.Time)
 			timeOutOccurred = timeOut > 0
 
-			if forceDeleteLabelPresent || timeOutOccurred || lastDrainFailed {
+			if forceDeleteLabelPresent || timeOutOccurred {
 				// To perform forceful machine drain/delete either one of the below conditions must be satified
 				// 1. force-deletion: "True" label must be present
 				// 2. Deletion operation is more than drain-timeout minutes old

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -496,7 +496,6 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 				pvDetachTimeOut         = c.safetyOptions.PvDetachTimeout.Duration
 				timeOutDuration         = c.safetyOptions.MachineDrainTimeout.Duration
 				forceDeleteLabelPresent = machine.Labels["force-deletion"] == "True"
-				lastDrainFailed         = machine.Status.LastOperation.Description[0:12] == "Drain failed"
 			)
 
 			// Timeout value obtained by subtracting last operation with expected time out period
@@ -507,18 +506,16 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 				// To perform forceful machine drain/delete either one of the below conditions must be satified
 				// 1. force-deletion: "True" label must be present
 				// 2. Deletion operation is more than drain-timeout minutes old
-				// 3. Last machine drain had failed
 				forceDeleteMachine = true
 				forceDeletePods = true
 				timeOutDuration = 1 * time.Minute
 				maxEvictRetries = 1
 
 				glog.V(2).Infof(
-					"Force deletion has been triggerred for machine %q due to Label:%t, timeout:%t, lastDrainFailed:%t",
+					"Force deletion has been triggerred for machine %q due to ForceDeletionLabel:%t, Timeout:%t",
 					machine.Name,
 					forceDeleteLabelPresent,
 					timeOutOccurred,
-					lastDrainFailed,
 				)
 			}
 

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -1122,8 +1122,8 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					errOccurred:    false,
-					machineDeleted: true,
+					errOccurred:    true,
+					machineDeleted: false,
 				},
 			}),
 		)


### PR DESCRIPTION
**What this PR does / why we need it**: This PR skips the force-deletion of the machine when the previous drain has failed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Avoided force-deleting the machine if previous drain has failed.
```
