### PR TITLE
Improve machine creation and deletion flow by listing the machines before actual creation/deletion

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -656,7 +656,7 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 
 			err = driver.Delete(machineID)
 		} else {
-			klog.V(2).Infof("Missing ProviderID when deleting the machine object. %s might have been deleted too soon.", machine.Name)
+			klog.V(2).Infof("Machine %q on deletion doesn't have a providerID attached to it. Checking for any VM linked to this machine object.", machine.Name)
 			// As MachineID is missing, we should check once if actual VM was created but MachineID was not updated on machine-object.
 			// We list VMs and check if any one them map with the given machine-object.
 			VMList, err := driver.GetVMs("")

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -106,5 +106,8 @@ func NewDriver(machineID string, secretRef *corev1.Secret, classKind string, mac
 		func() (string, error) {
 			return "fake", nil
 		},
+		func() (VMs, error) {
+			return nil, nil
+		},
 	)
 }

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -73,7 +73,7 @@ func (d *AzureDriver) getNICParameters(vmName string, subnet *network.Subnet) ne
 					Name: &nicName,
 					InterfaceIPConfigurationPropertiesFormat: &network.InterfaceIPConfigurationPropertiesFormat{
 						PrivateIPAllocationMethod: network.Dynamic,
-						Subnet:                    subnet,
+						Subnet: subnet,
 					},
 				},
 			},
@@ -269,7 +269,7 @@ func (d *AzureDriver) GetVMs(machineID string) (result VMs, err error) {
 	return
 }
 
-//GetUserData return the used data whit which the VM will be booted
+//GetUserData return the user data with which the VM will be booted
 func (d *AzureDriver) GetUserData() string {
 	return d.UserData
 }

--- a/pkg/driver/driver_fake.go
+++ b/pkg/driver/driver_fake.go
@@ -25,15 +25,17 @@ type FakeDriver struct {
 	delete func(string) error
 	//existing func() (string, v1alpha1.MachinePhase, error)
 	existing    func() (string, error)
+	getVMs      func() (VMs, error)
 	getVolNames func([]corev1.PersistentVolumeSpec) ([]string, error)
 }
 
 // NewFakeDriver returns a new fakedriver object
-func NewFakeDriver(create func() (string, string, error), delete func(string) error, existing func() (string, error)) Driver {
+func NewFakeDriver(create func() (string, string, error), delete func(string) error, existing func() (string, error), getVMs func() (VMs, error)) Driver {
 	return &FakeDriver{
 		create:   create,
 		delete:   delete,
 		existing: existing,
+		getVMs:   getVMs,
 	}
 }
 
@@ -54,8 +56,7 @@ func (d *FakeDriver) GetExisting() (string, error) {
 
 // GetVMs returns a list of VMs
 func (d *FakeDriver) GetVMs(name string) (VMs, error) {
-	listOfVMs := make(map[string]string)
-	return listOfVMs, nil
+	return d.getVMs()
 }
 
 // GetVolNames parses volume names from pv specs


### PR DESCRIPTION
**What this PR does / why we need it**: This PR addresses the cases when an unfortunate restart of the MCM can make it lose the state. MCM now lists the VMs in the cloud, before actually creating or deleting the machines. 
- This PR also enables MCM to adopt the dynamically node-object in case it is not populated on the machine-object while creation. 

**Which issue(s) this PR fixes**:
Fixes #423 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Improves the machine-creation and machine-deletion flow by listing and verifying the state of the machines before actual creation and deletion. 
```
```improvement operator
MCM now dynamically maps the node-objects with machines if `Status.Node` is not set. 
```
