### PR TITLE
Added Cinder based Custom Root Disks for OpenStack Vms

### DIFF
--- a/kubernetes/machine_classes/openstack-machine-class.yaml
+++ b/kubernetes/machine_classes/openstack-machine-class.yaml
@@ -16,6 +16,7 @@ spec:
   region: <region> # Region where to place the machine
   availabilityZone: <availability_zone> # Availability zone where to place the machine
   podNetworkCidr: <pod_network_cidr> # CIDR of the overlay Calico IP pool
+  # rootDiskSize: 100 # in GB (optional) overrides the flavor provider root disk size and use a Cinder backed block device instead
   # OpenStack machine metadata block
   # Be aware, that metadata keys (tags) in OpenStack can not contain special characters likes "/"
   tags:

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -673,6 +673,7 @@ type OpenStackMachineClassSpec struct {
 	Networks         []OpenStackNetwork
 	SecretRef        *corev1.SecretReference
 	PodNetworkCidr   string
+	RootDiskSize     int // in GB
 }
 
 type OpenStackNetwork struct {

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -742,6 +742,7 @@ type OpenStackMachineClassSpec struct {
 	Networks         []OpenStackNetwork      `json:"networks,omitempty"`
 	SecretRef        *corev1.SecretReference `json:"secretRef,omitempty"`
 	PodNetworkCidr   string                  `json:"podNetworkCidr"`
+	RootDiskSize     int                     `json:"rootDiskSize,omitempty"` // in GB
 }
 
 type OpenStackNetwork struct {

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -2536,6 +2536,7 @@ func autoConvert_v1alpha1_OpenStackMachineClassSpec_To_machine_OpenStackMachineC
 	out.Networks = *(*[]machine.OpenStackNetwork)(unsafe.Pointer(&in.Networks))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
+	out.RootDiskSize = in.RootDiskSize
 	return nil
 }
 
@@ -2557,6 +2558,7 @@ func autoConvert_machine_OpenStackMachineClassSpec_To_v1alpha1_OpenStackMachineC
 	out.Networks = *(*[]OpenStackNetwork)(unsafe.Pointer(&in.Networks))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
+	out.RootDiskSize = in.RootDiskSize
 	return nil
 }
 

--- a/pkg/apis/machine/validation/openstackmachineclass.go
+++ b/pkg/apis/machine/validation/openstackmachineclass.go
@@ -67,6 +67,9 @@ func validateOpenStackMachineClassSpec(spec *machine.OpenStackMachineClassSpec, 
 	if "" == spec.PodNetworkCidr {
 		allErrs = append(allErrs, field.Required(fldPath.Child("podNetworkCidr"), "PodNetworkCidr is required"))
 	}
+	if spec.RootDiskSize < 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("rootDiskSize"), "RootDiskSize can not be negative"))
+	}
 
 	allErrs = append(allErrs, validateOsNetworks(spec.Networks, spec.PodNetworkCidr, field.NewPath("spec.networks"))...)
 	allErrs = append(allErrs, validateSecretRef(spec.SecretRef, field.NewPath("spec.secretRef"))...)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2597,6 +2597,12 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 								Format: "",
 							},
 						},
+						"rootDiskSize": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"integer"},
+								Format: "int32",
+							},
+						},
 					},
 					Required: []string{"imageID", "imageName", "region", "availabilityZone", "flavorName", "keyName", "securityGroups", "networkID", "podNetworkCidr"},
 				},

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/doc.go
@@ -1,0 +1,152 @@
+/*
+Package bootfromvolume extends a server create request with the ability to
+specify block device options. This can be used to boot a server from a block
+storage volume as well as specify multiple ephemeral disks upon creation.
+
+It is recommended to refer to the Block Device Mapping documentation to see
+all possible ways to configure a server's block devices at creation time:
+
+https://docs.openstack.org/nova/latest/user/block-device-mapping.html
+
+Note that this package implements `block_device_mapping_v2`.
+
+Example of Creating a Server From an Image
+
+This example will boot a server from an image and use a standard ephemeral
+disk as the server's root disk. This is virtually no different than creating
+a server without using block device mappings.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From a New Volume
+
+This example will create a block storage volume based on the given Image. The
+server will use this volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          2,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server From an Existing Volume
+
+This example will create a server with an existing volume as its root disk.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			DeleteOnTermination: true,
+			DestinationType:     bootfromvolume.DestinationVolume,
+			SourceType:          bootfromvolume.SourceVolume,
+			UUID:                "volume-uuid",
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example of Creating a Server with Multiple Ephemeral Disks
+
+This example will create a server with multiple ephemeral disks. The first
+block device will be based off of an existing Image. Each additional
+ephemeral disks must have an index of -1.
+
+	blockDevices := []bootfromvolume.BlockDevice{
+		bootfromvolume.BlockDevice{
+			BootIndex:           0,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			SourceType:          bootfromvolume.SourceImage,
+			UUID:                "image-uuid",
+			VolumeSize:          5,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+		bootfromvolume.BlockDevice{
+			BootIndex:           -1,
+			DestinationType:     bootfromvolume.DestinationLocal,
+			DeleteOnTermination: true,
+			GuestFormat:         "ext4",
+			SourceType:          bootfromvolume.SourceBlank,
+			VolumeSize:          1,
+		},
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		FlavorRef: "flavor-uuid",
+		ImageRef:  "image-uuid",
+	}
+
+	createOpts := bootfromvolume.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		BlockDevice:       blockDevices,
+	}
+
+	server, err := bootfromvolume.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package bootfromvolume

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/requests.go
@@ -1,0 +1,132 @@
+package bootfromvolume
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+type (
+	// DestinationType represents the type of medium being used as the
+	// destination of the bootable device.
+	DestinationType string
+
+	// SourceType represents the type of medium being used as the source of the
+	// bootable device.
+	SourceType string
+)
+
+const (
+	// DestinationLocal DestinationType is for using an ephemeral disk as the
+	// destination.
+	DestinationLocal DestinationType = "local"
+
+	// DestinationVolume DestinationType is for using a volume as the destination.
+	DestinationVolume DestinationType = "volume"
+
+	// SourceBlank SourceType is for a "blank" or empty source.
+	SourceBlank SourceType = "blank"
+
+	// SourceImage SourceType is for using images as the source of a block device.
+	SourceImage SourceType = "image"
+
+	// SourceSnapshot SourceType is for using a volume snapshot as the source of
+	// a block device.
+	SourceSnapshot SourceType = "snapshot"
+
+	// SourceVolume SourceType is for using a volume as the source of block
+	// device.
+	SourceVolume SourceType = "volume"
+)
+
+// BlockDevice is a structure with options for creating block devices in a
+// server. The block device may be created from an image, snapshot, new volume,
+// or existing volume. The destination may be a new volume, existing volume
+// which will be attached to the instance, ephemeral disk, or boot device.
+type BlockDevice struct {
+	// SourceType must be one of: "volume", "snapshot", "image", or "blank".
+	SourceType SourceType `json:"source_type" required:"true"`
+
+	// UUID is the unique identifier for the existing volume, snapshot, or
+	// image (see above).
+	UUID string `json:"uuid,omitempty"`
+
+	// BootIndex is the boot index. It defaults to 0.
+	BootIndex int `json:"boot_index"`
+
+	// DeleteOnTermination specifies whether or not to delete the attached volume
+	// when the server is deleted. Defaults to `false`.
+	DeleteOnTermination bool `json:"delete_on_termination"`
+
+	// DestinationType is the type that gets created. Possible values are "volume"
+	// and "local".
+	DestinationType DestinationType `json:"destination_type,omitempty"`
+
+	// GuestFormat specifies the format of the block device.
+	GuestFormat string `json:"guest_format,omitempty"`
+
+	// VolumeSize is the size of the volume to create (in gigabytes). This can be
+	// omitted for existing volumes.
+	VolumeSize int `json:"volume_size,omitempty"`
+
+	// DeviceType specifies the device type of the block devices.
+	// Examples of this are disk, cdrom, floppy, lun, etc.
+	DeviceType string `json:"device_type,omitempty"`
+
+	// DiskBus is the bus type of the block devices.
+	// Examples of this are ide, usb, virtio, scsi, etc.
+	DiskBus string `json:"disk_bus,omitempty"`
+
+	// VolumeType is the volume type of the block device.
+	// This requires Compute API microversion 2.67 or later.
+	VolumeType string `json:"volume_type,omitempty"`
+}
+
+// CreateOptsExt is a structure that extends the server `CreateOpts` structure
+// by allowing for a block device mapping.
+type CreateOptsExt struct {
+	servers.CreateOptsBuilder
+	BlockDevice []BlockDevice `json:"block_device_mapping_v2,omitempty"`
+}
+
+// ToServerCreateMap adds the block device mapping option to the base server
+// creation options.
+func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToServerCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(opts.BlockDevice) == 0 {
+		err := gophercloud.ErrMissingInput{}
+		err.Argument = "bootfromvolume.CreateOptsExt.BlockDevice"
+		return nil, err
+	}
+
+	serverMap := base["server"].(map[string]interface{})
+
+	blockDevice := make([]map[string]interface{}, len(opts.BlockDevice))
+
+	for i, bd := range opts.BlockDevice {
+		b, err := gophercloud.BuildRequestBody(bd, "")
+		if err != nil {
+			return nil, err
+		}
+		blockDevice[i] = b
+	}
+	serverMap["block_device_mapping_v2"] = blockDevice
+
+	return base, nil
+}
+
+// Create requests the creation of a server from the given block device mapping.
+func Create(client *gophercloud.ServiceClient, opts servers.CreateOptsBuilder) (r servers.CreateResult) {
+	b, err := opts.ToServerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/results.go
@@ -1,0 +1,12 @@
+package bootfromvolume
+
+import (
+	os "github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+// CreateResult temporarily contains the response from a Create call.
+// It embeds the standard servers.CreateResults type and so can be used the
+// same way as a standard server request result.
+type CreateResult struct {
+	os.CreateResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume/urls.go
@@ -1,0 +1,7 @@
+package bootfromvolume
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("os-volumes_boot")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -114,6 +114,7 @@ github.com/googleapis/gnostic/extensions
 # github.com/gophercloud/gophercloud v0.7.0
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
+github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs
 github.com/gophercloud/gophercloud/openstack/compute/v2/flavors
 github.com/gophercloud/gophercloud/openstack/compute/v2/images


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the OpenStack MachineClass to support custom root disk size. It does this by adding a Cinder based root disk volume to the VM created via MCM.

To configure the root disk size the manifest looks like the following

```shell
apiVersion: machine.sapcloud.io/v1alpha1
kind: OpenStackMachineClass
metadata:
  name: test-openstack # Name of OpenStack machine class goes here
  namespace: default # Namespace in which the machine class is to be deployed
spec:
  ...
  rootDiskSize: 100 # 100 GB 
```

The creation policy for the Cinder volume is `DeleteOnTermination` meaning that the volume gets removed when the machine is terminated.

**Which issue(s) this PR fixes**:
Fixes #386 

**Release note**:
```improvement operator
Added Cinder based root disk support with customisable disk size 
```
