### PR TITLE
Support VM Image ID for Azure

### DIFF
--- a/kubernetes/machine_classes/azure-machine-class.yaml
+++ b/kubernetes/machine_classes/azure-machine-class.yaml
@@ -25,6 +25,7 @@ spec:
     storageProfile:
       imageReference:
         urn: "image-reference-urn" # Image reference urn, it has the format 'publisher:offer:sku:version' (Eg- "CoreOS:CoreOS:Beta:1000.0.0")
+        id: "image-id" # Image reference ID, useful when image is not available via URN
       osDisk:
         caching: "None" # Caching Strategy (None/ReadOnly/ReadWrite)
         diskSizeGB: 50 # Size of disk to be created in GB

--- a/pkg/apis/machine/validation/azuremachineclass.go
+++ b/pkg/apis/machine/validation/azuremachineclass.go
@@ -89,10 +89,12 @@ func validateAzureProperties(properties machine.AzureVirtualMachineProperties, f
 		allErrs = append(allErrs, field.Required(fldPath.Child("hardwareProfile.vmSize"), "VMSize is required"))
 	}
 
-	if properties.StorageProfile.ImageReference.URN == nil || *properties.StorageProfile.ImageReference.URN == "" {
-		allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference.urn"), "Empty urn"))
-	} else {
-		splits := strings.Split(*properties.StorageProfile.ImageReference.URN, ":")
+	imageRef := properties.StorageProfile.ImageReference
+	if ((imageRef.URN == nil || *imageRef.URN == "") && imageRef.ID == "") ||
+		(imageRef.URN != nil && *imageRef.URN != "" && imageRef.ID != "") {
+		allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference"), "must specify either a image id or an urn"))
+	} else if imageRef.URN != nil && *imageRef.URN != "" {
+		splits := strings.Split(*imageRef.URN, ":")
 		if len(splits) != 4 {
 			allErrs = append(allErrs, field.Required(fldPath.Child("storageProfile.imageReference.urn"), "Invalid urn format"))
 		} else {

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -99,7 +99,7 @@ func (d *AzureDriver) getVMParameters(vmName string, networkInterfaceReferenceID
 		tagList[idx] = to.StringPtr(element)
 	}
 
-	publisher, offer, sku, version := getAzureImageDetails(d)
+	imageReference := getImageReference(d)
 
 	VMParameters := compute.VirtualMachine{
 		Name:     &vmName,
@@ -109,12 +109,7 @@ func (d *AzureDriver) getVMParameters(vmName string, networkInterfaceReferenceID
 				VMSize: compute.VirtualMachineSizeTypes(d.AzureMachineClass.Spec.Properties.HardwareProfile.VMSize),
 			},
 			StorageProfile: &compute.StorageProfile{
-				ImageReference: &compute.ImageReference{
-					Publisher: &publisher,
-					Offer:     &offer,
-					Sku:       &sku,
-					Version:   &version,
-				},
+				ImageReference: &imageReference,
 				OsDisk: &compute.OSDisk{
 					Name:    &diskName,
 					Caching: compute.CachingTypes(d.AzureMachineClass.Spec.Properties.StorageProfile.OsDisk.Caching),
@@ -175,13 +170,25 @@ func (d *AzureDriver) getVMParameters(vmName string, networkInterfaceReferenceID
 	return VMParameters
 }
 
-func getAzureImageDetails(d *AzureDriver) (publisher, offer, sku, version string) {
-	splits := strings.Split(*d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference.URN, ":")
-	publisher = splits[0]
-	offer = splits[1]
-	sku = splits[2]
-	version = splits[3]
-	return
+func getImageReference(d *AzureDriver) compute.ImageReference {
+	imageRefClass := d.AzureMachineClass.Spec.Properties.StorageProfile.ImageReference
+	if imageRefClass.ID != "" {
+		return compute.ImageReference{
+			ID: &imageRefClass.ID,
+		}
+	}
+
+	splits := strings.Split(*imageRefClass.URN, ":")
+	publisher := splits[0]
+	offer := splits[1]
+	sku := splits[2]
+	version := splits[3]
+	return compute.ImageReference{
+		Publisher: &publisher,
+		Offer:     &offer,
+		Sku:       &sku,
+		Version:   &version,
+	}
 }
 
 // Create method is used to create an azure machine


### PR DESCRIPTION
**What this PR does / why we need it**:
Support VM Image ID for Azure.
With this change VMs can be created not only from URN, but also from image ID.
This is necessary when the VM images are not available in the marketplace and URN cannot be used. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Azure VMs now can be created with image ID.
```
