### PR TITLE
Added GitHub Docker build and push action

### DIFF
--- a/.github/workflows/docker_push.yaml
+++ b/.github/workflows/docker_push.yaml
@@ -1,0 +1,72 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+      - '**'
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: machine-controller-manager
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Run tests
+        run: |
+          echo "test run goes here"
+
+  # Push image to GitHub Package Registry.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    # needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag image
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          if [ "$VERSION" == "master" ]; then
+            VERSION=latest
+          else
+            VERSION="${{ github.sha }}"
+          fi
+          
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a GitHub action which builds (and potentially tests) and pushes a Docker image on each commit into a users own package repository on GH. Here it doesn't matter if it is on master or a specific branch.

In case of a master branch push the `latest` tag is updated. For a branch commit the corresponding `sha` is used as a tag.

**Why?** 
This GH action can conveniently be used on forks and publishes an image into a users local package repository.

E.g. for a commit into a users fork branch `feature/added_docker_action` the resulting image will be located here:
```shell
docker pull docker.pkg.github.com/${USER/ORG}/machine-controller-manager/machine-controller-manager:a8618041d1f44c4ff018777ada2e077661e7b0dd
```

This allows an easy use of the MCM in a forked testing environment as those org/user images can be used in your own deployment manifests.

**Release note**:
```improvement developer
Added GitHub Docker build and push action
```
