### PR TITLE
OpenStack: print verbose error message, when server is in error state

### DIFF
--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -535,6 +535,10 @@ func waitForStatus(c *gophercloud.ServiceClient, id string, pending []string, ta
 			return false, nil
 		}
 
+		if current.Fault != (servers.Fault{}) {
+			return false, fmt.Errorf("unexpected status %q, wanted target %q: %s", current.Status, strings.Join(target, ", "), current.Fault.Message)
+		}
+
 		return false, fmt.Errorf("unexpected status %q, wanted target %q", current.Status, strings.Join(target, ", "))
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Print a detailed error message, when compute node is in error state.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Improved logging for openstack provider.
```

/cc @hardikdr 