### PR TITLE
Annotate machine-deployment if machine-types are not available in cloud

### DIFF
--- a/pkg/controller/constants.go
+++ b/pkg/controller/constants.go
@@ -1,0 +1,20 @@
+package controller
+
+// TODO: Split and move this constants to provider-specific machine-controllers in future.
+const (
+	// MachineTypeNotAvailableAzure is a log message depicting certain machine-types are not available in the azure-cloud.
+	MachineTypeNotAvailableAzure = "The requested size for resource '.*' is currently not available in location '.*' zones '.*' for subscription '.*'"
+
+	// MachineTypeNotAvailableAWS is a log message depicting certain machine-types are not available in the azure-cloud.
+	MachineTypeNotAvailableAWS = "Unsupported: Your requested instance type (.*) is not supported in your requested Availability Zone (.*). Please retry your request by not specifying an Availability Zone or choosing .*"
+
+	// MachineTypeNotAvailableAnnotation annotation is put on machine and node obejcts when cloud-provider is out of certain machine-types.
+	MachineTypeNotAvailableAnnotation = "machine.sapcloud.io/machine-type-not-available"
+)
+
+// Original error messages:
+// AWS:
+// Cloud provider message - Unsupported: Your requested instance type (m5.4xlarge) is not supported in your requested Availability Zone (us-east-1e). Please retry your request by not specifying an Availability Zone or choosing us-east-1b, us-east-1d, us-east-1a, us-east-1f, us-east-1c.
+
+// Azure:
+// The requested size for resource '/subscriptions/123c2-4-1234/resourceGroups/shoot--12-12/providers/Microsoft.Compute/virtualMac2321321312/1234-nz7vw' is currently not available in location 'westeurope' zones '1' for subscription '2c3d1231-s21321321-8c04-2711234'.

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -302,7 +302,7 @@ func (dc *controller) getMachineDeploymentForMachine(machine *v1alpha1.Machine) 
 		// No controller owns this Machine.
 		return nil
 	}
-	if controllerRef.Kind != "MachineDeployment" { //TODO: Remove hardcoded string
+	if controllerRef.Kind != "MachineSet" { //TODO: Remove hardcoded string
 		// Not a Machine owned by a machine set.
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:  
This PR adds the annotation at the nodeSpec of the MachineDeployment, whenever a specific pattern is found in the creation-logs.
It is also mainly motivated due to the resource-scarcity at Azure, where certain machine-types are not available. MCM adds the annotation on such MachineDeployment, which becomes the hint for the autoscaler to keep trying to scale-up it up. 

Related to this: https://github.com/gardener/autoscaler/issues/35

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
MCM adds the annotation `machine.sapcloud.io/machine-type-not-available` whenever certain machine-types are not available in Azure and AWS.
```
