### PR TITLE
Don't requeue machine key if error returned is "not found"

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -157,6 +157,10 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 	machine, err = c.controlMachineClient.Machines(machine.Namespace).Get(machine.Name, metav1.GetOptions{})
 	if err != nil {
 		glog.Errorf("Could not fetch machine object %s", err)
+		if apierrors.IsNotFound(err) {
+			// Ignore the error "Not Found"
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't requeue machine key if it not found

**Which issue(s) this PR fixes**:
Fixes #402 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Stops reconciling machine objects that no longer exists
```
