### PR TITLE
Fixes regressions caused by PR #471

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -60,7 +60,6 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
-          description: Standard object metadata.
           type: object
         spec:
           description: Specification of the desired behavior of the MachineDeployment.

--- a/pkg/controller/deployment_machineset_util.go
+++ b/pkg/controller/deployment_machineset_util.go
@@ -152,6 +152,7 @@ func calculateMachineSetStatus(is *v1alpha1.MachineSet, filteredMachines []*v1al
 	newStatus.FullyLabeledReplicas = int32(fullyLabeledReplicasCount)
 	newStatus.ReadyReplicas = int32(readyReplicasCount)
 	newStatus.AvailableReplicas = int32(availableReplicasCount)
+	newStatus.LastOperation.LastUpdateTime = metav1.Now()
 	return newStatus
 }
 


### PR DESCRIPTION
https://github.com/gardener/machine-controller-manager/pull/471

**What this PR does / why we need it**:
Fixes regressions caused by [PR #471](https://github.com/gardener/machine-controller-manager/pull/471)

**Which issue(s) this PR fixes**:
With k8s version 1.18 `metadata.description` isn't supported. And also there was a bug while trying to create a machineSet with a null value for `newstatus.LastOperation.LastUpdateTime` which can no longer be null due to validation. 

```
E0730 17:15:56.773686   16403 machineset.go:535] Update machineSet test-machine-deployment-7dbb854886 failed with: MachineSet.machine.sapcloud.io "test-machine-deployment-7dbb854886" is invalid: status.lastOperation.lastUpdateTime: Invalid value: "null": status.lastOperation.lastUpdateTime in body must be of type string: "null"
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
