### PR TITLE
Inhibit scale-down by autoscaler during roll-outs.

### DIFF
--- a/cmd/machine-controller-manager/app/controllermanager.go
+++ b/cmd/machine-controller-manager/app/controllermanager.go
@@ -273,6 +273,7 @@ func StartControllers(s *options.MCMServer,
 			s.NodeConditions,
 			s.BootstrapTokenAuthExtraGroups,
 			s.DeleteMigratedMachineClass,
+			s.AutoscalerScaleDownAnnotationDuringRollout,
 		)
 		if err != nil {
 			return err

--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -62,6 +62,7 @@ func NewMCMServer() *MCMServer {
 			KubeAPIBurst:            30,
 			LeaderElection:          leaderelectionconfig.DefaultLeaderElectionConfiguration(),
 			ControllerStartInterval: metav1.Duration{Duration: 0 * time.Second},
+			AutoscalerScaleDownAnnotationDuringRollout: true,
 			SafetyOptions: machineconfig.SafetyOptions{
 				SafetyUp:                                 2,
 				SafetyDown:                               1,
@@ -114,6 +115,8 @@ func (s *MCMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.NodeConditions, "node-conditions", s.NodeConditions, "List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.")
 	fs.StringVar(&s.BootstrapTokenAuthExtraGroups, "bootstrap-token-auth-extra-groups", s.BootstrapTokenAuthExtraGroups, "Comma-separated list of groups to set bootstrap token's \"auth-extra-groups\" field to")
 	fs.BoolVar(&s.DeleteMigratedMachineClass, "delete-migrated-machine-class", false, "Deletes any (provider specific) machine class that has the machine.sapcloud.io/migrated annotation")
+
+	fs.BoolVar(&s.AutoscalerScaleDownAnnotationDuringRollout, "autoscaler-scaldown-annotation-during-rollout", true, "Add cluster autoscaler scale-down disabled annotation during roll-out.")
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -81,32 +81,34 @@ func NewController(
 	nodeConditions string,
 	bootstrapTokenAuthExtraGroups string,
 	deleteMigratedMachineClass bool,
+	autoscalerScaleDownAnnotationDuringRollout bool,
 ) (Controller, error) {
 	controller := &controller{
-		namespace:                      namespace,
-		controlMachineClient:           controlMachineClient,
-		controlCoreClient:              controlCoreClient,
-		targetCoreClient:               targetCoreClient,
-		recorder:                       recorder,
-		expectations:                   NewUIDTrackingContExpectations(NewContExpectations()),
-		secretQueue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secret"),
-		nodeQueue:                      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node"),
-		openStackMachineClassQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "openstackmachineclass"),
-		awsMachineClassQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "awsmachineclass"),
-		azureMachineClassQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "azuremachineclass"),
-		gcpMachineClassQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "gcpmachineclass"),
-		alicloudMachineClassQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "alicloudmachineclass"),
-		packetMachineClassQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "packetmachineclass"),
-		machineQueue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machine"),
-		machineSetQueue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineset"),
-		machineDeploymentQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinedeployment"),
-		machineSafetyOrphanVMsQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyorphanvms"),
-		machineSafetyOvershootingQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyovershooting"),
-		machineSafetyAPIServerQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyapiserver"),
-		safetyOptions:                  safetyOptions,
-		nodeConditions:                 nodeConditions,
-		bootstrapTokenAuthExtraGroups:  bootstrapTokenAuthExtraGroups,
-		deleteMigratedMachineClass:     deleteMigratedMachineClass,
+		namespace:                                  namespace,
+		controlMachineClient:                       controlMachineClient,
+		controlCoreClient:                          controlCoreClient,
+		targetCoreClient:                           targetCoreClient,
+		recorder:                                   recorder,
+		expectations:                               NewUIDTrackingContExpectations(NewContExpectations()),
+		secretQueue:                                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secret"),
+		nodeQueue:                                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node"),
+		openStackMachineClassQueue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "openstackmachineclass"),
+		awsMachineClassQueue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "awsmachineclass"),
+		azureMachineClassQueue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "azuremachineclass"),
+		gcpMachineClassQueue:                       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "gcpmachineclass"),
+		alicloudMachineClassQueue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "alicloudmachineclass"),
+		packetMachineClassQueue:                    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "packetmachineclass"),
+		machineQueue:                               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machine"),
+		machineSetQueue:                            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineset"),
+		machineDeploymentQueue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinedeployment"),
+		machineSafetyOrphanVMsQueue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyorphanvms"),
+		machineSafetyOvershootingQueue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyovershooting"),
+		machineSafetyAPIServerQueue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machinesafetyapiserver"),
+		safetyOptions:                              safetyOptions,
+		nodeConditions:                             nodeConditions,
+		bootstrapTokenAuthExtraGroups:              bootstrapTokenAuthExtraGroups,
+		deleteMigratedMachineClass:                 deleteMigratedMachineClass,
+		autoscalerScaleDownAnnotationDuringRollout: autoscalerScaleDownAnnotationDuringRollout,
 	}
 
 	controller.internalExternalScheme = runtime.NewScheme()
@@ -398,10 +400,11 @@ type Controller interface {
 
 // controller is a concrete Controller.
 type controller struct {
-	namespace                     string
-	nodeConditions                string
-	bootstrapTokenAuthExtraGroups string
-	deleteMigratedMachineClass    bool
+	namespace                                  string
+	nodeConditions                             string
+	bootstrapTokenAuthExtraGroups              string
+	deleteMigratedMachineClass                 bool
+	autoscalerScaleDownAnnotationDuringRollout bool
 
 	controlMachineClient machineapi.MachineV1alpha1Interface
 	controlCoreClient    kubernetes.Interface

--- a/pkg/controller/deployment_rolling.go
+++ b/pkg/controller/deployment_rolling.go
@@ -44,6 +44,13 @@ var (
 
 // rolloutRolling implements the logic for rolling a new machine set.
 func (dc *controller) rolloutRolling(d *v1alpha1.MachineDeployment, isList []*v1alpha1.MachineSet, machineMap map[types.UID]*v1alpha1.MachineList) error {
+
+	clusterAutoscalerScaleDownAnnotations := make(map[string]string)
+	clusterAutoscalerScaleDownAnnotations[ClusterAutoscalerScaleDownDisabledAnnotationKey] = ClusterAutoscalerScaleDownDisabledAnnotationValue
+
+	// We do this to avoid accidentally deleting the user provided annotations.
+	clusterAutoscalerScaleDownAnnotations[ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey] = ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue
+
 	newIS, oldISs, err := dc.getAllMachineSetsAndSyncRevision(d, isList, machineMap, true)
 	if err != nil {
 		return err
@@ -57,6 +64,21 @@ func (dc *controller) rolloutRolling(d *v1alpha1.MachineDeployment, isList []*v1
 			Effect: "PreferNoSchedule",
 		},
 	)
+
+	if dc.autoscalerScaleDownAnnotationDuringRollout {
+		// Add the annotation on the all machinesets if there are any old-machinesets and not scaled-to-zero.
+		// This also helps in annotating the node under new-machineset, incase the reconciliation is failing in next
+		// status-rollout steps.
+		if len(oldISs) > 0 && !dc.machineSetsScaledToZero(oldISs) {
+			// Annotate all the nodes under this machine-deployment, as roll-out is on-going.
+			err := dc.annotateNodesBackingMachineSets(allISs, clusterAutoscalerScaleDownAnnotations)
+			if err != nil {
+				klog.Errorf("Failed to add %s on all nodes. Error: %s", clusterAutoscalerScaleDownAnnotations, err)
+				return err
+			}
+		}
+	}
+
 	if err != nil {
 		klog.Warningf("Failed to add %s on all nodes. Error: %s", PreferNoScheduleKey, err)
 	}
@@ -82,6 +104,14 @@ func (dc *controller) rolloutRolling(d *v1alpha1.MachineDeployment, isList []*v1
 	}
 
 	if MachineDeploymentComplete(d, &d.Status) {
+		if dc.autoscalerScaleDownAnnotationDuringRollout {
+			// Check if any of the machine under this MachineDeployment contains the by-mcm annotation, and
+			// remove the original autoscaler annotation only after.
+			err := dc.removeAutoscalerAnnotationsIfRequired(allISs, clusterAutoscalerScaleDownAnnotations)
+			if err != nil {
+				return err
+			}
+		}
 		if err := dc.cleanupMachineDeployment(oldISs, d); err != nil {
 			return err
 		}
@@ -337,6 +367,115 @@ func (dc *controller) taintNodesBackingMachineSets(MachineSets []*v1alpha1.Machi
 			break
 		}
 		klog.V(2).Infof("Tainted MachineSet object %q with %s to avoid scheduling of pods", machineSet.Name, taint.Key)
+	}
+
+	return nil
+}
+
+// annotateNodesBackingMachineSets annotates all nodes backing the machineSets
+func (dc *controller) annotateNodesBackingMachineSets(MachineSets []*v1alpha1.MachineSet, annotations map[string]string) error {
+
+	for _, machineSet := range MachineSets {
+
+		klog.V(3).Infof("Trying to annotate nodes under the MachineSet object %q with %s", machineSet.Name, annotations)
+		selector, err := metav1.LabelSelectorAsSelector(machineSet.Spec.Selector)
+		if err != nil {
+			return err
+		}
+
+		// list all machines to include the machines that don't match the ms`s selector
+		// anymore but has the stale controller ref.
+		// TODO: Do the List and Filter in a single pass, or use an index.
+		filteredMachines, err := dc.machineLister.List(labels.Everything())
+		if err != nil {
+			return err
+		}
+		// NOTE: filteredMachines are pointing to objects from cache - if you need to
+		// modify them, you need to copy it first.
+		filteredMachines, err = dc.claimMachines(machineSet, selector, filteredMachines)
+		if err != nil {
+			return err
+		}
+
+		for _, machine := range filteredMachines {
+			if machine.Status.Node != "" {
+				err = AddOrUpdateAnnotationOnNode(
+					dc.targetCoreClient,
+					machine.Status.Node,
+					annotations,
+				)
+				if err != nil {
+					klog.Warningf("Adding annotation failed for node: %s, %s", machine.Status.Node, err)
+				}
+			}
+		}
+		klog.V(2).Infof("Annotated the nodes backed by MachineSet %q with %s", machineSet.Name, annotations)
+	}
+
+	return nil
+}
+
+func (dc *controller) machineSetsScaledToZero(MachineSets []*v1alpha1.MachineSet) bool {
+	for _, machineSet := range MachineSets {
+		if machineSet.Spec.Replicas != 0 && machineSet.Status.AvailableReplicas != 0 && machineSet.Status.FullyLabeledReplicas != 0 && machineSet.Status.ReadyReplicas != 0 && machineSet.Status.Replicas != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// removeAutoscalerAnnotationsIfRequired removes the annotations if needed from nodes backing machinesets.
+func (dc *controller) removeAutoscalerAnnotationsIfRequired(MachineSets []*v1alpha1.MachineSet, annotations map[string]string) error {
+
+	for _, machineSet := range MachineSets {
+
+		selector, err := metav1.LabelSelectorAsSelector(machineSet.Spec.Selector)
+		if err != nil {
+			return err
+		}
+
+		// list all machines to include the machines that don't match the ms`s selector
+		// anymore but has the stale controller ref.
+		// TODO: Do the List and Filter in a single pass, or use an index.
+		filteredMachines, err := dc.machineLister.List(labels.Everything())
+		if err != nil {
+			return err
+		}
+		// NOTE: filteredMachines are pointing to objects from cache - if you need to
+		// modify them, you need to copy it first.
+		filteredMachines, err = dc.claimMachines(machineSet, selector, filteredMachines)
+		if err != nil {
+			return err
+		}
+
+		for _, machine := range filteredMachines {
+			if machine.Status.Node != "" {
+
+				nodeAnnotations, err := GetAnnotationsFromNode(
+					dc.targetCoreClient,
+					machine.Status.Node,
+				)
+				if err != nil {
+					klog.Warningf("Get annotations failed for node: %s, %s", machine.Status.Node, err)
+					return err
+				}
+
+				// Remove the autoscaler-related annotation only if the by-mcm annotation is already set. If
+				// by-mcm annotation is not set, the original annotation is likely be put by the end-user for their usecases.
+				if _, exists := nodeAnnotations[ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey]; exists {
+					err = RemoveAnnotationsOffNode(
+						dc.targetCoreClient,
+						machine.Status.Node,
+						annotations,
+					)
+					if err != nil {
+						klog.Warningf("Removing annotation failed for node: %s, %s", machine.Status.Node, err)
+						return err
+					}
+					klog.V(3).Infof("De-annotated the node %q backed by MachineSet %q with %s", machine.Status.Node, machineSet.Name, annotations)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/pkg/controller/deployment_rolling_test.go
+++ b/pkg/controller/deployment_rolling_test.go
@@ -197,4 +197,562 @@ var _ = Describe("deployment_rolling", func() {
 			}),
 		)
 	})
+
+	Describe("#annotateNodesBackingMachineSets", func() {
+		type setup struct {
+			nodes               []*corev1.Node
+			machineSets         []*machinev1.MachineSet
+			machines            []*machinev1.Machine
+			existingAnnotations map[string]string
+		}
+		type expect struct {
+			nodeAnnotations map[string]string
+			err             bool
+		}
+		type action struct {
+			machineSets []*machinev1.MachineSet
+			annotations map[string]string
+		}
+		type data struct {
+			setup  setup
+			action action
+			expect expect
+		}
+		objMeta := &metav1.ObjectMeta{
+			Namespace: testNamespace,
+		}
+		machineSets := newMachineSets(
+			1,
+			&machinev1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "machineset-0",
+					Labels: map[string]string{
+						"key": "value",
+					},
+				},
+				Spec: machinev1.MachineSpec{
+					Class: machinev1.ClassSpec{
+						Kind: "OpenStackMachineClass",
+						Name: "test-machine-class",
+					},
+				},
+			},
+			3,
+			500,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		DescribeTable("##table",
+			func(data *data) {
+				stop := make(chan struct{})
+				defer close(stop)
+
+				controlMachineObjects := []runtime.Object{}
+				for _, o := range data.setup.machineSets {
+					controlMachineObjects = append(controlMachineObjects, o)
+				}
+				for _, o := range data.setup.machines {
+					controlMachineObjects = append(controlMachineObjects, o)
+				}
+
+				targetCoreObjects := []runtime.Object{}
+				for _, o := range data.setup.nodes {
+					o.Annotations = data.setup.existingAnnotations
+					targetCoreObjects = append(targetCoreObjects, o)
+				}
+
+				controller, trackers := createController(stop, testNamespace, controlMachineObjects, nil, targetCoreObjects)
+				defer trackers.Stop()
+				waitForCacheSync(stop, controller)
+
+				err := controller.annotateNodesBackingMachineSets(
+					data.action.machineSets,
+					data.action.annotations,
+				)
+				if !data.expect.err {
+					Expect(err).To(BeNil())
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+
+				for _, expectedNode := range data.setup.nodes {
+					actualNode, err := controller.targetCoreClient.CoreV1().Nodes().Get(expectedNode.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(actualNode.Annotations).Should(Equal(data.expect.nodeAnnotations))
+				}
+			},
+			Entry("annotate nodes backing machineSets when there are annotations present", &data{
+				setup: setup{
+					machineSets: machineSets,
+					machines: newMachinesFromMachineSet(
+						1,
+						machineSets[0],
+						&machinev1.MachineStatus{
+							Node: "node",
+						},
+						nil,
+						nil,
+					),
+					nodes: newNodes(
+						1,
+						&corev1.NodeSpec{
+							Taints: []corev1.Taint{},
+						},
+						nil,
+					),
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+				},
+				action: action{
+					machineSets: newMachineSets(
+						1,
+						&machinev1.MachineTemplateSpec{
+							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Spec: machinev1.MachineSpec{
+								Class: machinev1.ClassSpec{
+									Kind: "OpenStackMachineClass",
+									Name: "test-machine-class",
+								},
+							},
+						},
+						3,
+						500,
+						nil,
+						nil,
+						nil,
+						nil,
+					),
+					annotations: map[string]string{
+						"anno2": "anno2",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "anno2",
+					},
+					err: false,
+				},
+			}),
+			Entry("annotate nodes backing machineSets when there are not other annotations", &data{
+				setup: setup{
+					machineSets: machineSets,
+					machines: newMachinesFromMachineSet(
+						1,
+						machineSets[0],
+						&machinev1.MachineStatus{
+							Node: "node",
+						},
+						nil,
+						nil,
+					),
+					nodes: newNodes(
+						1,
+						&corev1.NodeSpec{
+							Taints: []corev1.Taint{},
+						},
+						nil,
+					),
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+				},
+				action: action{
+					machineSets: newMachineSets(
+						1,
+						&machinev1.MachineTemplateSpec{
+							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Spec: machinev1.MachineSpec{
+								Class: machinev1.ClassSpec{
+									Kind: "OpenStackMachineClass",
+									Name: "test-machine-class",
+								},
+							},
+						},
+						3,
+						500,
+						nil,
+						nil,
+						nil,
+						nil,
+					),
+					annotations: map[string]string{
+						"anno1": "anno1",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+					err: false,
+				},
+			}),
+			Entry("annotate nodes backing machineSets when there are same annotations but different value", &data{
+				setup: setup{
+					machineSets: machineSets,
+					machines: newMachinesFromMachineSet(
+						1,
+						machineSets[0],
+						&machinev1.MachineStatus{
+							Node: "node",
+						},
+						nil,
+						nil,
+					),
+					nodes: newNodes(
+						1,
+						&corev1.NodeSpec{
+							Taints: []corev1.Taint{},
+						},
+						nil,
+					),
+					existingAnnotations: map[string]string{
+						"anno1": "annoDummy",
+					},
+				},
+				action: action{
+					machineSets: newMachineSets(
+						1,
+						&machinev1.MachineTemplateSpec{
+							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Spec: machinev1.MachineSpec{
+								Class: machinev1.ClassSpec{
+									Kind: "OpenStackMachineClass",
+									Name: "test-machine-class",
+								},
+							},
+						},
+						3,
+						500,
+						nil,
+						nil,
+						nil,
+						nil,
+					),
+					annotations: map[string]string{
+						"anno1": "anno1",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+					err: false,
+				},
+			}),
+			Entry("when there are no nodes backiing the machinesets", &data{
+				setup: setup{
+					machineSets: machineSets,
+					machines: newMachinesFromMachineSet(
+						1,
+						machineSets[0],
+						&machinev1.MachineStatus{
+							Node: "node",
+						},
+						nil,
+						nil,
+					),
+					nodes: newNodes(
+						0,
+						&corev1.NodeSpec{
+							Taints: []corev1.Taint{},
+						},
+						nil,
+					),
+					existingAnnotations: map[string]string{
+						"anno2": "anno2",
+					},
+				},
+				action: action{
+					machineSets: newMachineSets(
+						1,
+						&machinev1.MachineTemplateSpec{
+							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Spec: machinev1.MachineSpec{
+								Class: machinev1.ClassSpec{
+									Kind: "OpenStackMachineClass",
+									Name: "test-machine-class",
+								},
+							},
+						},
+						3,
+						500,
+						nil,
+						nil,
+						nil,
+						nil,
+					),
+					annotations: map[string]string{
+						"anno1": "anno1",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "anno2",
+					},
+					err: false,
+				},
+			}),
+		)
+	})
+
+	Describe("#removeAutoscalerAnnotationsIfRequired", func() {
+		type setup struct {
+			nodes               []*corev1.Node
+			machineSets         []*machinev1.MachineSet
+			machines            []*machinev1.Machine
+			existingAnnotations map[string]string
+		}
+		type expect struct {
+			nodeAnnotations map[string]string
+			err             bool
+		}
+		type action struct {
+			machineSets []*machinev1.MachineSet
+			annotations map[string]string
+		}
+		type data struct {
+			setup  setup
+			action action
+			expect expect
+		}
+		objMeta := &metav1.ObjectMeta{
+			Namespace: testNamespace,
+		}
+		machineSets := newMachineSets(
+			1,
+			&machinev1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "machineset-0",
+					Labels: map[string]string{
+						"key": "value",
+					},
+				},
+				Spec: machinev1.MachineSpec{
+					Class: machinev1.ClassSpec{
+						Kind: "OpenStackMachineClass",
+						Name: "test-machine-class",
+					},
+				},
+			},
+			3,
+			500,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		DescribeTable("##table",
+			func(data *data) {
+				stop := make(chan struct{})
+				defer close(stop)
+
+				controlMachineObjects := []runtime.Object{}
+				for _, o := range data.setup.machineSets {
+					controlMachineObjects = append(controlMachineObjects, o)
+				}
+				for _, o := range data.setup.machines {
+					controlMachineObjects = append(controlMachineObjects, o)
+				}
+
+				targetCoreObjects := []runtime.Object{}
+				for _, o := range data.setup.nodes {
+					o.Annotations = data.setup.existingAnnotations
+					targetCoreObjects = append(targetCoreObjects, o)
+				}
+
+				controller, trackers := createController(stop, testNamespace, controlMachineObjects, nil, targetCoreObjects)
+				defer trackers.Stop()
+				waitForCacheSync(stop, controller)
+
+				err := controller.removeAutoscalerAnnotationsIfRequired(
+					data.action.machineSets,
+					data.action.annotations,
+				)
+				if !data.expect.err {
+					Expect(err).To(BeNil())
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+
+				for _, expectedNode := range data.setup.nodes {
+					actualNode, err := controller.targetCoreClient.CoreV1().Nodes().Get(expectedNode.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(actualNode.Annotations).Should(Equal(data.expect.nodeAnnotations))
+				}
+			},
+			Entry("remove autoscaler annotation when by-mcm annotation is present", &data{
+				setup: setup{
+					machineSets: machineSets,
+					machines: newMachinesFromMachineSet(
+						1,
+						machineSets[0],
+						&machinev1.MachineStatus{
+							Node: "node",
+						},
+						nil,
+						nil,
+					),
+					nodes: newNodes(
+						1,
+						&corev1.NodeSpec{
+							Taints: []corev1.Taint{},
+						},
+						nil,
+					),
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+					},
+				},
+				action: action{
+					machineSets: newMachineSets(
+						1,
+						&machinev1.MachineTemplateSpec{
+							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Spec: machinev1.MachineSpec{
+								Class: machinev1.ClassSpec{
+									Kind: "OpenStackMachineClass",
+									Name: "test-machine-class",
+								},
+							},
+						},
+						3,
+						500,
+						nil,
+						nil,
+						nil,
+						nil,
+					),
+					annotations: map[string]string{
+						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+					err: false,
+				},
+			}),
+			Entry("do not remove autoscaler annotation when by-mcm annotation is not present", &data{
+				setup: setup{
+					machineSets: machineSets,
+					machines: newMachinesFromMachineSet(
+						1,
+						machineSets[0],
+						&machinev1.MachineStatus{
+							Node: "node",
+						},
+						nil,
+						nil,
+					),
+					nodes: newNodes(
+						1,
+						&corev1.NodeSpec{
+							Taints: []corev1.Taint{},
+						},
+						nil,
+					),
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+						ClusterAutoscalerScaleDownDisabledAnnotationKey: ClusterAutoscalerScaleDownDisabledAnnotationValue,
+					},
+				},
+				action: action{
+					machineSets: newMachineSets(
+						1,
+						&machinev1.MachineTemplateSpec{
+							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Spec: machinev1.MachineSpec{
+								Class: machinev1.ClassSpec{
+									Kind: "OpenStackMachineClass",
+									Name: "test-machine-class",
+								},
+							},
+						},
+						3,
+						500,
+						nil,
+						nil,
+						nil,
+						nil,
+					),
+					annotations: map[string]string{
+						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+						ClusterAutoscalerScaleDownDisabledAnnotationKey: ClusterAutoscalerScaleDownDisabledAnnotationValue,
+					},
+					err: false,
+				},
+			}),
+			Entry("when there are no autoscaler annotations present", &data{
+				setup: setup{
+					machineSets: machineSets,
+					machines: newMachinesFromMachineSet(
+						1,
+						machineSets[0],
+						&machinev1.MachineStatus{
+							Node: "node",
+						},
+						nil,
+						nil,
+					),
+					nodes: newNodes(
+						1,
+						&corev1.NodeSpec{
+							Taints: []corev1.Taint{},
+						},
+						nil,
+					),
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+				},
+				action: action{
+					machineSets: newMachineSets(
+						1,
+						&machinev1.MachineTemplateSpec{
+							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Spec: machinev1.MachineSpec{
+								Class: machinev1.ClassSpec{
+									Kind: "OpenStackMachineClass",
+									Name: "test-machine-class",
+								},
+							},
+						},
+						3,
+						500,
+						nil,
+						nil,
+						nil,
+						nil,
+					),
+					annotations: map[string]string{
+						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+					err: false,
+				},
+			}),
+		)
+	})
 })

--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -109,6 +109,14 @@ const (
 	// PreferNoScheduleKey is used to identify machineSet nodes on which PreferNoSchedule taint is added on
 	// older machineSets during a rolling update
 	PreferNoScheduleKey = "deployment.machine.sapcloud.io/prefer-no-schedule"
+	// ClusterAutoscalerScaleDownDisabledAnnotationKey annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+	// ClusterAutoscalerScaleDownDisabledAnnotationValue annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationValue = "True"
+	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled-by-mcm"
+	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue = "True"
 
 	// RollbackRevisionNotFound is not found rollback event reason
 	RollbackRevisionNotFound = "DeploymentRollbackRevisionNotFound"

--- a/pkg/options/types.go
+++ b/pkg/options/types.go
@@ -46,7 +46,6 @@ type MachineControllerManagerConfiguration struct {
 
 	// namespace in seed cluster in which controller would look for the resources.
 	Namespace string
-
 	// port is the port that the controller-manager's http service runs on.
 	Port int32
 	// address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
@@ -57,7 +56,6 @@ type MachineControllerManagerConfiguration struct {
 	// allowed to sync concurrently. Larger number = more responsive nodes,
 	// but more CPU (and network) load.
 	ConcurrentNodeSyncs int32
-
 	// enableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling bool
 	// enableContentionProfiling enables lock contention profiling, if enableProfiling is true.
@@ -75,16 +73,17 @@ type MachineControllerManagerConfiguration struct {
 	// minResyncPeriod is the resync period in reflectors; will be random between
 	// minResyncPeriod and 2*minResyncPeriod.
 	MinResyncPeriod metav1.Duration
-
 	// SafetyOptions is the set of options to set to ensure safety of controller
 	SafetyOptions SafetyOptions
-
 	// NodeCondition is the string of known NodeConditions. If any of these NodeCondition is set for a timeout period, the machine  will be declared failed and will replaced.
 	NodeConditions string
 	// BootstrapTokenAuthExtraGroups is a comma-separated string of groups to set bootstrap token's "auth-extra-groups" field to.
 	BootstrapTokenAuthExtraGroups string
 	// DeleteMigratedMachineClass deletes any machine class with has the migrate machineclass
 	DeleteMigratedMachineClass bool
+	// AutoscalerScaleDownAnnotationDuringRollout is an option to disable annotating the node-objects during roll-out.
+	// The cluster autoscaler native annotation is "cluster-autoscaler.kubernetes.io/scale-down-disabled".
+	AutoscalerScaleDownAnnotationDuringRollout bool
 }
 
 // SafetyOptions are used to configure the upper-limit and lower-limit

--- a/pkg/util/annotations/annotations.go
+++ b/pkg/util/annotations/annotations.go
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package annotations implements utilites for working with annotatoins
+package annotations
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// AddOrUpdateAnnotation tries to add an annotation. Returns a new copy of updated Node and true if something was updated
+// false otherwise.
+func AddOrUpdateAnnotation(node *v1.Node, annotations map[string]string) (*v1.Node, bool, error) {
+
+	newNode := node.DeepCopy()
+	nodeAnnotations := newNode.Annotations
+	updated := false
+
+	if nodeAnnotations == nil {
+		nodeAnnotations = make(map[string]string)
+	}
+
+	for annotationKey, annotationValue := range annotations {
+		if nodeAnnotationValue, exists := nodeAnnotations[annotationKey]; exists {
+			if nodeAnnotationValue == annotationValue {
+				// Annotation is already available on the node.
+				continue
+			}
+		}
+		// If the given annotation doesnt exist in the nodeAnnotation, we anyways update.
+		nodeAnnotations[annotationKey] = annotationValue
+		updated = true
+	}
+
+	newNode.Annotations = nodeAnnotations
+
+	return newNode, updated, nil
+}
+
+// RemoveAnnotation tries to remove an annotation from annotations list. Returns a new copy of updated Node and true if something was updated
+// false otherwise.
+func RemoveAnnotation(node *v1.Node, annotations map[string]string) (*v1.Node, bool, error) {
+	newNode := node.DeepCopy()
+	nodeAnnotations := newNode.Annotations
+	deleted := false
+
+	// Short circuit if annotation doesnt exist for limiting API calls.
+	if node == nil || node.Annotations == nil || annotations == nil {
+		return newNode, deleted, nil
+	}
+
+	newAnnotations, deleted := DeleteAnnotation(nodeAnnotations, annotations)
+	newNode.Annotations = newAnnotations
+	return newNode, deleted, nil
+}
+
+// DeleteAnnotation removes the annotation with annotationKey.
+func DeleteAnnotation(nodeAnnotations map[string]string, annotations map[string]string) (map[string]string, bool) {
+	newAnnotations := make(map[string]string)
+	deleted := false
+	for key, value := range nodeAnnotations {
+		if _, exists := annotations[key]; exists {
+			deleted = true
+			continue
+		}
+		newAnnotations[key] = value
+	}
+	return newAnnotations, deleted
+}

--- a/pkg/util/annotations/annotations_suite_test.go
+++ b/pkg/util/annotations/annotations_suite_test.go
@@ -1,0 +1,13 @@
+package annotations_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAnnotations(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Annotations Suite")
+}

--- a/pkg/util/annotations/annotations_test.go
+++ b/pkg/util/annotations/annotations_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package annotations
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("annotations", func() {
+
+	Describe("#AddOrUpdateAnnotation", func() {
+		type setup struct {
+			existingAnnotations map[string]string
+		}
+		type expect struct {
+			nodeAnnotations map[string]string
+			updated         bool
+			err             bool
+		}
+		type action struct {
+			toBeAppliedAnnotations map[string]string
+		}
+		type data struct {
+			setup  setup
+			action action
+			expect expect
+		}
+
+		DescribeTable("##table",
+			func(data *data) {
+				stop := make(chan struct{})
+				defer close(stop)
+
+				nodeObject := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+				}
+				nodeObject.Annotations = data.setup.existingAnnotations
+
+				newNode, updated, err := AddOrUpdateAnnotation(
+					&nodeObject,
+					data.action.toBeAppliedAnnotations,
+				)
+				if !data.expect.err {
+					Expect(err).To(BeNil())
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+
+				Expect(newNode.Annotations).Should(Equal(data.expect.nodeAnnotations))
+				Expect(updated).Should(Equal(data.expect.updated))
+			},
+			Entry("Add the given annotation", &data{
+				setup: setup{
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+				},
+				action: action{
+					toBeAppliedAnnotations: map[string]string{
+						"anno2": "anno2",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "anno2",
+					},
+					updated: true,
+					err:     false,
+				},
+			}),
+			Entry("Update the given annotation", &data{
+				setup: setup{
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "annoDummy",
+					},
+				},
+				action: action{
+					toBeAppliedAnnotations: map[string]string{
+						"anno2": "anno2",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "anno2",
+					},
+					updated: true,
+					err:     false,
+				},
+			}),
+			Entry("Add annotations when there are none in node", &data{
+				setup: setup{
+					existingAnnotations: map[string]string{},
+				},
+				action: action{
+					toBeAppliedAnnotations: map[string]string{
+						"anno2": "anno2",
+						"anno1": "anno1",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "anno2",
+					},
+					updated: true,
+					err:     false,
+				},
+			}),
+		)
+	})
+	Describe("#RemoveAnnotation", func() {
+		type setup struct {
+			existingAnnotations map[string]string
+		}
+		type expect struct {
+			nodeAnnotations map[string]string
+			updated         bool
+			err             bool
+		}
+		type action struct {
+			toBeAppliedAnnotations map[string]string
+		}
+		type data struct {
+			setup  setup
+			action action
+			expect expect
+		}
+
+		DescribeTable("##table",
+			func(data *data) {
+				stop := make(chan struct{})
+				defer close(stop)
+
+				nodeObject := corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node-0",
+					},
+				}
+				nodeObject.Annotations = data.setup.existingAnnotations
+
+				newNode, updated, err := RemoveAnnotation(
+					&nodeObject,
+					data.action.toBeAppliedAnnotations,
+				)
+				if !data.expect.err {
+					Expect(err).To(BeNil())
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+
+				Expect(newNode.Annotations).Should(Equal(data.expect.nodeAnnotations))
+				Expect(updated).Should(Equal(data.expect.updated))
+			},
+			Entry("Remove the given annotation when it already exists", &data{
+				setup: setup{
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "anno2",
+					},
+				},
+				action: action{
+					toBeAppliedAnnotations: map[string]string{
+						"anno2": "anno2",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+					updated: true,
+					err:     false,
+				},
+			}),
+			Entry("Remove the given annotation when it exists but modified value", &data{
+				setup: setup{
+					existingAnnotations: map[string]string{
+						"anno1": "anno1",
+						"anno2": "annoDummy",
+					},
+				},
+				action: action{
+					toBeAppliedAnnotations: map[string]string{
+						"anno2": "anno2",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{
+						"anno1": "anno1",
+					},
+					updated: true,
+					err:     false,
+				},
+			}),
+			Entry("When the annotation doesnt exist in the node", &data{
+				setup: setup{
+					existingAnnotations: map[string]string{},
+				},
+				action: action{
+					toBeAppliedAnnotations: map[string]string{
+						"anno2": "anno2",
+					},
+				},
+				expect: expect{
+					nodeAnnotations: map[string]string{},
+					updated:         false,
+					err:             false,
+				},
+			}),
+		)
+	})
+
+})

--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"


### PR DESCRIPTION
**What this PR does / why we need it**: With this PR, during roll out of the machine-deployment, all the machines under it are annotated with `cluster-autoscaler.kubernetes.io/scale-down-disabled: "True"`. 

This will help us keeping the cluster-autoscaler running even during the cluster-rollouts. CA will not scale-down a specific machine-deployment which is being rolled, but will be able to scale-down the rest of them. Also, CA will be able to scale-up all the machine-deployments during roll-outs.

There are mainly 2 parts to the PR:
1. Adding the annotation during roll-out.
   - To determine if the roll-out if on-going we check if there are old-machine-sets that are not scaled-to-zero completely. We check the `up-to-date`, and `ready` replicas as well here.
 
2. Removing the annotation after the roll-out.
   - Keeping the controller nature in mind, we need a way to differentiate between 2 possibilities:
       - Cluster rollout just got over, MachineDeployment is complete[all machine-replicas ready] and we should remove the annotation. 
       - There have been no roll-outs recently, MachineDeployment is complete and we shouldn't remove the annotation. Looking at older machine-set doesn't help as I see them retained after roll-outs.
    - If we don't consider the possibilities above, we may end up removing the same ca-annotation which might have been added by the user via `NodeTemplate`.
    - I have mitigated the situation, by introducing the `by-mcm` annotation, which is added on the node along with the original annotation. This place-holder-annotation helps in deciding if the original annotation is added by mcm or by the user. This helps in avoiding potential race-condition with `nodeTemplate`  logic.
    - Open for further suggestions or alternatives. 

Unfortunately, we cant use the `nodeTemplate` feature for adding/removing the annotation:
1. If we set the annotation on the MachineSet's `nodeTemplate`, machine-deployment overwrites it back.
   - If we ignore the specific annotation in code, user-provided CA-annotation might also be overwritten. 
2. If we set the annotation on the MachineDeployment's `nodeTemplate`, worker-controller will eventually overwrite it to the original state.


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/autoscaler/issues/48
FIxes https://github.com/gardener/machine-controller-manager/issues/472

**Special notes for your reviewer**:
We need to consider the possibility that users might also be using the same annotation for their use cases. We should make sure, autoscaler annotations from users are maintained. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Machine-deployments being rolled-out are annotated with `cluster-autoscaler.kubernetes.io/scale-down-disabled: "True"` for the duration of the rolling-update.
```
