### PR TITLE
[openstack] Provide Fault information when Server creation ERRORs out

### DIFF
--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -535,7 +535,12 @@ func waitForStatus(c *gophercloud.ServiceClient, id string, pending []string, ta
 			return false, nil
 		}
 
-		return false, fmt.Errorf("unexpected status %q, wanted target %q", current.Status, strings.Join(target, ", "))
+		retErr := fmt.Errorf("unexpected status %q, wanted target %q", current.Status, strings.Join(target, ", "))
+		if current.Status == "ERROR" {
+			retErr = fmt.Errorf("%s, fault: %+v", retErr, current.Fault)
+		}
+
+		return false, retErr
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we have to contact an API to figure out the reason for a Server's ERROR status. Let's provide all the info in-band.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
When a Server creation ERRORs out in the openstack driver, provide formatted Fault information
```
