### PR TITLE
An option to throttle deletion of Failed Machines

### DIFF
--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -69,6 +69,7 @@ func NewMCMServer() *MCMServer {
 				MachineCreationTimeout:                   metav1.Duration{Duration: 20 * time.Minute},
 				MachineHealthTimeout:                     metav1.Duration{Duration: 10 * time.Minute},
 				MachineDrainTimeout:                      metav1.Duration{Duration: controller.DefaultMachineDrainTimeout},
+				FailedMachineDeletionRatio:               1,
 				MaxEvictRetries:                          controller.DefaultMaxEvictRetries,
 				PvDetachTimeout:                          metav1.Duration{Duration: 2 * time.Minute},
 				MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 30 * time.Minute},
@@ -102,9 +103,10 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&s.SafetyOptions.SafetyUp, "safety-up", s.SafetyOptions.SafetyUp, "The number of excess machine objects permitted for any machineSet/machineDeployment beyond its expected number of replicas based on desired and max-surge, we call this the upper-limit. When this upper-limit is reached, the objects are temporarily frozen until the number of objects reduce. upper-limit = desired + maxSurge (if applicable) + safetyUp.")
 	fs.Int32Var(&s.SafetyOptions.SafetyDown, "safety-down", s.SafetyOptions.SafetyDown, "Upper-limit minus safety-down value gives the lower-limit. This is the limits below which any temporarily frozen machineSet/machineDeployment object is unfrozen. lower-limit = desired + maxSurge (if applicable) + safetyUp - safetyDown.")
 
-	fs.DurationVar(&s.SafetyOptions.MachineCreationTimeout.Duration, "machine-creation-timeout", s.SafetyOptions.MachineCreationTimeout.Duration, "Timeout (in duration) used while joining (during creation) of machine before it is declared as failed.")
-	fs.DurationVar(&s.SafetyOptions.MachineHealthTimeout.Duration, "machine-health-timeout", s.SafetyOptions.MachineHealthTimeout.Duration, "Timeout (in duration) used while re-joining (in case of temporary health issues) of machine before it is declared as failed.")
-	fs.DurationVar(&s.SafetyOptions.MachineDrainTimeout.Duration, "machine-drain-timeout", controller.DefaultMachineDrainTimeout, "Timeout (in duration) used while draining of machine before deletion, beyond which MCM forcefully deletes machine.")
+	fs.DurationVar(&s.SafetyOptions.MachineCreationTimeout.Duration, "machine-creation-timeout", s.SafetyOptions.MachineCreationTimeout.Duration, "Timeout (in durartion) used while joining (during creation) of machine before it is declared as failed.")
+	fs.DurationVar(&s.SafetyOptions.MachineHealthTimeout.Duration, "machine-health-timeout", s.SafetyOptions.MachineHealthTimeout.Duration, "Timeout (in durartion) used while re-joining (in case of temporary health issues) of machine before it is declared as failed.")
+	fs.DurationVar(&s.SafetyOptions.MachineDrainTimeout.Duration, "machine-drain-timeout", controller.DefaultMachineDrainTimeout, "Timeout (in durartion) used while draining of machine before deletion, beyond which MCM forcefully deletes machine.")
+	fs.Float64Var(&s.SafetyOptions.FailedMachineDeletionRatio, "failed-machine-deletion-ratio", s.SafetyOptions.FailedMachineDeletionRatio, "Ratio of Failed Machine deletion relative to total amount of Failed Machines in a single MachineSet.")
 	fs.Int32Var(&s.SafetyOptions.MaxEvictRetries, "machine-max-evict-retries", controller.DefaultMaxEvictRetries, "Maximum number of times evicts would be attempted on a pod before it is forcibly deleted during draining of a machine.")
 	fs.DurationVar(&s.SafetyOptions.PvDetachTimeout.Duration, "machine-pv-detach-timeout", s.SafetyOptions.PvDetachTimeout.Duration, "Timeout (in duration) used while waiting for detach of PV while evicting/deleting pods")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "machine-safety-apiserver-statuscheck-timeout", s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "Timeout (in duration) for which the APIServer can be down before declare the machine controller frozen by safety controller")

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -22,6 +22,7 @@ Modifications Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights 
 package options
 
 import (
+	"fmt"
 	"time"
 
 	machineconfig "github.com/gardener/machine-controller-manager/pkg/options"
@@ -106,7 +107,7 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.SafetyOptions.MachineCreationTimeout.Duration, "machine-creation-timeout", s.SafetyOptions.MachineCreationTimeout.Duration, "Timeout (in durartion) used while joining (during creation) of machine before it is declared as failed.")
 	fs.DurationVar(&s.SafetyOptions.MachineHealthTimeout.Duration, "machine-health-timeout", s.SafetyOptions.MachineHealthTimeout.Duration, "Timeout (in durartion) used while re-joining (in case of temporary health issues) of machine before it is declared as failed.")
 	fs.DurationVar(&s.SafetyOptions.MachineDrainTimeout.Duration, "machine-drain-timeout", controller.DefaultMachineDrainTimeout, "Timeout (in durartion) used while draining of machine before deletion, beyond which MCM forcefully deletes machine.")
-	fs.Float64Var(&s.SafetyOptions.FailedMachineDeletionRatio, "failed-machine-deletion-ratio", s.SafetyOptions.FailedMachineDeletionRatio, "Ratio of Failed Machine deletion relative to total amount of Failed Machines in a single MachineSet.")
+	fs.Float64Var(&s.SafetyOptions.FailedMachineDeletionRatio, "failed-machine-deletion-ratio", s.SafetyOptions.FailedMachineDeletionRatio, "Ratio of Failed Machine deletion relative to MachineSet's \"spec.replicas\".")
 	fs.Int32Var(&s.SafetyOptions.MaxEvictRetries, "machine-max-evict-retries", controller.DefaultMaxEvictRetries, "Maximum number of times evicts would be attempted on a pod before it is forcibly deleted during draining of a machine.")
 	fs.DurationVar(&s.SafetyOptions.PvDetachTimeout.Duration, "machine-pv-detach-timeout", s.SafetyOptions.PvDetachTimeout.Duration, "Timeout (in duration) used while waiting for detach of PV while evicting/deleting pods")
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "machine-safety-apiserver-statuscheck-timeout", s.SafetyOptions.MachineSafetyAPIServerStatusCheckTimeout.Duration, "Timeout (in duration) for which the APIServer can be down before declare the machine controller frozen by safety controller")
@@ -128,6 +129,10 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 // Validate is used to validate the options and config before launching the controller manager
 func (s *MCMServer) Validate() error {
 	var errs []error
-	// TODO add validation
+
+	if s.SafetyOptions.FailedMachineDeletionRatio < 0 || s.SafetyOptions.FailedMachineDeletionRatio > 1 {
+		errs = append(errs, fmt.Errorf("\"failed-machine-deletion-ratio\" should be between 0.0 and 1.0 (inclusive)"))
+	}
+
 	return utilerrors.NewAggregate(errs)
 }

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -504,6 +504,7 @@ func createController(
 		MachineSafetyOvershootingPeriod:          metav1.Duration{Duration: 1 * time.Minute},
 		MachineSafetyAPIServerStatusCheckPeriod:  metav1.Duration{Duration: 1 * time.Minute},
 		MachineSafetyAPIServerStatusCheckTimeout: metav1.Duration{Duration: 30 * time.Second},
+		FailedMachineDeletionRatio:               1.0,
 	}
 
 	controller := &controller{

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -826,6 +826,15 @@ func IsMachineFailed(p *v1alpha1.Machine) bool {
 	return false
 }
 
+// IsMachineRunning checks if machine is ready
+func IsMachineRunning(p *v1alpha1.Machine) bool {
+	if p.Status.CurrentStatus.Phase == v1alpha1.MachineRunning {
+		return true
+	}
+
+	return false
+}
+
 // MachineKey is the function used to get the machine name from machine object
 //ToCheck : as machine-namespace does not matter
 func MachineKey(machine *v1alpha1.Machine) string {

--- a/pkg/controller/machine_util_test.go
+++ b/pkg/controller/machine_util_test.go
@@ -1915,7 +1915,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineTemplateSpec{},
 						&machinev1.MachineStatus{
 							Node:          "test-node",
-							CurrentStatus: machinev1.CurrentStatus{Phase: MachineFailed},
+							CurrentStatus: machinev1.CurrentStatus{Phase: machinev1.MachineFailed},
 						},
 						nil, nil, nil),
 				},
@@ -1961,7 +1961,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineTemplateSpec{},
 						&machinev1.MachineStatus{
 							Node:          "test-node",
-							CurrentStatus: machinev1.CurrentStatus{Phase: MachineRunning},
+							CurrentStatus: machinev1.CurrentStatus{Phase: machinev1.MachineRunning},
 						},
 						nil, nil, nil),
 				},
@@ -2007,7 +2007,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineTemplateSpec{},
 						&machinev1.MachineStatus{
 							Node:          "test-node",
-							CurrentStatus: machinev1.CurrentStatus{Phase: MachineTerminating},
+							CurrentStatus: machinev1.CurrentStatus{Phase: machinev1.MachineTerminating},
 						},
 						nil, nil, nil),
 				},
@@ -2053,7 +2053,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineTemplateSpec{},
 						&machinev1.MachineStatus{
 							Node:          "test-node",
-							CurrentStatus: machinev1.CurrentStatus{Phase: MachineTerminating},
+							CurrentStatus: machinev1.CurrentStatus{Phase: machinev1.MachineTerminating},
 						},
 						nil, nil, nil),
 				},
@@ -2103,7 +2103,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineTemplateSpec{},
 						&machinev1.MachineStatus{
 							Node:          "test-node",
-							CurrentStatus: machinev1.CurrentStatus{Phase: MachineFailed},
+							CurrentStatus: machinev1.CurrentStatus{Phase: machinev1.MachineFailed},
 						},
 						nil, nil, nil),
 				},
@@ -2148,7 +2148,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineTemplateSpec{},
 						&machinev1.MachineStatus{
 							Node:          "test-node",
-							CurrentStatus: machinev1.CurrentStatus{Phase: MachineTerminating},
+							CurrentStatus: machinev1.CurrentStatus{Phase: machinev1.MachineTerminating},
 						},
 						nil, nil, nil),
 				},

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -712,6 +712,10 @@ func (c *controller) terminateStaleMachines(inactiveMachines []*v1alpha1.Machine
 	)
 	defer close(errCh)
 
+	if deletionWindow > len(inactiveMachines) {
+		deletionWindow = len(inactiveMachines)
+	}
+
 	wg.Add(deletionWindow)
 	for i := 0; i < deletionWindow; i++ {
 		go c.prepareMachineForDeletion(inactiveMachines[i], machineSet, &wg, errCh)

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -712,10 +712,6 @@ func (c *controller) terminateStaleMachines(inactiveMachines []*v1alpha1.Machine
 	)
 	defer close(errCh)
 
-	if deletionWindow > len(inactiveMachines) {
-		deletionWindow = len(inactiveMachines)
-	}
-
 	wg.Add(deletionWindow)
 	for i := 0; i < deletionWindow; i++ {
 		go c.prepareMachineForDeletion(inactiveMachines[i], machineSet, &wg, errCh)
@@ -773,6 +769,10 @@ func (c *controller) calculateStaleMachineDeletionWindow(activeMachines, running
 		} else {
 			deletionWindow = 0
 		}
+	}
+
+	if deletionWindow > numOfInactiveMachines {
+		deletionWindow = numOfInactiveMachines
 	}
 
 	return deletionWindow

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -223,7 +223,7 @@ FailedMachineDeletionRatio: %v
 
 `
 
-		DescribeTable("", func(machineSetReplicas, runningMachinesCount, pendingMachinesCount, failedMachinesCount,
+		FDescribeTable("", func(machineSetReplicas, runningMachinesCount, pendingMachinesCount, failedMachinesCount,
 			expectedActiveMachinesCount, expectedFailedMachinesCount int, failedMachineDeletionRatio float64) {
 
 			testMachineSet := &machinev1.MachineSet{
@@ -302,13 +302,15 @@ FailedMachineDeletionRatio: %v
 
 			// let's test FailedMachineDeletionRatio behavior
 			generateEntry("should not delete failed machines and not create any new machines"+entryTemplate, 3, 2, 0, 5, 2, 5, 0.0),
-			generateEntry("should delete one machine"+entryTemplate, 3, 2, 0, 5, 2, 4, 0.2),
+			generateEntry("should delete one machine and create one machine"+entryTemplate, 3, 2, 0, 5, 3, 4, 0.2),
 
 			// playing with different FailedMachineDeletionRatios
 			generateEntry("should delete one machine"+entryTemplate, 10, 10, 0, 10, 10, 9, 0.1),
 			generateEntry("should delete two machines"+entryTemplate, 10, 10, 0, 5, 10, 3, 0.2),
 			generateEntry("should delete 4 machines"+entryTemplate, 10, 10, 0, 5, 10, 1, 0.4),
+			generateEntry("should delete 3 failed machines (and create new ones)"+entryTemplate, 10, 5, 0, 5, 8, 2, 0.3),
 			generateEntry("should delete all failed machines (and create new ones)"+entryTemplate, 10, 2, 0, 5, 10, 0, 1.0),
+			generateEntry("should delete two failed machines (and create new ones)"+entryTemplate, 5, 15, 0, 5, 5, 2, 0.5),
 		)
 	})
 
@@ -919,4 +921,8 @@ func generateMachines(running, pending, failed int, labels map[string]string) (r
 
 func generateEntry(template string, parameters ...interface{}) TableEntry {
 	return Entry(fmt.Sprintf(template, parameters...), parameters...)
+}
+
+func FgenerateEntry(template string, parameters ...interface{}) TableEntry {
+	return FEntry(fmt.Sprintf(template, parameters...), parameters...)
 }

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -103,6 +103,8 @@ type SafetyOptions struct {
 	// Deprecated. No effect. Timeout (in durartion) used while draining of machine before deletion,
 	// beyond which it forcefully deletes machine
 	MachineDrainTimeout metav1.Duration
+	// Ratio of Failed Machine deletion relative to total amount of Failed Machines in a single MachineSet
+	FailedMachineDeletionRatio float64
 	// Maximum number of times evicts would be attempted on a pod for it is forcibly deleted
 	// during draining of a machine.
 	MaxEvictRetries int32

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -103,7 +103,7 @@ type SafetyOptions struct {
 	// Deprecated. No effect. Timeout (in durartion) used while draining of machine before deletion,
 	// beyond which it forcefully deletes machine
 	MachineDrainTimeout metav1.Duration
-	// Ratio of Failed Machine deletion relative to total amount of Failed Machines in a single MachineSet
+	// Ratio of Failed Machine deletion relative to MachineSet's "spec.replicas"
 	FailedMachineDeletionRatio float64
 	// Maximum number of times evicts would be attempted on a pod for it is forcibly deleted
 	// during draining of a machine.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an ability to throttle Failed Machine deletion. Why? It's time for a story!

Imagine a Kubernetes cluster, custom-built for a customer. Virtual machines are created via MCM, masters are static. A tragically under-tested infrastructure platform release that severs the routing between Master and Worker Nodes via improperly configured routing tables in a CNI provider.

After losing connection, Machines transfer to the Unknown state, and, after a timeout, into the Failed state, and then MCM deletes them all. All of them at the same time. The recovery time of 80 Nodes in a vSphere environment is abysmal. Disks are slow to detach and attach, the hypervisors become overloaded due to a lot of new machines springing to life.

Moral of the story: if Nodes become detached from Master, the workload would not immediately falter, it's not healthy to remove all Machines from the cluster if they become unavailable. They can still work well, since properly written microservices cache Service Discovery and other information upon startup.

**Special notes for your reviewer**:

If you agree with the overall approach, I'd like to direct your attention to the new table tests. Please, verify the exhaustiveness of the provided test cases.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
A new option "--failed-machine-deletion-ratio" that configures throttling of Failed Machines deletion process until new Machines transition into Running state.
```