### PR TITLE
Activate healthz earlier

### DIFF
--- a/cmd/machine-controller-manager/app/controllermanager.go
+++ b/cmd/machine-controller-manager/app/controllermanager.go
@@ -364,6 +364,7 @@ func startHTTP(s *options.MCMServer) {
 	}
 	configz.InstallHandler(mux)
 	mux.Handle("/metrics", prometheus.Handler())
+	handlers.UpdateHealth(true)
 	mux.HandleFunc("/healthz", handlers.Healthz)
 
 	server := &http.Server{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -482,7 +482,6 @@ func (c *controller) Run(workers int, stopCh <-chan struct{}) {
 	}
 
 	glog.V(1).Info("Starting machine-controller-manager")
-	handlers.UpdateHealth(true)
 
 	// The controller implement the prometheus.Collector interface and can therefore
 	// be passed to the metrics registry. Collectors which added to the registry


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, due to failed leader election (in the case of multiple machine-controller-managers), the liveness probe will constantly restart a container, which is confusing at best and may trip a monitoring system. Also, it makes no sense to not enable liveness probe immediately. Liveness probe should start to fail once a program transitions into a state, in which it won't be able to continue operating correctly, and it needs to be shut down externally.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       noteworthy
- target_group:   user|operator|developer
-->
```noteworthy operator
Healthz endpoint is immediately initialized with a healty (200) response
```