### PR TITLE
Use channel id for posting slack release notes

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,6 +42,6 @@ machine-controller-manager:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:
             internal_scp_workspace:
-              channel_name: 'k8s-mcm'
+              channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
         component_descriptor: ~


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the channel id for posting slack release notes so that the definition does not need to be adapted in case the channel will be renamed

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator

```
