### PR TITLE
Do not adopt Nodes with empty ProviderID field

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -277,6 +277,10 @@ func (c *controller) updateMachineState(machine *v1alpha1.Machine) (*v1alpha1.Ma
 		}
 		for _, node := range nodeList {
 			nID, mID := decodeMachineID(node.Spec.ProviderID), decodeMachineID(machine.Spec.ProviderID)
+			if nID == "" {
+				continue
+			}
+
 			if nID == mID {
 				klog.V(2).Infof("Adopting the node object %s for machine %s", node.Name, machine.Name)
 				nodeName = node.Name

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -1816,6 +1816,37 @@ var _ = Describe("machine", func() {
 					),
 				},
 			}),
+			Entry("Machine object does not have status.node set and node exists (without providerID) then it should not adopt node using providerID", &data{
+				setup: setup{
+					machines: newMachines(1, &machinev1.MachineTemplateSpec{
+						ObjectMeta: *newObjectMeta(objMeta, 0),
+						Spec: machinev1.MachineSpec{
+							ProviderID: "aws//fakeID",
+						},
+					}, &machinev1.MachineStatus{}, nil, nil, nil),
+					nodes: []*corev1.Node{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "node-0",
+							},
+							Spec: corev1.NodeSpec{
+								ProviderID: "",
+							},
+						},
+					},
+				},
+				action: action{
+					machine: machineName,
+				},
+				expect: expect{
+					machine: newMachine(&machinev1.MachineTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "machine-0",
+						},
+					}, nil, nil, nil, nil,
+					),
+				},
+			}),
 		)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not adopt Nodes with an empty ProviderID field.

**Special notes for your reviewer**:

We've hit a nasty cloud-controller-manager bug: manually created master Node has not been assigned a ProviderID. As a result, the machine-controller-manager adopted the master Node, promptly replacing its metadata and removing it after when Machine has been removed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
The mcm stopped adopting Nodes with empty ProviderID field
```
