### PR TITLE
OpenStack: Print API request/response debug, when verbosity is set to 6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,10 @@ require (
 	github.com/emicklei/go-restful v2.9.6+incompatible // indirect
 	github.com/go-ini/ini v1.36.0 // indirect
 	github.com/go-openapi/spec v0.19.2
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/gophercloud/gophercloud v0.7.0
-	github.com/gophercloud/utils v0.0.0-20190527093828-25f1b77b8c03
+	github.com/gophercloud/utils v0.0.0-20200204043447-9864b6f1f12f
 	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
 	github.com/onsi/ginkgo v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -110,12 +110,12 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.2.0 h1:l6N3VoaVzTncYYW+9yOz2LJJammFZGBO13sqgEhpy9g=
 github.com/googleapis/gnostic v0.2.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
-github.com/gophercloud/gophercloud v0.0.0-20190212181753-892256c46858/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
+github.com/gophercloud/gophercloud v0.6.1-0.20191122030953-d8ac278c1c9d/go.mod h1:ozGNgr9KYOVATV5jsgHl/ceCDXGuguqOZAzoQ/2vcNM=
 github.com/gophercloud/gophercloud v0.7.0 h1:vhmQQEM2SbnGCg2/3EzQnQZ3V7+UCGy9s8exQCprNYg=
 github.com/gophercloud/gophercloud v0.7.0/go.mod h1:gmC5oQqMDOMO1t1gq5DquX/yAU808e/4mzjjDA76+Ss=
-github.com/gophercloud/utils v0.0.0-20190527093828-25f1b77b8c03 h1:QQqgDN0yxFHrhPV1BWFGP6hEZ82s18CGzu/bLQKT8RY=
-github.com/gophercloud/utils v0.0.0-20190527093828-25f1b77b8c03/go.mod h1:SZ9FTKibIotDtCrxAU/evccoyu1yhKST6hgBvwTB5Eg=
+github.com/gophercloud/utils v0.0.0-20200204043447-9864b6f1f12f h1:JCE3TtmNKlOUeXXdxLe1ipU7F0GOxcj+BenaG4uiz8Y=
+github.com/gophercloud/utils v0.0.0-20200204043447-9864b6f1f12f/go.mod h1:ehWUbLQJPqS0Ep+CxeD559hsm9pthPXadJNKwZkp43w=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -323,6 +323,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkep
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/vendor/github.com/gophercloud/utils/client/client.go
+++ b/vendor/github.com/gophercloud/utils/client/client.go
@@ -1,0 +1,340 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// Logger is an interface representing the Logger struct
+type Logger interface {
+	Printf(format string, args ...interface{})
+}
+
+// DefaultLogger is a default struct, which satisfies the Logger interface
+type DefaultLogger struct{}
+
+// Printf is a default Printf method
+func (DefaultLogger) Printf(format string, args ...interface{}) {
+	log.Printf("[DEBUG] "+format, args...)
+}
+
+// noopLogger is a default noop logger satisfies the Logger interface
+type noopLogger struct{}
+
+// Printf is a default noop method
+func (noopLogger) Printf(format string, args ...interface{}) {}
+
+// RoundTripper satisfies the http.RoundTripper interface and is used to
+// customize the default http client RoundTripper
+type RoundTripper struct {
+	// Default http.RoundTripper
+	Rt http.RoundTripper
+	// Additional request headers to be set (not appended) in all client
+	// requests
+	headers *http.Header
+	// A pointer to a map of headers to be masked in logger
+	maskHeaders *map[string]struct{}
+	// A custom function to format and mask JSON requests and responses
+	FormatJSON func([]byte) (string, error)
+	// How many times HTTP connection should be retried until giving up
+	MaxRetries int
+	// If Logger is not nil, then RoundTrip method will debug the JSON
+	// requests and responses
+	Logger Logger
+}
+
+// List of headers that contain sensitive data.
+var defaultSensitiveHeaders = map[string]struct{}{
+	"x-auth-token":                    {},
+	"x-auth-key":                      {},
+	"x-service-token":                 {},
+	"x-storage-token":                 {},
+	"x-account-meta-temp-url-key":     {},
+	"x-account-meta-temp-url-key-2":   {},
+	"x-container-meta-temp-url-key":   {},
+	"x-container-meta-temp-url-key-2": {},
+	"set-cookie":                      {},
+	"x-subject-token":                 {},
+}
+
+// GetDefaultSensitiveHeaders returns the default list of headers to be masked
+func GetDefaultSensitiveHeaders() []string {
+	headers := make([]string, len(defaultSensitiveHeaders))
+	i := 0
+	for k := range defaultSensitiveHeaders {
+		headers[i] = k
+		i++
+	}
+
+	return headers
+}
+
+// SetSensitiveHeaders sets the list of case insensitive headers to be masked in
+// debug log
+func (rt *RoundTripper) SetSensitiveHeaders(headers []string) {
+	newHeaders := make(map[string]struct{}, len(headers))
+
+	for _, h := range headers {
+		newHeaders[h] = struct{}{}
+	}
+
+	// this is concurrency safe
+	rt.maskHeaders = &newHeaders
+}
+
+// SetHeaders sets request headers to be set (not appended) in all client
+// requests
+func (rt *RoundTripper) SetHeaders(headers http.Header) {
+	newHeaders := make(http.Header, len(headers))
+	for k, v := range headers {
+		s := make([]string, len(v))
+		for i, v := range v {
+			s[i] = v
+		}
+		newHeaders[k] = s
+	}
+
+	// this is concurrency safe
+	rt.headers = &newHeaders
+}
+
+func (rt *RoundTripper) hideSensitiveHeadersData(headers http.Header) []string {
+	result := make([]string, len(headers))
+	headerIdx := 0
+
+	// this is concurrency safe
+	v := rt.maskHeaders
+	if v == nil {
+		v = &defaultSensitiveHeaders
+	}
+	maskHeaders := *v
+
+	for header, data := range headers {
+		v := strings.ToLower(header)
+		if _, ok := maskHeaders[v]; ok {
+			result[headerIdx] = fmt.Sprintf("%s: %s", header, "***")
+		} else {
+			result[headerIdx] = fmt.Sprintf("%s: %s", header, strings.Join(data, " "))
+		}
+		headerIdx++
+	}
+
+	return result
+}
+
+// formatHeaders converts standard http.Header type to a string with separated headers.
+// It will hide data of sensitive headers.
+func (rt *RoundTripper) formatHeaders(headers http.Header, separator string) string {
+	redactedHeaders := rt.hideSensitiveHeadersData(headers)
+	sort.Strings(redactedHeaders)
+
+	return strings.Join(redactedHeaders, separator)
+}
+
+// RoundTrip performs a round-trip HTTP request and logs relevant information about it.
+func (rt *RoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	defer func() {
+		if request.Body != nil {
+			request.Body.Close()
+		}
+	}()
+
+	// for future reference, this is how to access the Transport struct:
+	//tlsconfig := rt.Rt.(*http.Transport).TLSClientConfig
+
+	// this is concurrency safe
+	h := rt.headers
+	if h != nil {
+		for k, v := range *h {
+			// Set additional request headers
+			request.Header[k] = v
+		}
+	}
+
+	var err error
+
+	if rt.Logger != nil {
+		rt.log().Printf("OpenStack Request URL: %s %s", request.Method, request.URL)
+		rt.log().Printf("OpenStack Request Headers:\n%s", rt.formatHeaders(request.Header, "\n"))
+
+		if request.Body != nil {
+			request.Body, err = rt.logRequest(request.Body, request.Header.Get("Content-Type"))
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// this is concurrency safe
+	ort := rt.Rt
+	if ort == nil {
+		return nil, fmt.Errorf("Rt RoundTripper is nil, aborting")
+	}
+	response, err := ort.RoundTrip(request)
+
+	// If the first request didn't return a response, retry up to `max_retries`.
+	retry := 1
+	for response == nil {
+		if retry > rt.MaxRetries {
+			if rt.Logger != nil {
+				rt.log().Printf("OpenStack connection error, retries exhausted. Aborting")
+			}
+			err = fmt.Errorf("OpenStack connection error, retries exhausted. Aborting. Last error was: %s", err)
+			return nil, err
+		}
+
+		if rt.Logger != nil {
+			rt.log().Printf("OpenStack connection error, retry number %d: %s", retry, err)
+		}
+		response, err = ort.RoundTrip(request)
+		retry += 1
+	}
+
+	if rt.Logger != nil {
+		rt.log().Printf("OpenStack Response Code: %d", response.StatusCode)
+		rt.log().Printf("OpenStack Response Headers:\n%s", rt.formatHeaders(response.Header, "\n"))
+
+		response.Body, err = rt.logResponse(response.Body, response.Header.Get("Content-Type"))
+	}
+
+	return response, err
+}
+
+// logRequest will log the HTTP Request details.
+// If the body is JSON, it will attempt to be pretty-formatted.
+func (rt *RoundTripper) logRequest(original io.ReadCloser, contentType string) (io.ReadCloser, error) {
+	// Handle request contentType
+	if strings.HasPrefix(contentType, "application/json") {
+		var bs bytes.Buffer
+		defer original.Close()
+
+		_, err := io.Copy(&bs, original)
+		if err != nil {
+			return nil, err
+		}
+
+		debugInfo, err := rt.formatJSON()(bs.Bytes())
+		if err != nil {
+			rt.log().Printf("%s", err)
+		}
+		rt.log().Printf("OpenStack Request Body: %s", debugInfo)
+
+		return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+	}
+
+	rt.log().Printf("Not logging because OpenStack request body isn't JSON")
+	return original, nil
+}
+
+// logResponse will log the HTTP Response details.
+// If the body is JSON, it will attempt to be pretty-formatted.
+func (rt *RoundTripper) logResponse(original io.ReadCloser, contentType string) (io.ReadCloser, error) {
+	if strings.HasPrefix(contentType, "application/json") {
+		var bs bytes.Buffer
+		defer original.Close()
+
+		_, err := io.Copy(&bs, original)
+		if err != nil {
+			return nil, err
+		}
+
+		debugInfo, err := rt.formatJSON()(bs.Bytes())
+		if err != nil {
+			rt.log().Printf("%s", err)
+		}
+		if debugInfo != "" {
+			rt.log().Printf("OpenStack Response Body: %s", debugInfo)
+		}
+
+		return ioutil.NopCloser(strings.NewReader(bs.String())), nil
+	}
+
+	rt.log().Printf("Not logging because OpenStack response body isn't JSON")
+	return original, nil
+}
+
+func (rt *RoundTripper) formatJSON() func([]byte) (string, error) {
+	// this is concurrency safe
+	f := rt.FormatJSON
+	if f == nil {
+		return FormatJSON
+	}
+	return f
+}
+
+func (rt *RoundTripper) log() Logger {
+	// this is concurrency safe
+	l := rt.Logger
+	if l == nil {
+		// noop is used, when logger pointer has been set to nil
+		return &noopLogger{}
+	}
+	return l
+}
+
+// FormatJSON is a default function to pretty-format a JSON body.
+// It will also mask known fields which contain sensitive information.
+func FormatJSON(raw []byte) (string, error) {
+	var rawData interface{}
+
+	err := json.Unmarshal(raw, &rawData)
+	if err != nil {
+		return string(raw), fmt.Errorf("unable to parse OpenStack JSON: %s", err)
+	}
+
+	data, ok := rawData.(map[string]interface{})
+	if !ok {
+		pretty, err := json.MarshalIndent(rawData, "", "  ")
+		if err != nil {
+			return string(raw), fmt.Errorf("unable to re-marshal OpenStack JSON: %s", err)
+		}
+
+		return string(pretty), nil
+	}
+
+	// Mask known password fields
+	if v, ok := data["auth"].(map[string]interface{}); ok {
+		// v2 auth methods
+		if v, ok := v["passwordCredentials"].(map[string]interface{}); ok {
+			v["password"] = "***"
+		}
+		if v, ok := v["token"].(map[string]interface{}); ok {
+			v["id"] = "***"
+		}
+		// v3 auth methods
+		if v, ok := v["identity"].(map[string]interface{}); ok {
+			if v, ok := v["password"].(map[string]interface{}); ok {
+				if v, ok := v["user"].(map[string]interface{}); ok {
+					v["password"] = "***"
+				}
+			}
+			if v, ok := v["application_credential"].(map[string]interface{}); ok {
+				v["secret"] = "***"
+			}
+			if v, ok := v["token"].(map[string]interface{}); ok {
+				v["id"] = "***"
+			}
+		}
+	}
+
+	// Ignore the huge catalog output
+	if v, ok := data["token"].(map[string]interface{}); ok {
+		if _, ok := v["catalog"]; ok {
+			v["catalog"] = "***"
+		}
+	}
+
+	pretty, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return string(raw), fmt.Errorf("unable to re-marshal OpenStack JSON: %s", err)
+	}
+
+	return string(pretty), nil
+}

--- a/vendor/github.com/gophercloud/utils/client/doc.go
+++ b/vendor/github.com/gophercloud/utils/client/doc.go
@@ -1,0 +1,147 @@
+/*
+Package client provides an ability to create a http.RoundTripper OpenStack
+client with extended options, including the JSON requests and responses log
+capabilities.
+
+Example usage with the default logger:
+
+	package example
+
+	import (
+		"net/http"
+		"os"
+
+		"github.com/gophercloud/gophercloud"
+		"github.com/gophercloud/gophercloud/openstack"
+		"github.com/gophercloud/utils/client"
+		"github.com/gophercloud/utils/openstack/clientconfig"
+	)
+
+	func NewComputeV2Client() (*gophercloud.ServiceClient, error) {
+		ao, err := clientconfig.AuthOptions(nil)
+		if err != nil {
+			return nil, err
+		}
+
+		provider, err := openstack.NewClient(ao.IdentityEndpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		if os.Getenv("OS_DEBUG") != "" {
+			provider.HTTPClient = http.Client{
+				Transport: &client.RoundTripper{
+					Rt:     &http.Transport{},
+					Logger: &client.DefaultLogger{},
+				},
+			}
+		}
+
+		err = openstack.Authenticate(provider, *ao)
+		if err != nil {
+			return nil, err
+		}
+
+		return openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+			Region: os.Getenv("OS_REGION_NAME"),
+		})
+	}
+
+Example usage with the custom logger:
+
+	package example
+
+	import (
+		"net/http"
+		"os"
+
+		"github.com/gophercloud/gophercloud"
+		"github.com/gophercloud/gophercloud/openstack"
+		"github.com/gophercloud/utils/client"
+		"github.com/gophercloud/utils/openstack/clientconfig"
+		log "github.com/sirupsen/logrus"
+	)
+
+	type myLogger struct {
+		Prefix string
+	}
+
+	func (l myLogger) Printf(format string, args ...interface{}) {
+		log.Debugf("%s [DEBUG] "+format, append([]interface{}{l.Prefix}, args...)...)
+	}
+
+	func NewComputeV2Client() (*gophercloud.ServiceClient, error) {
+		ao, err := clientconfig.AuthOptions(nil)
+		if err != nil {
+			return nil, err
+		}
+
+		provider, err := openstack.NewClient(ao.IdentityEndpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		if os.Getenv("OS_DEBUG") != "" {
+			provider.HTTPClient = http.Client{
+				Transport: &client.RoundTripper{
+					Rt:     &http.Transport{},
+					Logger: &myLogger{Prefix: "myApp"},
+				},
+			}
+		}
+
+		err = openstack.Authenticate(provider, *ao)
+		if err != nil {
+			return nil, err
+		}
+
+		return openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+			Region: os.Getenv("OS_REGION_NAME"),
+		})
+	}
+
+Example usage with additinal headers:
+
+	package example
+
+	import (
+		"net/http"
+		"os"
+
+		"github.com/gophercloud/gophercloud"
+		"github.com/gophercloud/gophercloud/openstack"
+		"github.com/gophercloud/utils/client"
+		"github.com/gophercloud/utils/openstack/clientconfig"
+	)
+
+	func NewComputeV2Client() (*gophercloud.ServiceClient, error) {
+		ao, err := clientconfig.AuthOptions(nil)
+		if err != nil {
+			return nil, err
+		}
+
+		provider, err := openstack.NewClient(ao.IdentityEndpoint)
+		if err != nil {
+			return nil, err
+		}
+
+		provider.HTTPClient = http.Client{
+			Transport: &client.RoundTripper{
+				Rt:     &http.Transport{},
+			},
+		}
+
+		provider.HTTPClient.Transport.(*client.RoundTripper).SetHeaders(map[string][]string{"Cache-Control": {"no-cache"}}})
+
+		err = openstack.Authenticate(provider, *ao)
+		if err != nil {
+			return nil, err
+		}
+
+		return openstack.NewComputeV2(provider, gophercloud.EndpointOpts{
+			Region: os.Getenv("OS_REGION_NAME"),
+		})
+	}
+
+*/
+package client

--- a/vendor/github.com/gophercloud/utils/env/env.go
+++ b/vendor/github.com/gophercloud/utils/env/env.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package env
+
+import (
+	"os"
+)
+
+func Getenv(s string) string {
+	return os.Getenv(s)
+}

--- a/vendor/github.com/gophercloud/utils/env/env_windows.go
+++ b/vendor/github.com/gophercloud/utils/env/env_windows.go
@@ -1,0 +1,106 @@
+package env
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/text/encoding/charmap"
+)
+
+func Getenv(s string) string {
+	var st uint32
+	env := os.Getenv(s)
+	if windows.GetConsoleMode(windows.Handle(syscall.Stdin), &st) == nil ||
+		windows.GetConsoleMode(windows.Handle(syscall.Stdout), &st) == nil ||
+		windows.GetConsoleMode(windows.Handle(syscall.Stderr), &st) == nil {
+		// detect windows console, should be skipped in cygwin environment
+		var cm charmap.Charmap
+		switch windows.GetACP() {
+		case 37:
+			cm = *charmap.CodePage037
+		case 1047:
+			cm = *charmap.CodePage1047
+		case 1140:
+			cm = *charmap.CodePage1140
+		case 437:
+			cm = *charmap.CodePage437
+		case 850:
+			cm = *charmap.CodePage850
+		case 852:
+			cm = *charmap.CodePage852
+		case 855:
+			cm = *charmap.CodePage855
+		case 858:
+			cm = *charmap.CodePage858
+		case 860:
+			cm = *charmap.CodePage860
+		case 862:
+			cm = *charmap.CodePage862
+		case 863:
+			cm = *charmap.CodePage863
+		case 865:
+			cm = *charmap.CodePage865
+		case 866:
+			cm = *charmap.CodePage866
+		case 28591:
+			cm = *charmap.ISO8859_1
+		case 28592:
+			cm = *charmap.ISO8859_2
+		case 28593:
+			cm = *charmap.ISO8859_3
+		case 28594:
+			cm = *charmap.ISO8859_4
+		case 28595:
+			cm = *charmap.ISO8859_5
+		case 28596:
+			cm = *charmap.ISO8859_6
+		case 28597:
+			cm = *charmap.ISO8859_7
+		case 28598:
+			cm = *charmap.ISO8859_8
+		case 28599:
+			cm = *charmap.ISO8859_9
+		case 28600:
+			cm = *charmap.ISO8859_10
+		case 28603:
+			cm = *charmap.ISO8859_13
+		case 28604:
+			cm = *charmap.ISO8859_14
+		case 28605:
+			cm = *charmap.ISO8859_15
+		case 28606:
+			cm = *charmap.ISO8859_16
+		case 20866:
+			cm = *charmap.KOI8R
+		case 21866:
+			cm = *charmap.KOI8U
+		case 1250:
+			cm = *charmap.Windows1250
+		case 1251:
+			cm = *charmap.Windows1251
+		case 1252:
+			cm = *charmap.Windows1252
+		case 1253:
+			cm = *charmap.Windows1253
+		case 1254:
+			cm = *charmap.Windows1254
+		case 1255:
+			cm = *charmap.Windows1255
+		case 1256:
+			cm = *charmap.Windows1256
+		case 1257:
+			cm = *charmap.Windows1257
+		case 1258:
+			cm = *charmap.Windows1258
+		case 874:
+			cm = *charmap.Windows874
+		default:
+			return env
+		}
+		if v, err := cm.NewEncoder().String(env); err == nil {
+			return v
+		}
+	}
+	return env
+}

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/doc.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/doc.go
@@ -7,7 +7,7 @@ See https://docs.openstack.org/os-client-config/latest for details.
 Example to Create a Provider Client From clouds.yaml
 
 	opts := &clientconfig.ClientOpts{
-		Name: "hawaii",
+		Cloud: "hawaii",
 	}
 
 	pClient, err := clientconfig.AuthenticatedClient(opts)

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/requests.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/requests.go
@@ -2,12 +2,13 @@ package clientconfig
 
 import (
 	"fmt"
-	"os"
+	"net/http"
 	"reflect"
 	"strings"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack"
+	"github.com/gophercloud/utils/env"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -56,11 +57,62 @@ type ClientOpts struct {
 	// This will override a region in clouds.yaml or can be used
 	// when authenticating directly with AuthInfo.
 	RegionName string
+
+	// EndpointType specifies whether to use the public, internal, or
+	// admin endpoint of a service.
+	EndpointType string
+
+	// HTTPClient provides the ability customize the ProviderClient's
+	// internal HTTP client.
+	HTTPClient *http.Client
+
+	// YAMLOpts provides the ability to pass a customized set
+	// of options and methods for loading the YAML file.
+	// It takes a YAMLOptsBuilder interface that is defined
+	// in this file. This is optional and the default behavior
+	// is to call the local LoadCloudsYAML functions defined
+	// in this file.
+	YAMLOpts YAMLOptsBuilder
+}
+
+// YAMLOptsBuilder defines an interface for customization when
+// loading a clouds.yaml file.
+type YAMLOptsBuilder interface {
+	LoadCloudsYAML() (map[string]Cloud, error)
+	LoadSecureCloudsYAML() (map[string]Cloud, error)
+	LoadPublicCloudsYAML() (map[string]Cloud, error)
+}
+
+// YAMLOpts represents options and methods to load a clouds.yaml file.
+type YAMLOpts struct {
+	// By default, no options are specified.
+}
+
+// LoadCloudsYAML defines how to load a clouds.yaml file.
+// By default, this calls the local LoadCloudsYAML function.
+func (opts YAMLOpts) LoadCloudsYAML() (map[string]Cloud, error) {
+	return LoadCloudsYAML()
+}
+
+// LoadSecureCloudsYAML defines how to load a secure.yaml file.
+// By default, this calls the local LoadSecureCloudsYAML function.
+func (opts YAMLOpts) LoadSecureCloudsYAML() (map[string]Cloud, error) {
+	return LoadSecureCloudsYAML()
+}
+
+// LoadPublicCloudsYAML defines how to load a public-secure.yaml file.
+// By default, this calls the local LoadPublicCloudsYAML function.
+func (opts YAMLOpts) LoadPublicCloudsYAML() (map[string]Cloud, error) {
+	return LoadPublicCloudsYAML()
 }
 
 // LoadCloudsYAML will load a clouds.yaml file and return the full config.
+// This is called by the YAMLOpts method. Calling this function directly
+// is supported for now but has only been retained for backwards
+// compatibility from before YAMLOpts was defined. This may be removed in
+// the future.
 func LoadCloudsYAML() (map[string]Cloud, error) {
-	content, err := findAndReadCloudsYAML()
+	_, content, err := FindAndReadCloudsYAML()
 	if err != nil {
 		return nil, err
 	}
@@ -75,10 +127,14 @@ func LoadCloudsYAML() (map[string]Cloud, error) {
 }
 
 // LoadSecureCloudsYAML will load a secure.yaml file and return the full config.
+// This is called by the YAMLOpts method. Calling this function directly
+// is supported for now but has only been retained for backwards
+// compatibility from before YAMLOpts was defined. This may be removed in
+// the future.
 func LoadSecureCloudsYAML() (map[string]Cloud, error) {
 	var secureClouds Clouds
 
-	content, err := findAndReadSecureCloudsYAML()
+	_, content, err := FindAndReadSecureCloudsYAML()
 	if err != nil {
 		if err.Error() == "no secure.yaml file found" {
 			// secure.yaml is optional so just ignore read error
@@ -96,10 +152,14 @@ func LoadSecureCloudsYAML() (map[string]Cloud, error) {
 }
 
 // LoadPublicCloudsYAML will load a public-clouds.yaml file and return the full config.
+// This is called by the YAMLOpts method. Calling this function directly
+// is supported for now but has only been retained for backwards
+// compatibility from before YAMLOpts was defined. This may be removed in
+// the future.
 func LoadPublicCloudsYAML() (map[string]Cloud, error) {
 	var publicClouds PublicClouds
 
-	content, err := findAndReadPublicCloudsYAML()
+	_, content, err := FindAndReadPublicCloudsYAML()
 	if err != nil {
 		if err.Error() == "no clouds-public.yaml file found" {
 			// clouds-public.yaml is optional so just ignore read error
@@ -119,7 +179,13 @@ func LoadPublicCloudsYAML() (map[string]Cloud, error) {
 
 // GetCloudFromYAML will return a cloud entry from a clouds.yaml file.
 func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
-	clouds, err := LoadCloudsYAML()
+	if opts.YAMLOpts == nil {
+		opts.YAMLOpts = new(YAMLOpts)
+	}
+
+	yamlOpts := opts.YAMLOpts
+
+	clouds, err := yamlOpts.LoadCloudsYAML()
 	if err != nil {
 		return nil, fmt.Errorf("unable to load clouds.yaml: %s", err)
 	}
@@ -138,7 +204,7 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		envPrefix = opts.EnvPrefix
 	}
 
-	if v := os.Getenv(envPrefix + "CLOUD"); v != "" {
+	if v := env.Getenv(envPrefix + "CLOUD"); v != "" {
 		cloudName = v
 	}
 
@@ -167,7 +233,7 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		cloudIsInCloudsYaml = true
 	}
 
-	publicClouds, err := LoadPublicCloudsYAML()
+	publicClouds, err := yamlOpts.LoadPublicCloudsYAML()
 	if err != nil {
 		return nil, fmt.Errorf("unable to load clouds-public.yaml: %s", err)
 	}
@@ -184,7 +250,7 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 		}
 	}
 
-	secureClouds, err := LoadSecureCloudsYAML()
+	secureClouds, err := yamlOpts.LoadSecureCloudsYAML()
 	if err != nil {
 		return nil, fmt.Errorf("unable to load secure.yaml: %s", err)
 	}
@@ -227,6 +293,17 @@ func GetCloudFromYAML(opts *ClientOpts) (*Cloud, error) {
 	// clouds-public.yml
 	// https://github.com/openstack/openstacksdk/tree/master/openstack/config/vendors
 
+	// Both Interface and EndpointType are valid settings in clouds.yaml,
+	// but we want to standardize on EndpointType for simplicity.
+	//
+	// If only Interface was set, we copy that to EndpointType to use as the setting.
+	// But in all other cases, EndpointType is used and Interface is cleared.
+	if cloud.Interface != "" && cloud.EndpointType == "" {
+		cloud.EndpointType = cloud.Interface
+	}
+
+	cloud.Interface = ""
+
 	return cloud, nil
 }
 
@@ -260,7 +337,7 @@ func AuthOptions(opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 		envPrefix = opts.EnvPrefix
 	}
 
-	if v := os.Getenv(envPrefix + "CLOUD"); v != "" {
+	if v := env.Getenv(envPrefix + "CLOUD"); v != "" {
 		cloudName = v
 	}
 
@@ -310,7 +387,7 @@ func determineIdentityAPI(cloud *Cloud, opts *ClientOpts) string {
 		envPrefix = opts.EnvPrefix
 	}
 
-	if v := os.Getenv(envPrefix + "IDENTITY_API_VERSION"); v != "" {
+	if v := env.Getenv(envPrefix + "IDENTITY_API_VERSION"); v != "" {
 		identityAPI = v
 	}
 
@@ -359,49 +436,49 @@ func v2auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 	}
 
 	if cloud.AuthInfo.AuthURL == "" {
-		if v := os.Getenv(envPrefix + "AUTH_URL"); v != "" {
+		if v := env.Getenv(envPrefix + "AUTH_URL"); v != "" {
 			cloud.AuthInfo.AuthURL = v
 		}
 	}
 
 	if cloud.AuthInfo.Token == "" {
-		if v := os.Getenv(envPrefix + "TOKEN"); v != "" {
+		if v := env.Getenv(envPrefix + "TOKEN"); v != "" {
 			cloud.AuthInfo.Token = v
 		}
 
-		if v := os.Getenv(envPrefix + "AUTH_TOKEN"); v != "" {
+		if v := env.Getenv(envPrefix + "AUTH_TOKEN"); v != "" {
 			cloud.AuthInfo.Token = v
 		}
 	}
 
 	if cloud.AuthInfo.Username == "" {
-		if v := os.Getenv(envPrefix + "USERNAME"); v != "" {
+		if v := env.Getenv(envPrefix + "USERNAME"); v != "" {
 			cloud.AuthInfo.Username = v
 		}
 	}
 
 	if cloud.AuthInfo.Password == "" {
-		if v := os.Getenv(envPrefix + "PASSWORD"); v != "" {
+		if v := env.Getenv(envPrefix + "PASSWORD"); v != "" {
 			cloud.AuthInfo.Password = v
 		}
 	}
 
 	if cloud.AuthInfo.ProjectID == "" {
-		if v := os.Getenv(envPrefix + "TENANT_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "TENANT_ID"); v != "" {
 			cloud.AuthInfo.ProjectID = v
 		}
 
-		if v := os.Getenv(envPrefix + "PROJECT_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "PROJECT_ID"); v != "" {
 			cloud.AuthInfo.ProjectID = v
 		}
 	}
 
 	if cloud.AuthInfo.ProjectName == "" {
-		if v := os.Getenv(envPrefix + "TENANT_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "TENANT_NAME"); v != "" {
 			cloud.AuthInfo.ProjectName = v
 		}
 
-		if v := os.Getenv(envPrefix + "PROJECT_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "PROJECT_NAME"); v != "" {
 			cloud.AuthInfo.ProjectName = v
 		}
 	}
@@ -427,115 +504,115 @@ func v3auth(cloud *Cloud, opts *ClientOpts) (*gophercloud.AuthOptions, error) {
 	}
 
 	if cloud.AuthInfo.AuthURL == "" {
-		if v := os.Getenv(envPrefix + "AUTH_URL"); v != "" {
+		if v := env.Getenv(envPrefix + "AUTH_URL"); v != "" {
 			cloud.AuthInfo.AuthURL = v
 		}
 	}
 
 	if cloud.AuthInfo.Token == "" {
-		if v := os.Getenv(envPrefix + "TOKEN"); v != "" {
+		if v := env.Getenv(envPrefix + "TOKEN"); v != "" {
 			cloud.AuthInfo.Token = v
 		}
 
-		if v := os.Getenv(envPrefix + "AUTH_TOKEN"); v != "" {
+		if v := env.Getenv(envPrefix + "AUTH_TOKEN"); v != "" {
 			cloud.AuthInfo.Token = v
 		}
 	}
 
 	if cloud.AuthInfo.Username == "" {
-		if v := os.Getenv(envPrefix + "USERNAME"); v != "" {
+		if v := env.Getenv(envPrefix + "USERNAME"); v != "" {
 			cloud.AuthInfo.Username = v
 		}
 	}
 
 	if cloud.AuthInfo.UserID == "" {
-		if v := os.Getenv(envPrefix + "USER_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "USER_ID"); v != "" {
 			cloud.AuthInfo.UserID = v
 		}
 	}
 
 	if cloud.AuthInfo.Password == "" {
-		if v := os.Getenv(envPrefix + "PASSWORD"); v != "" {
+		if v := env.Getenv(envPrefix + "PASSWORD"); v != "" {
 			cloud.AuthInfo.Password = v
 		}
 	}
 
 	if cloud.AuthInfo.ProjectID == "" {
-		if v := os.Getenv(envPrefix + "TENANT_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "TENANT_ID"); v != "" {
 			cloud.AuthInfo.ProjectID = v
 		}
 
-		if v := os.Getenv(envPrefix + "PROJECT_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "PROJECT_ID"); v != "" {
 			cloud.AuthInfo.ProjectID = v
 		}
 	}
 
 	if cloud.AuthInfo.ProjectName == "" {
-		if v := os.Getenv(envPrefix + "TENANT_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "TENANT_NAME"); v != "" {
 			cloud.AuthInfo.ProjectName = v
 		}
 
-		if v := os.Getenv(envPrefix + "PROJECT_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "PROJECT_NAME"); v != "" {
 			cloud.AuthInfo.ProjectName = v
 		}
 	}
 
 	if cloud.AuthInfo.DomainID == "" {
-		if v := os.Getenv(envPrefix + "DOMAIN_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "DOMAIN_ID"); v != "" {
 			cloud.AuthInfo.DomainID = v
 		}
 	}
 
 	if cloud.AuthInfo.DomainName == "" {
-		if v := os.Getenv(envPrefix + "DOMAIN_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "DOMAIN_NAME"); v != "" {
 			cloud.AuthInfo.DomainName = v
 		}
 	}
 
 	if cloud.AuthInfo.DefaultDomain == "" {
-		if v := os.Getenv(envPrefix + "DEFAULT_DOMAIN"); v != "" {
+		if v := env.Getenv(envPrefix + "DEFAULT_DOMAIN"); v != "" {
 			cloud.AuthInfo.DefaultDomain = v
 		}
 	}
 
 	if cloud.AuthInfo.ProjectDomainID == "" {
-		if v := os.Getenv(envPrefix + "PROJECT_DOMAIN_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "PROJECT_DOMAIN_ID"); v != "" {
 			cloud.AuthInfo.ProjectDomainID = v
 		}
 	}
 
 	if cloud.AuthInfo.ProjectDomainName == "" {
-		if v := os.Getenv(envPrefix + "PROJECT_DOMAIN_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "PROJECT_DOMAIN_NAME"); v != "" {
 			cloud.AuthInfo.ProjectDomainName = v
 		}
 	}
 
 	if cloud.AuthInfo.UserDomainID == "" {
-		if v := os.Getenv(envPrefix + "USER_DOMAIN_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "USER_DOMAIN_ID"); v != "" {
 			cloud.AuthInfo.UserDomainID = v
 		}
 	}
 
 	if cloud.AuthInfo.UserDomainName == "" {
-		if v := os.Getenv(envPrefix + "USER_DOMAIN_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "USER_DOMAIN_NAME"); v != "" {
 			cloud.AuthInfo.UserDomainName = v
 		}
 	}
 
 	if cloud.AuthInfo.ApplicationCredentialID == "" {
-		if v := os.Getenv(envPrefix + "APPLICATION_CREDENTIAL_ID"); v != "" {
+		if v := env.Getenv(envPrefix + "APPLICATION_CREDENTIAL_ID"); v != "" {
 			cloud.AuthInfo.ApplicationCredentialID = v
 		}
 	}
 
 	if cloud.AuthInfo.ApplicationCredentialName == "" {
-		if v := os.Getenv(envPrefix + "APPLICATION_CREDENTIAL_NAME"); v != "" {
+		if v := env.Getenv(envPrefix + "APPLICATION_CREDENTIAL_NAME"); v != "" {
 			cloud.AuthInfo.ApplicationCredentialName = v
 		}
 	}
 
 	if cloud.AuthInfo.ApplicationCredentialSecret == "" {
-		if v := os.Getenv(envPrefix + "APPLICATION_CREDENTIAL_SECRET"); v != "" {
+		if v := env.Getenv(envPrefix + "APPLICATION_CREDENTIAL_SECRET"); v != "" {
 			cloud.AuthInfo.ApplicationCredentialSecret = v
 		}
 	}
@@ -643,7 +720,7 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 		envPrefix = opts.EnvPrefix
 	}
 
-	if v := os.Getenv(envPrefix + "CLOUD"); v != "" {
+	if v := env.Getenv(envPrefix + "CLOUD"); v != "" {
 		cloudName = v
 	}
 
@@ -663,10 +740,15 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 		return nil, err
 	}
 
+	// If an HTTPClient was specified, use it.
+	if opts.HTTPClient != nil {
+		pClient.HTTPClient = *opts.HTTPClient
+	}
+
 	// Determine the region to use.
 	// First, check if the REGION_NAME environment variable is set.
 	var region string
-	if v := os.Getenv(envPrefix + "REGION_NAME"); v != "" {
+	if v := env.Getenv(envPrefix + "REGION_NAME"); v != "" {
 		region = v
 	}
 
@@ -681,8 +763,27 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 		region = v
 	}
 
+	// Determine the endpoint type to use.
+	// First, check if the OS_INTERFACE environment variable is set.
+	var endpointType string
+	if v := env.Getenv(envPrefix + "INTERFACE"); v != "" {
+		endpointType = v
+	}
+
+	// Next, check if the cloud entry sets an endpoint type.
+	if v := cloud.EndpointType; v != "" {
+		endpointType = v
+	}
+
+	// Finally, see if one was specified in the ClientOpts.
+	// If so, this takes precedence.
+	if v := opts.EndpointType; v != "" {
+		endpointType = v
+	}
+
 	eo := gophercloud.EndpointOpts{
-		Region: region,
+		Region:       region,
+		Availability: GetEndpointType(endpointType),
 	}
 
 	switch service {
@@ -692,6 +793,8 @@ func NewServiceClient(service string, opts *ClientOpts) (*gophercloud.ServiceCli
 		return openstack.NewComputeV2(pClient, eo)
 	case "container":
 		return openstack.NewContainerV1(pClient, eo)
+	case "container-infra":
+		return openstack.NewContainerInfraV1(pClient, eo)
 	case "database":
 		return openstack.NewDBV1(pClient, eo)
 	case "dns":

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/results.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/results.go
@@ -16,106 +16,112 @@ type Clouds struct {
 
 // Cloud represents an entry in a clouds.yaml/public-clouds.yaml/secure.yaml file.
 type Cloud struct {
-	Cloud      string        `yaml:"cloud" json:"cloud"`
-	Profile    string        `yaml:"profile" json:"profile"`
-	AuthInfo   *AuthInfo     `yaml:"auth" json:"auth"`
-	AuthType   AuthType      `yaml:"auth_type" json:"auth_type"`
-	RegionName string        `yaml:"region_name" json:"region_name"`
-	Regions    []interface{} `yaml:"regions" json:"regions"`
+	Cloud      string        `yaml:"cloud,omitempty" json:"cloud,omitempty"`
+	Profile    string        `yaml:"profile,omitempty" json:"profile,omitempty"`
+	AuthInfo   *AuthInfo     `yaml:"auth,omitempty" json:"auth,omitempty"`
+	AuthType   AuthType      `yaml:"auth_type,omitempty" json:"auth_type,omitempty"`
+	RegionName string        `yaml:"region_name,omitempty" json:"region_name,omitempty"`
+	Regions    []interface{} `yaml:"regions,omitempty" json:"regions,omitempty"`
+
+	// EndpointType and Interface both specify whether to use the public, internal,
+	// or admin interface of a service. They should be considered synonymous, but
+	// EndpointType will take precedence when both are specified.
+	EndpointType string `yaml:"endpoint_type,omitempty" json:"endpoint_type,omitempty"`
+	Interface    string `yaml:"interface,omitempty" json:"interface,omitempty"`
 
 	// API Version overrides.
-	IdentityAPIVersion string `yaml:"identity_api_version" json:"identity_api_version"`
-	VolumeAPIVersion   string `yaml:"volume_api_version" json:"volume_api_version"`
+	IdentityAPIVersion string `yaml:"identity_api_version,omitempty" json:"identity_api_version,omitempty"`
+	VolumeAPIVersion   string `yaml:"volume_api_version,omitempty" json:"volume_api_version,omitempty"`
 
 	// Verify whether or not SSL API requests should be verified.
-	Verify *bool `yaml:"verify" json:"verify"`
+	Verify *bool `yaml:"verify,omitempty" json:"verify,omitempty"`
 
 	// CACertFile a path to a CA Cert bundle that can be used as part of
 	// verifying SSL API requests.
-	CACertFile string `yaml:"cacert" json:"cacert"`
+	CACertFile string `yaml:"cacert,omitempty" json:"cacert,omitempty"`
 
 	// ClientCertFile a path to a client certificate to use as part of the SSL
 	// transaction.
-	ClientCertFile string `yaml:"cert" json:"cert"`
+	ClientCertFile string `yaml:"cert,omitempty" json:"cert,omitempty"`
 
 	// ClientKeyFile a path to a client key to use as part of the SSL
 	// transaction.
-	ClientKeyFile string `yaml:"key" json:"key"`
+	ClientKeyFile string `yaml:"key,omitempty" json:"key,omitempty"`
 }
 
 // AuthInfo represents the auth section of a cloud entry or
 // auth options entered explicitly in ClientOpts.
 type AuthInfo struct {
 	// AuthURL is the keystone/identity endpoint URL.
-	AuthURL string `yaml:"auth_url" json:"auth_url"`
+	AuthURL string `yaml:"auth_url,omitempty" json:"auth_url,omitempty"`
 
 	// Token is a pre-generated authentication token.
-	Token string `yaml:"token" json:"token"`
+	Token string `yaml:"token,omitempty" json:"token,omitempty"`
 
 	// Username is the username of the user.
-	Username string `yaml:"username" json:"username"`
+	Username string `yaml:"username,omitempty" json:"username,omitempty"`
 
 	// UserID is the unique ID of a user.
-	UserID string `yaml:"user_id" json:"user_id"`
+	UserID string `yaml:"user_id,omitempty" json:"user_id,omitempty"`
 
 	// Password is the password of the user.
-	Password string `yaml:"password" json:"password"`
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
 
 	// Application Credential ID to login with.
-	ApplicationCredentialID string `yaml:"application_credential_id" json:"application_credential_id"`
+	ApplicationCredentialID string `yaml:"application_credential_id,omitempty" json:"application_credential_id,omitempty"`
 
 	// Application Credential name to login with.
-	ApplicationCredentialName string `yaml:"application_credential_name" json:"application_credential_name"`
+	ApplicationCredentialName string `yaml:"application_credential_name,omitempty" json:"application_credential_name,omitempty"`
 
 	// Application Credential secret to login with.
-	ApplicationCredentialSecret string `yaml:"application_credential_secret" json:"application_credential_secret"`
+	ApplicationCredentialSecret string `yaml:"application_credential_secret,omitempty" json:"application_credential_secret,omitempty"`
 
 	// ProjectName is the common/human-readable name of a project.
 	// Users can be scoped to a project.
 	// ProjectName on its own is not enough to ensure a unique scope. It must
 	// also be combined with either a ProjectDomainName or ProjectDomainID.
 	// ProjectName cannot be combined with ProjectID in a scope.
-	ProjectName string `yaml:"project_name" json:"project_name"`
+	ProjectName string `yaml:"project_name,omitempty" json:"project_name,omitempty"`
 
 	// ProjectID is the unique ID of a project.
 	// It can be used to scope a user to a specific project.
-	ProjectID string `yaml:"project_id" json:"project_id"`
+	ProjectID string `yaml:"project_id,omitempty" json:"project_id,omitempty"`
 
 	// UserDomainName is the name of the domain where a user resides.
 	// It is used to identify the source domain of a user.
-	UserDomainName string `yaml:"user_domain_name" json:"user_domain_name"`
+	UserDomainName string `yaml:"user_domain_name,omitempty" json:"user_domain_name,omitempty"`
 
 	// UserDomainID is the unique ID of the domain where a user resides.
 	// It is used to identify the source domain of a user.
-	UserDomainID string `yaml:"user_domain_id" json:"user_domain_id"`
+	UserDomainID string `yaml:"user_domain_id,omitempty" json:"user_domain_id,omitempty"`
 
 	// ProjectDomainName is the name of the domain where a project resides.
 	// It is used to identify the source domain of a project.
 	// ProjectDomainName can be used in addition to a ProjectName when scoping
 	// a user to a specific project.
-	ProjectDomainName string `yaml:"project_domain_name" json:"project_domain_name"`
+	ProjectDomainName string `yaml:"project_domain_name,omitempty" json:"project_domain_name,omitempty"`
 
 	// ProjectDomainID is the name of the domain where a project resides.
 	// It is used to identify the source domain of a project.
 	// ProjectDomainID can be used in addition to a ProjectName when scoping
 	// a user to a specific project.
-	ProjectDomainID string `yaml:"project_domain_id" json:"project_domain_id"`
+	ProjectDomainID string `yaml:"project_domain_id,omitempty" json:"project_domain_id,omitempty"`
 
 	// DomainName is the name of a domain which can be used to identify the
 	// source domain of either a user or a project.
 	// If UserDomainName and ProjectDomainName are not specified, then DomainName
 	// is used as a default choice.
 	// It can also be used be used to specify a domain-only scope.
-	DomainName string `yaml:"domain_name" json:"domain_name"`
+	DomainName string `yaml:"domain_name,omitempty" json:"domain_name,omitempty"`
 
 	// DomainID is the unique ID of a domain which can be used to identify the
 	// source domain of eitehr a user or a project.
 	// If UserDomainID and ProjectDomainID are not specified, then DomainID is
 	// used as a default choice.
 	// It can also be used be used to specify a domain-only scope.
-	DomainID string `yaml:"domain_id" json:"domain_id"`
+	DomainID string `yaml:"domain_id,omitempty" json:"domain_id,omitempty"`
 
 	// DefaultDomain is the domain ID to fall back on if no other domain has
 	// been specified and a domain is required for scope.
-	DefaultDomain string `yaml:"default_domain" json:"default_domain"`
+	DefaultDomain string `yaml:"default_domain,omitempty" json:"default_domain,omitempty"`
 }

--- a/vendor/github.com/gophercloud/utils/openstack/clientconfig/utils.go
+++ b/vendor/github.com/gophercloud/utils/openstack/clientconfig/utils.go
@@ -8,6 +8,9 @@ import (
 	"os/user"
 	"path/filepath"
 	"reflect"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/utils/env"
 )
 
 // defaultIfEmpty is a helper function to make it cleaner to set default value
@@ -87,7 +90,7 @@ func mergeInterfaces(overridingInterface, inferiorInterface interface{}) interfa
 	}
 }
 
-// findAndReadCloudsYAML attempts to locate a clouds.yaml file in the following
+// FindAndReadCloudsYAML attempts to locate a clouds.yaml file in the following
 // locations:
 //
 // 1. OS_CLIENT_CONFIG_FILE
@@ -96,35 +99,37 @@ func mergeInterfaces(overridingInterface, inferiorInterface interface{}) interfa
 // 4. unix-specific site_config_dir (/etc/openstack/clouds.yaml)
 //
 // If found, the contents of the file is returned.
-func findAndReadCloudsYAML() ([]byte, error) {
+func FindAndReadCloudsYAML() (string, []byte, error) {
 	// OS_CLIENT_CONFIG_FILE
-	if v := os.Getenv("OS_CLIENT_CONFIG_FILE"); v != "" {
+	if v := env.Getenv("OS_CLIENT_CONFIG_FILE"); v != "" {
 		if ok := fileExists(v); ok {
-			return ioutil.ReadFile(v)
+			content, err := ioutil.ReadFile(v)
+			return v, content, err
 		}
 	}
 
-	return findAndReadYAML("clouds.yaml")
+	return FindAndReadYAML("clouds.yaml")
 }
 
-func findAndReadPublicCloudsYAML() ([]byte, error) {
-	return findAndReadYAML("clouds-public.yaml")
+func FindAndReadPublicCloudsYAML() (string, []byte, error) {
+	return FindAndReadYAML("clouds-public.yaml")
 }
 
-func findAndReadSecureCloudsYAML() ([]byte, error) {
-	return findAndReadYAML("secure.yaml")
+func FindAndReadSecureCloudsYAML() (string, []byte, error) {
+	return FindAndReadYAML("secure.yaml")
 }
 
-func findAndReadYAML(yamlFile string) ([]byte, error) {
+func FindAndReadYAML(yamlFile string) (string, []byte, error) {
 	// current directory
 	cwd, err := os.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine working directory: %s", err)
+		return "", nil, fmt.Errorf("unable to determine working directory: %s", err)
 	}
 
 	filename := filepath.Join(cwd, yamlFile)
 	if ok := fileExists(filename); ok {
-		return ioutil.ReadFile(filename)
+		content, err := ioutil.ReadFile(filename)
+		return filename, content, err
 	}
 
 	// unix user config directory: ~/.config/openstack.
@@ -133,17 +138,20 @@ func findAndReadYAML(yamlFile string) ([]byte, error) {
 		if homeDir != "" {
 			filename := filepath.Join(homeDir, ".config/openstack/"+yamlFile)
 			if ok := fileExists(filename); ok {
-				return ioutil.ReadFile(filename)
+				content, err := ioutil.ReadFile(filename)
+				return filename, content, err
 			}
 		}
 	}
 
 	// unix-specific site config directory: /etc/openstack.
-	if ok := fileExists("/etc/openstack/" + yamlFile); ok {
-		return ioutil.ReadFile("/etc/openstack/" + yamlFile)
+	filename = "/etc/openstack/" + yamlFile
+	if ok := fileExists(filename); ok {
+		content, err := ioutil.ReadFile(filename)
+		return filename, content, err
 	}
 
-	return nil, fmt.Errorf("no " + yamlFile + " file found")
+	return "", nil, fmt.Errorf("no " + yamlFile + " file found")
 }
 
 // fileExists checks for the existence of a file at a given location.
@@ -152,4 +160,16 @@ func fileExists(filename string) bool {
 		return true
 	}
 	return false
+}
+
+// GetEndpointType is a helper method to determine the endpoint type
+// requested by the user.
+func GetEndpointType(endpointType string) gophercloud.Availability {
+	if endpointType == "internal" || endpointType == "internalURL" {
+		return gophercloud.AvailabilityInternal
+	}
+	if endpointType == "admin" || endpointType == "adminURL" {
+		return gophercloud.AvailabilityAdmin
+	}
+	return gophercloud.AvailabilityPublic
 }

--- a/vendor/k8s.io/klog/README.md
+++ b/vendor/k8s.io/klog/README.md
@@ -1,7 +1,7 @@
 klog
 ====
 
-klog is a permanent fork of https://github.com/golang/klog.
+klog is a permanent fork of https://github.com/golang/glog.
 
 ## Why was klog created?
 
@@ -34,7 +34,7 @@ How to use klog
 - For more logging conventions (See [Logging Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md))
 
 ### Coexisting with glog
-This package can be used side by side with klog. [This example](examples/coexist_glog/coexist_klog.go) shows how to initialize and syncronize flags from the global `flag.CommandLine` FlagSet. In addition, the example makes use of stderr as combined output by setting `alsologtostderr` (or `logtostderr`) to `true`.
+This package can be used side by side with glog. [This example](examples/coexist_glog/coexist_glog.go) shows how to initialize and syncronize flags from the global `flag.CommandLine` FlagSet. In addition, the example makes use of stderr as combined output by setting `alsologtostderr` (or `logtostderr`) to `true`.
 
 ## Community, discussion, contribution, and support
 
@@ -65,7 +65,7 @@ without paying the expense of evaluating the arguments to the log.
 Through the -vmodule flag, the package also provides fine-grained
 control over logging at the file level.
 
-The comment from klog.go introduces the ideas:
+The comment from glog.go introduces the ideas:
 
 	Package glog implements logging analogous to the Google-internal
 	C++ INFO/ERROR/V setup.  It provides functions Info, Warning,
@@ -75,18 +75,18 @@ The comment from klog.go introduces the ideas:
 
 	Basic examples:
 
-		klog.Info("Prepare to repel boarders")
+		glog.Info("Prepare to repel boarders")
 
-		klog.Fatalf("Initialization failed: %s", err)
+		glog.Fatalf("Initialization failed: %s", err)
 
 	See the documentation for the V function for an explanation
 	of these examples:
 
-		if klog.V(2) {
-			klog.Info("Starting transaction...")
+		if glog.V(2) {
+			glog.Info("Starting transaction...")
 		}
 
-		klog.V(2).Infoln("Processed", nItems, "elements")
+		glog.V(2).Infoln("Processed", nItems, "elements")
 
 
 The repository contains an open source version of the log package

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,7 +122,9 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/networks
 github.com/gophercloud/gophercloud/openstack/networking/v2/ports
 github.com/gophercloud/gophercloud/openstack/utils
 github.com/gophercloud/gophercloud/pagination
-# github.com/gophercloud/utils v0.0.0-20190527093828-25f1b77b8c03
+# github.com/gophercloud/utils v0.0.0-20200204043447-9864b6f1f12f
+github.com/gophercloud/utils/client
+github.com/gophercloud/utils/env
 github.com/gophercloud/utils/openstack/clientconfig
 # github.com/hashicorp/golang-lru v0.5.1
 github.com/hashicorp/golang-lru


### PR DESCRIPTION
**What this PR does / why we need it**:

Setting the verbosity to 6 allows to print detailed OpenStack API requests/responses.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Openstack: Print API request/response debug when verbosity is set to 6
```

cc @rfranzke . It might be an idea to introduce an interface to enable verbose logging dynamically, because if you change the manifest for one particular shoot, it will be reconciled with the defaults. Any thoughts on how to do this?