### PR TITLE
Prepend mcm to all work queue metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,6 +20,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+const (
+	namespace                  = "mcm"
+	machineSubsystem           = "machine"
+	machinesetSubsystem        = "machine_set"
+	machinedeploymentSubsystem = "machine_deployment"
+	cloudAPISubsystem          = "cloud_api"
+)
+
 var (
 	// MachineControllerFrozenDesc is a metric about MachineController's frozen status
 	MachineControllerFrozenDesc = prometheus.NewDesc("mcm_machine_controller_frozen", "Frozen status of the machine controller manager.", nil, nil)
@@ -28,21 +36,27 @@ var (
 
 	//MachineCSPhase Current status phase of the Machines currently managed by the mcm.
 	MachineCSPhase = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_current_status_phase",
-		Help: "Current status phase of the Machines currently managed by the mcm.",
+		Namespace: namespace,
+		Subsystem: machineSubsystem,
+		Name:      "current_status_phase",
+		Help:      "Current status phase of the Machines currently managed by the mcm.",
 	}, []string{"name", "namespace"})
 
 	//MachineInfo Information of the Machines currently managed by the mcm.
 	MachineInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_info",
-		Help: "Information of the Machines currently managed by the mcm.",
+		Namespace: namespace,
+		Subsystem: machineSubsystem,
+		Name:      "info",
+		Help:      "Information of the Machines currently managed by the mcm.",
 	}, []string{"name", "namespace", "createdAt",
 		"spec_provider_id", "spec_class_api_group", "spec_class_kind", "spec_class_name"})
 
 	// MachineStatusCondition Information of the mcm managed Machines' status conditions
 	MachineStatusCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_status_condition",
-		Help: "Information of the mcm managed Machines' status conditions.",
+		Namespace: namespace,
+		Subsystem: machineSubsystem,
+		Name:      "status_condition",
+		Help:      "Information of the mcm managed Machines' status conditions.",
 	}, []string{"name", "namespace", "condition"})
 
 	// MachineSetCountDesc Count of machinesets currently managed by the mcm
@@ -50,59 +64,77 @@ var (
 
 	// MachineSetInfo Information of the Machinesets currently managed by the mcm.
 	MachineSetInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_info",
-		Help: "Information of the Machinesets currently managed by the mcm.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "info",
+		Help:      "Information of the Machinesets currently managed by the mcm.",
 	}, []string{"name", "namespace", "createdAt",
 		"spec_machine_class_api_group", "spec_machine_class_kind", "spec_machine_class_name"})
 
 	// MachineSetInfoSpecReplicas Count of the Machinesets Spec Replicas.
 	MachineSetInfoSpecReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_info_spec_replicas",
-		Help: "Count of the Machinesets Spec Replicas.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "info_spec_replicas",
+		Help:      "Count of the Machinesets Spec Replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineSetInfoSpecMinReadySeconds Information of the Machinesets currently managed by the mcm.
 	MachineSetInfoSpecMinReadySeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_info_spec_min_ready_seconds",
-		Help: "Information of the Machinesets currently managed by the mcm.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "info_spec_min_ready_seconds",
+		Help:      "Information of the Machinesets currently managed by the mcm.",
 	}, []string{"name", "namespace"})
 
 	// MachineSetStatusCondition Information of the mcm managed Machinesets' status conditions.
 	MachineSetStatusCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_status_condition",
-		Help: "Information of the mcm managed Machinesets' status conditions.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "status_condition",
+		Help:      "Information of the mcm managed Machinesets' status conditions.",
 	}, []string{"name", "namespace", "condition"})
 
 	// MachineSetStatusFailedMachines Information of the mcm managed Machinesets' failed machines.
 	MachineSetStatusFailedMachines = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_failed_machines",
-		Help: "Information of the mcm managed Machinesets' failed machines.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "failed_machines",
+		Help:      "Information of the mcm managed Machinesets' failed machines.",
 	}, []string{"name", "namespace", "failed_machine_name", "failed_machine_provider_id", "failed_machine_owner_ref",
 		"failed_machine_last_operation_state",
 		"failed_machine_last_operation_machine_operation_type"})
 
 	// MachineSetStatusAvailableReplicas Information of the mcm managed Machinesets' status for available replicas.
 	MachineSetStatusAvailableReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_status_available_replicas",
-		Help: "Information of the mcm managed Machinesets' status for available replicas.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "status_available_replicas",
+		Help:      "Information of the mcm managed Machinesets' status for available replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineSetStatusFullyLabelledReplicas Information of the mcm managed Machinesets' status for fully labelled replicas.
 	MachineSetStatusFullyLabelledReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_status_fully_labelled_replicas",
-		Help: "Information of the mcm managed Machinesets' status for fully labelled replicas.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "status_fully_labelled_replicas",
+		Help:      "Information of the mcm managed Machinesets' status for fully labelled replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineSetStatusReadyReplicas Information of the mcm managed Machinesets' status for ready replicas
 	MachineSetStatusReadyReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_status_ready_replicas",
-		Help: "Information of the mcm managed Machinesets' status for ready replicas.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "status_ready_replicas",
+		Help:      "Information of the mcm managed Machinesets' status for ready replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineSetStatusReplicas Information of the mcm managed Machinesets' status for replicas.
 	MachineSetStatusReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_set_status_replicas",
-		Help: "Information of the mcm managed Machinesets' status for replicas.",
+		Namespace: namespace,
+		Subsystem: machinesetSubsystem,
+		Name:      "status_replicas",
+		Help:      "Information of the mcm managed Machinesets' status for replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentCountDesc Count of machinedeployments currently managed by the mcm.
@@ -110,126 +142,165 @@ var (
 
 	// MachineDeploymentInfo Information of the Machinedeployments currently managed by the mcm.
 	MachineDeploymentInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info",
-		Help: "Information of the Machinedeployments currently managed by the mcm.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info",
+		Help:      "Information of the Machinedeployments currently managed by the mcm.",
 	}, []string{"name", "namespace", "createdAt", "spec_strategy_type"})
 
 	// MachineDeploymentInfoSpecPaused Information of the Machinedeployments paused status.
 	MachineDeploymentInfoSpecPaused = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_paused",
-		Help: "Information of the Machinedeployments paused status.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_paused",
+		Help:      "Information of the Machinedeployments paused status.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentInfoSpecReplicas Information of the Machinedeployments spec replicas.
 	MachineDeploymentInfoSpecReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_replicas",
-		Help: "Information of the Machinedeployments spec replicas.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_replicas",
+		Help:      "Information of the Machinedeployments spec replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentInfoSpecMinReadySeconds Information of the Machinedeployments spec min ready seconds.
 	MachineDeploymentInfoSpecMinReadySeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_min_ready_seconds",
-		Help: "Information of the Machinedeployments spec min ready seconds.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_min_ready_seconds",
+		Help:      "Information of the Machinedeployments spec min ready seconds.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentInfoSpecRollingUpdateMaxSurge Information of the Machinedeployments spec rolling update max surge.
 	MachineDeploymentInfoSpecRollingUpdateMaxSurge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_rolling_update_max_surge",
-		Help: "Information of the Machinedeployments spec rolling update max surge.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_rolling_update_max_surge",
+		Help:      "Information of the Machinedeployments spec rolling update max surge.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentInfoSpecRollingUpdateMaxUnavailable Information of the Machinedeployments spec rolling update max unavailable.
 	MachineDeploymentInfoSpecRollingUpdateMaxUnavailable = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_rolling_update_max_unavailable",
-		Help: "Information of the Machinedeployments spec rolling update max unavailable.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_rolling_update_max_unavailable",
+		Help:      "Information of the Machinedeployments spec rolling update max unavailable.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentInfoSpecRevisionHistoryLimit Information of the Machinedeployments spec revision history limit.
 	MachineDeploymentInfoSpecRevisionHistoryLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_revision_history_limit",
-		Help: "Information of the Machinedeployments spec revision history limit.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_revision_history_limit",
+		Help:      "Information of the Machinedeployments spec revision history limit.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentInfoSpecProgressDeadlineSeconds Information of the Machinedeployments spec deadline seconds.
 	MachineDeploymentInfoSpecProgressDeadlineSeconds = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_progress_deadline_seconds",
-		Help: "Information of the Machinedeployments spec deadline seconds.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_progress_deadline_seconds",
+		Help:      "Information of the Machinedeployments spec deadline seconds.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentInfoSpecRollbackToRevision Information of the Machinedeployments spec rollback to revision.
 	MachineDeploymentInfoSpecRollbackToRevision = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_info_spec_rollback_to_revision",
-		Help: "Information of the Machinedeployments spec rollback to revision.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "info_spec_rollback_to_revision",
+		Help:      "Information of the Machinedeployments spec rollback to revision.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentStatusCondition Information of the mcm managed Machinedeployments' status conditions.
 	MachineDeploymentStatusCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_status_condition",
-		Help: "Information of the mcm managed Machinedeployments' status conditions.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "status_condition",
+		Help:      "Information of the mcm managed Machinedeployments' status conditions.",
 	}, []string{"name", "namespace", "condition"})
 
 	// MachineDeploymentStatusAvailableReplicas Count of the mcm managed Machinedeployments available replicas.
 	MachineDeploymentStatusAvailableReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_status_available_replicas",
-		Help: "Count of the mcm managed Machinedeployments available replicas.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "status_available_replicas",
+		Help:      "Count of the mcm managed Machinedeployments available replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentStatusUnavailableReplicas Count of the mcm managed Machinedeployments unavailable replicas.
 	MachineDeploymentStatusUnavailableReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_status_unavailable_replicas",
-		Help: "Count of the mcm managed Machinedeployments unavailable replicas.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "status_unavailable_replicas",
+		Help:      "Count of the mcm managed Machinedeployments unavailable replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentStatusReadyReplicas Count of the mcm managed Machinedeployments ready replicas.
 	MachineDeploymentStatusReadyReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_status_ready_replicas",
-		Help: "Count of the mcm managed Machinedeployments ready replicas.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "status_ready_replicas",
+		Help:      "Count of the mcm managed Machinedeployments ready replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentStatusUpdatedReplicas Count of the mcm managed Machinedeployments updated replicas.
 	MachineDeploymentStatusUpdatedReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_status_updated_replicas",
-		Help: "Count of the mcm managed Machinedeployments updated replicas.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "status_updated_replicas",
+		Help:      "Count of the mcm managed Machinedeployments updated replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentStatusCollisionCount Mcm managed Machinedeployments collision count.
 	MachineDeploymentStatusCollisionCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_status_collision_count",
-		Help: "Mcm managed Machinedeployments collision count.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "status_collision_count",
+		Help:      "Mcm managed Machinedeployments collision count.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentStatusReplicas Count of the mcm managed Machinedeployments replicas.
 	MachineDeploymentStatusReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_status_replicas",
-		Help: "Count of the mcm managed Machinedeployments replicas.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "status_replicas",
+		Help:      "Count of the mcm managed Machinedeployments replicas.",
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentStatusFailedMachines Information of the mcm managed Machinedeployments' failed machines.
 	MachineDeploymentStatusFailedMachines = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "mcm_machine_deployment_failed_machines",
-		Help: "Information of the mcm managed Machinedeployments' failed machines.",
+		Namespace: namespace,
+		Subsystem: machinedeploymentSubsystem,
+		Name:      "failed_machines",
+		Help:      "Information of the mcm managed Machinedeployments' failed machines.",
 	}, []string{"name", "namespace", "failed_machine_name", "failed_machine_provider_id", "failed_machine_owner_ref",
 		"failed_machine_last_operation_state",
 		"failed_machine_last_operation_machine_operation_type"})
 
 	// APIRequestCount Number of Cloud Service API requests, partitioned by provider, and service.
 	APIRequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "mcm_cloud_api_requests_total",
-		Help: "Number of Cloud Service API requests, partitioned by provider, and service.",
+		Namespace: namespace,
+		Subsystem: cloudAPISubsystem,
+		Name:      "requests_total",
+		Help:      "Number of Cloud Service API requests, partitioned by provider, and service.",
 	}, []string{"provider", "service"},
 	)
 
 	// APIFailedRequestCount Number of Failed Cloud Service API requests, partitioned by provider, and service.
 	APIFailedRequestCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "mcm_cloud_api_requests_failed_total",
-		Help: "Number of Failed Cloud Service API requests, partitioned by provider, and service.",
+		Namespace: namespace,
+		Subsystem: cloudAPISubsystem,
+		Name:      "requests_failed_total",
+		Help:      "Number of Failed Cloud Service API requests, partitioned by provider, and service.",
 	}, []string{"provider", "service"},
 	)
 
 	// ScrapeFailedCounter is a Prometheus metric, which counts errors during metrics collection.
 	ScrapeFailedCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "mcm_scrape_failure_total",
-		Help: "Total count of scrape failures.",
+		Namespace: namespace,
+		Name:      "scrape_failure_total",
+		Help:      "Total count of scrape failures.",
 	}, []string{"kind"})
 )
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,7 +60,7 @@ var (
 	}, []string{"name", "namespace", "condition"})
 
 	// MachineSetCountDesc Count of machinesets currently managed by the mcm
-	MachineSetCountDesc = prometheus.NewDesc("mcm_machineset_items_total", "Count of machinesets currently managed by the mcm.", nil, nil)
+	MachineSetCountDesc = prometheus.NewDesc("mcm_machine_set_items_total", "Count of machinesets currently managed by the mcm.", nil, nil)
 
 	// MachineSetInfo Information of the Machinesets currently managed by the mcm.
 	MachineSetInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -138,7 +138,7 @@ var (
 	}, []string{"name", "namespace"})
 
 	// MachineDeploymentCountDesc Count of machinedeployments currently managed by the mcm.
-	MachineDeploymentCountDesc = prometheus.NewDesc("mcm_machinedeployment_items_total", "Count of machinedeployments currently managed by the mcm.", nil, nil)
+	MachineDeploymentCountDesc = prometheus.NewDesc("mcm_machine_deployment_items_total", "Count of machinedeployments currently managed by the mcm.", nil, nil)
 
 	// MachineDeploymentInfo Information of the Machinedeployments currently managed by the mcm.
 	MachineDeploymentInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/util/reflector/prometheus/prometheus.go
+++ b/pkg/util/reflector/prometheus/prometheus.go
@@ -29,52 +29,63 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const reflectorSubsystem = "reflector"
+const (
+	reflectorSubsystem = "reflector"
+	namespace          = "mcm"
+)
 
 var (
 	listsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "lists_total",
 		Help:      "Total number of API lists done by the reflectors",
 	}, []string{"name"})
 
 	listsDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "list_duration_seconds",
 		Help:      "How long an API list takes to return and decode for the reflectors",
 	}, []string{"name"})
 
 	itemsPerList = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "items_per_list",
 		Help:      "How many items an API list returns to the reflectors",
 	}, []string{"name"})
 
 	watchesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "watches_total",
 		Help:      "Total number of API watches done by the reflectors",
 	}, []string{"name"})
 
 	shortWatchesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "short_watches_total",
 		Help:      "Total number of short API watches done by the reflectors",
 	}, []string{"name"})
 
 	watchDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "watch_duration_seconds",
 		Help:      "How long an API watch takes to return and decode for the reflectors",
 	}, []string{"name"})
 
 	itemsPerWatch = prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "items_per_watch",
 		Help:      "How many items an API watch returns to the reflectors",
 	}, []string{"name"})
 
 	lastResourceVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
 		Subsystem: reflectorSubsystem,
 		Name:      "last_resource_version",
 		Help:      "Last resource version seen for the reflectors",

--- a/pkg/util/workqueue/prometheus/prometheus.go
+++ b/pkg/util/workqueue/prometheus/prometheus.go
@@ -32,6 +32,7 @@ import (
 
 // Metrics subsystem and keys used by the workqueue.
 const (
+	Namespace                  = "mcm"
 	WorkQueueSubsystem         = "workqueue"
 	DepthKey                   = "depth"
 	AddsKey                    = "adds_total"
@@ -45,6 +46,7 @@ const (
 var (
 	depth = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
+			Namespace: Namespace,
 			Subsystem: WorkQueueSubsystem,
 			Name:      DepthKey,
 			Help:      "Current depth of workqueue",
@@ -54,6 +56,7 @@ var (
 
 	adds = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
+			Namespace: Namespace,
 			Subsystem: WorkQueueSubsystem,
 			Name:      AddsKey,
 			Help:      "Total number of adds handled by workqueue",
@@ -63,6 +66,7 @@ var (
 
 	latency = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
+			Namespace: Namespace,
 			Subsystem: WorkQueueSubsystem,
 			Name:      QueueLatencyKey,
 			Help:      "How long in seconds an item stays in workqueue before being requested.",
@@ -73,6 +77,7 @@ var (
 
 	workDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
+			Namespace: Namespace,
 			Subsystem: WorkQueueSubsystem,
 			Name:      WorkDurationKey,
 			Help:      "How long in seconds processing an item from workqueue takes.",
@@ -83,6 +88,7 @@ var (
 
 	unfinished = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
+			Namespace: Namespace,
 			Subsystem: WorkQueueSubsystem,
 			Name:      UnfinishedWorkKey,
 			Help: "How many seconds of work has done that " +
@@ -95,6 +101,7 @@ var (
 
 	longestRunningProcessor = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
+			Namespace: Namespace,
 			Subsystem: WorkQueueSubsystem,
 			Name:      LongestRunningProcessorKey,
 			Help: "How many seconds has the longest running " +
@@ -105,6 +112,7 @@ var (
 
 	retries = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
+			Namespace: Namespace,
 			Subsystem: WorkQueueSubsystem,
 			Name:      RetriesKey,
 			Help:      "Total number of retries handled by workqueue",


### PR DESCRIPTION
**What this PR does / why we need it**:
Prepend MCM to all work queue metrics to make MCM metrics unique

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy operator
Prepend mcm to all work queue metrics
```
```noteworthy operator
Subsystems and Namespaces to MCM metrics
```
```noteworthy operator
Renamed mcm_machine_deployment_items_total & mcm_machine_set_items_total metrics
```