### PR TITLE
Fix typo in AWSMachineClass

### DIFF
--- a/kubernetes/machine_classes/aws-machine-class.yaml
+++ b/kubernetes/machine_classes/aws-machine-class.yaml
@@ -25,13 +25,13 @@ spec:
     namespace: default  # Namespace
     name: test-secret # Name of the secret
   blockDevices:
-    - name: /root
+    - deviceName: /root
       ebs:
         volumeSize: 50  # Size of the root block device
         volumeType: gp2 # Type of the root block device
         encrypted: false
         deleteOnTermination: true
-    - name: /dev/sdb
+    - deviceName: /dev/sdb
       ebs:
         volumeSize: 50  # Size of the root block device
         volumeType: gp2 # Type of the root block device


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes the typo in aws-machine-class. 
Check: https://github.com/gardener/machine-controller-manager/blob/master/pkg/apis/machine/v1alpha1/types.go#L804

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
