### PR TITLE
Add termination condition to deleting nodes

### DIFF
--- a/kubernetes/deployment/in-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/in-tree/control-cluster-role.yaml
@@ -28,6 +28,7 @@ rules:
    - ""
    resources:
    - nodes
+   - nodes/status
    - configmaps
    - secrets
    - endpoints

--- a/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
@@ -28,6 +28,7 @@ rules:
    - ""
    resources:
    - nodes
+   - nodes/status
    - configmaps
    - secrets
    - endpoints

--- a/pkg/util/conditions/conditions.go
+++ b/pkg/util/conditions/conditions.go
@@ -1,0 +1,46 @@
+package conditions
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// CloneAndAddCondition adds condition to the conditions slice if
+func CloneAndAddCondition(conditions []v1.NodeCondition, condition v1.NodeCondition) []v1.NodeCondition {
+	if condition.Type == "" || condition.Status == "" {
+		return conditions
+	}
+	// Clone
+	var newConditions []v1.NodeCondition
+
+	for _, existingCondition := range conditions {
+		if existingCondition.Type != condition.Type { // filter out the condition that is being updated
+			newConditions = append(newConditions, existingCondition)
+		} else { // condition with this type already exists
+			if existingCondition.Status == condition.Status && existingCondition.Reason == condition.Reason {
+				// condition status and reason are  the same, keep existing transition time
+				condition.LastTransitionTime = existingCondition.LastTransitionTime
+			}
+		}
+	}
+
+	newConditions = append(newConditions, condition)
+	return newConditions
+}
+
+// AddOrUpdateCondition adds a condition to the condition list. Returns a new copy of updated Node
+func AddOrUpdateCondition(node *v1.Node, condition v1.NodeCondition) *v1.Node {
+	newNode := node.DeepCopy()
+	nodeConditions := newNode.Status.Conditions
+	newNode.Status.Conditions = CloneAndAddCondition(nodeConditions, condition)
+	return newNode
+}
+
+// GetNodeCondition returns a condition matching the type from the node's status
+func GetNodeCondition(node *v1.Node, conditionType v1.NodeConditionType) *v1.NodeCondition {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == conditionType {
+			return &cond
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Helps users monitor and react to ongoing node terminations.

**Which issue(s) this PR fixes**:
Fixes #488

**Special notes for your reviewer**:
Assumes that termination is final in MCM, and a terminating node cannot be restored. So, only situations where the termination condition is true are handled. 

Note that some RBAC changes are required to allow MCM updates of the node's status. 

**Release note**:
```noteworthy operator
RBAC policies have to be updated to allow updating of `node/status` resources. 
```
```improvement user
Node condition is added to the status of terminating nodes indicating the termination start time and reason (Unhealthy|ScaleDown)
```
