### PR TITLE
Add SnapshotID field in AWSMachineClass

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -775,6 +775,18 @@ type AWSEbsBlockDeviceSpec struct {
 	// it is not used in requests to create gp2, st1, sc1, or standard volumes.
 	Iops int64
 
+	// Identifier (key ID, key alias, ID ARN, or alias ARN) for a customer managed
+	// CMK under which the EBS volume is encrypted.
+	//
+	// This parameter is only supported on BlockDeviceMapping objects called by
+	// RunInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html),
+	// RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html),
+	// and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html).
+	KmsKeyID *string
+
+	// The ID of the snapshot.
+	SnapshotID *string
+
 	// The size of the volume, in GiB.
 	//
 	// Constraints: 1-16384 for General Purpose SSD (gp2), 4-16384 for Provisioned

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -850,6 +850,18 @@ type AWSEbsBlockDeviceSpec struct {
 	// it is not used in requests to create gp2, st1, sc1, or standard volumes.
 	Iops int64 `json:"iops,omitempty"`
 
+	// Identifier (key ID, key alias, ID ARN, or alias ARN) for a customer managed
+	// CMK under which the EBS volume is encrypted.
+	//
+	// This parameter is only supported on BlockDeviceMapping objects called by
+	// RunInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html),
+	// RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html),
+	// and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html).
+	KmsKeyID *string `json:"kmsKeyID,omitempty"`
+
+	// The ID of the snapshot.
+	SnapshotID *string `json:"snapshotID,omitempty"`
+
 	// The size of the volume, in GiB.
 	//
 	// Constraints: 1-16384 for General Purpose SSD (gp2), 4-16384 for Provisioned
@@ -993,7 +1005,7 @@ type AzureOSDisk struct {
 
 type AzureDataDisk struct {
 	Name               string `json:"name,omitempty"`
-	Lun                *int32  `json:"lun,omitempty"`
+	Lun                *int32 `json:"lun,omitempty"`
 	Caching            string `json:"caching,omitempty"`
 	StorageAccountType string `json:"storageAccountType,omitempty"`
 	DiskSizeGB         int32  `json:"diskSizeGB,omitempty"`

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -845,6 +845,8 @@ func autoConvert_v1alpha1_AWSEbsBlockDeviceSpec_To_machine_AWSEbsBlockDeviceSpec
 	out.DeleteOnTermination = (*bool)(unsafe.Pointer(in.DeleteOnTermination))
 	out.Encrypted = in.Encrypted
 	out.Iops = in.Iops
+	out.KmsKeyID = (*string)(unsafe.Pointer(in.KmsKeyID))
+	out.SnapshotID = (*string)(unsafe.Pointer(in.SnapshotID))
 	out.VolumeSize = in.VolumeSize
 	out.VolumeType = in.VolumeType
 	return nil
@@ -859,6 +861,8 @@ func autoConvert_machine_AWSEbsBlockDeviceSpec_To_v1alpha1_AWSEbsBlockDeviceSpec
 	out.DeleteOnTermination = (*bool)(unsafe.Pointer(in.DeleteOnTermination))
 	out.Encrypted = in.Encrypted
 	out.Iops = in.Iops
+	out.KmsKeyID = (*string)(unsafe.Pointer(in.KmsKeyID))
+	out.SnapshotID = (*string)(unsafe.Pointer(in.SnapshotID))
 	out.VolumeSize = in.VolumeSize
 	out.VolumeType = in.VolumeType
 	return nil

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -52,6 +52,16 @@ func (in *AWSEbsBlockDeviceSpec) DeepCopyInto(out *AWSEbsBlockDeviceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.KmsKeyID != nil {
+		in, out := &in.KmsKeyID, &out.KmsKeyID
+		*out = new(string)
+		**out = **in
+	}
+	if in.SnapshotID != nil {
+		in, out := &in.SnapshotID, &out.SnapshotID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -52,6 +52,16 @@ func (in *AWSEbsBlockDeviceSpec) DeepCopyInto(out *AWSEbsBlockDeviceSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.KmsKeyID != nil {
+		in, out := &in.KmsKeyID, &out.KmsKeyID
+		*out = new(string)
+		**out = **in
+	}
+	if in.SnapshotID != nil {
+		in, out := &in.SnapshotID, &out.SnapshotID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -183,6 +183,7 @@ func (d *AWSDriver) generateBlockDevices(blockDevices []v1alpha1.AWSBlockDeviceM
 		volumeSize := disk.Ebs.VolumeSize
 		volumeType := disk.Ebs.VolumeType
 		encrypted := disk.Ebs.Encrypted
+		snapshotID := disk.Ebs.SnapshotID
 
 		blkDeviceMapping := ec2.BlockDeviceMapping{
 			DeviceName: aws.String(deviceName),
@@ -198,6 +199,10 @@ func (d *AWSDriver) generateBlockDevices(blockDevices []v1alpha1.AWSBlockDeviceM
 
 		if volumeType == "io1" {
 			blkDeviceMapping.Ebs.Iops = aws.Int64(disk.Ebs.Iops)
+		}
+
+		if snapshotID != nil {
+			blkDeviceMapping.Ebs.SnapshotId = snapshotID
 		}
 		blkDeviceMappings = append(blkDeviceMappings, &blkDeviceMapping)
 	}

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -436,6 +436,20 @@ func schema_pkg_apis_machine_v1alpha1_AWSEbsBlockDeviceSpec(ref common.Reference
 							Format:      "int64",
 						},
 					},
+					"kmsKeyID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Identifier (key ID, key alias, ID ARN, or alias ARN) for a customer managed CMK under which the EBS volume is encrypted.\n\nThis parameter is only supported on BlockDeviceMapping objects called by RunInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html), RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html), and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"snapshotID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The ID of the snapshot.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"volumeSize": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The size of the volume, in GiB.\n\nConstraints: 1-16384 for General Purpose SSD (gp2), 4-16384 for Provisioned IOPS SSD (io1), 500-16384 for Throughput Optimized HDD (st1), 500-16384 for Cold HDD (sc1), and 1-1024 for Magnetic (standard) volumes. If you specify a snapshot, the volume size must be equal to or larger than the snapshot size.\n\nDefault: If you're creating the volume from a snapshot and don't specify a volume size, the default is the snapshot size.",


### PR DESCRIPTION
**What this PR does / why we need it**: Enable support of snapshot-based volumes for machines in AWS.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Enable support of snapshot-based volumes for machines in AWS.
```
