### PR TITLE
Bugfix: Fixed regressions from PR-379

### DIFF
--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -269,7 +269,7 @@ func (d *AWSDriver) GetVMs(machineID string) (VMs, error) {
 	}
 
 	svc, err := d.createSVC()
-	if svc != nil {
+	if err != nil {
 		return listOfVMs, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes regressions from PR 379 where an error handling was wrongly handled causing orphan VMs. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
