### PR TITLE
[openstack] Config drive option

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
@@ -102,6 +102,8 @@ spec:
               additionalProperties:
                 type: string
               type: object
+            useConfigDrive:
+              type: boolean
           required:
           - availabilityZone
           - flavorName

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -638,6 +638,7 @@ type OpenStackMachineClassSpec struct {
 	SecretRef        *corev1.SecretReference
 	PodNetworkCidr   string
 	RootDiskSize     int // in GB
+	UseConfigDrive   *bool
 }
 
 type OpenStackNetwork struct {

--- a/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
@@ -101,6 +101,7 @@ type OpenStackMachineClassSpec struct {
 	SecretRef        *corev1.SecretReference `json:"secretRef,omitempty"`
 	PodNetworkCidr   string                  `json:"podNetworkCidr"`
 	RootDiskSize     int                     `json:"rootDiskSize,omitempty"` // in GB
+	UseConfigDrive   *bool                   `json:"useConfigDrive,omitempty"`
 }
 
 type OpenStackNetwork struct {

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -2603,6 +2603,7 @@ func autoConvert_v1alpha1_OpenStackMachineClassSpec_To_machine_OpenStackMachineC
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
+	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
 	return nil
 }
 
@@ -2625,6 +2626,7 @@ func autoConvert_machine_OpenStackMachineClassSpec_To_v1alpha1_OpenStackMachineC
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
+	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
 	return nil
 }
 

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -1692,6 +1692,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.UseConfigDrive != nil {
+		in, out := &in.UseConfigDrive, &out.UseConfigDrive
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -1785,6 +1785,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.UseConfigDrive != nil {
+		in, out := &in.UseConfigDrive, &out.UseConfigDrive
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -25,10 +25,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
-
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/metrics"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
@@ -113,6 +112,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 	metadata := d.OpenStackMachineClass.Spec.Tags
 	podNetworkCidr := d.OpenStackMachineClass.Spec.PodNetworkCidr
 	rootDiskSize := d.OpenStackMachineClass.Spec.RootDiskSize
+	useConfigDrive := d.OpenStackMachineClass.Spec.UseConfigDrive
 
 	var createOpts servers.CreateOptsBuilder
 	var imageRef string
@@ -170,6 +170,7 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 		Metadata:         metadata,
 		UserData:         []byte(d.UserData),
 		AvailabilityZone: availabilityZone,
+		ConfigDrive:      useConfigDrive,
 	}
 
 	createOpts = &keypairs.CreateOptsExt{

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3355,6 +3355,13 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 							Format: "int32",
 						},
 					},
+					"rootDiskSize": {
+						SchemaProps: spec.SchemaProps{
+							Description: "in GB",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"imageID", "imageName", "region", "availabilityZone", "flavorName", "keyName", "securityGroups", "networkID", "podNetworkCidr"},
 			},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3355,7 +3355,7 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 							Format: "int32",
 						},
 					},
-					"rootDiskSize": {
+					"useConfigDrive": {
 						SchemaProps: spec.SchemaProps{
 							Description: "in GB",
 							Type:        []string{"boolean"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an option to use config drive while provisioning OpenStack Servers.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Added an option to use configDrive in the OpenStackMachineClass
```