### PR TITLE
Add "auth-extra-groups" field to bootstrap token

### DIFF
--- a/cmd/machine-controller-manager/app/controllermanager.go
+++ b/cmd/machine-controller-manager/app/controllermanager.go
@@ -272,6 +272,7 @@ func StartControllers(s *options.MCMServer,
 			recorder,
 			s.SafetyOptions,
 			s.NodeConditions,
+			s.BootstrapTokenAuthExtraGroups,
 		)
 		if err != nil {
 			return err

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -112,6 +112,7 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "machine-safety-overshooting-period", s.SafetyOptions.MachineSafetyOvershootingPeriod.Duration, "Time period (in durartion) used to poll for overshooting of machine objects backing a machineSet by safety controller.")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "machine-safety-apiserver-statuscheck-period", s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "Time period (in duration) used to poll for APIServer's health by safety controller")
 	fs.StringVar(&s.NodeConditions, "node-conditions", s.NodeConditions, "List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.")
+	fs.StringVar(&s.BootstrapTokenAuthExtraGroups, "bootstrap-token-auth-extra-groups", s.BootstrapTokenAuthExtraGroups, "Comma-separated list of groups to set bootstrap token's \"auth-extra-groups\" field to")
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -82,6 +82,7 @@ func NewController(
 	recorder record.EventRecorder,
 	safetyOptions options.SafetyOptions,
 	nodeConditions string,
+	bootstrapTokenAuthExtraGroups string,
 ) (Controller, error) {
 	controller := &controller{
 		namespace:                      namespace,
@@ -106,6 +107,7 @@ func NewController(
 		machineSafetyAPIServerQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyapiserver"),
 		safetyOptions:                  safetyOptions,
 		nodeConditions:                 nodeConditions,
+		bootstrapTokenAuthExtraGroups:  bootstrapTokenAuthExtraGroups,
 	}
 
 	controller.internalExternalScheme = runtime.NewScheme()
@@ -397,8 +399,9 @@ type Controller interface {
 
 // controller is a concrete Controller.
 type controller struct {
-	namespace      string
-	nodeConditions string
+	namespace                     string
+	nodeConditions                string
+	bootstrapTokenAuthExtraGroups string
 
 	controlMachineClient machineapi.MachineV1alpha1Interface
 	controlCoreClient    kubernetes.Interface

--- a/pkg/controller/machine_bootstrap_token.go
+++ b/pkg/controller/machine_bootstrap_token.go
@@ -73,6 +73,7 @@ func (c *controller) getBootstrapTokenOrCreateIfNotExist(machineName string) (se
 				bootstraptokenapi.BootstrapTokenExpirationKey:       []byte(metav1.Now().Add(c.safetyOptions.MachineCreationTimeout.Duration).Format(time.RFC3339)),
 				bootstraptokenapi.BootstrapTokenUsageAuthentication: []byte("true"),
 				bootstraptokenapi.BootstrapTokenUsageSigningKey:     []byte("true"),
+				bootstraptokenapi.BootstrapTokenExtraGroupsKey:      []byte(c.bootstrapTokenAuthExtraGroups),
 			}
 
 			secret = &v1.Secret{

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -81,6 +81,9 @@ type MachineControllerManagerConfiguration struct {
 
 	//NodeCondition is the string of known NodeConditions. If any of these NodeCondition is set for a timeout period, the machine  will be declared failed and will replaced.
 	NodeConditions string
+
+	//BootstrapTokenAuthExtraGroups is a comma-separated string of groups to set bootstrap token's "auth-extra-groups" field to.
+	BootstrapTokenAuthExtraGroups string
 }
 
 // SafetyOptions are used to configure the upper-limit and lower-limit


### PR DESCRIPTION
**What this PR does / why we need it**:

I'd like to access Kubernetes objects in some way or another using the bootstrap token. It's possible to do just that by providing the [`auth-extra-groups`](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/#bootstrap-token-secret-format) field (this PR) and creating a Role/RoleBinding. 

**Special notes for your reviewer**:

The format of the configuration is open to discussion. Perhaps, it would be better to move this to a per-MachineClass Secret?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
Provide a way to specify "auth-extra-groups" field in created bootstrap tokens.
```
