### PR TITLE
Limit the Random Hash in the MachineSet Name

### DIFF
--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -304,7 +304,7 @@ func (dc *controller) getNewMachineSet(d *v1alpha1.MachineDeployment, isList, ol
 	newIS := v1alpha1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
 			// Make the name deterministic, to ensure idempotence
-			Name:            d.Name + "-" + rand.SafeEncodeString(machineTemplateSpecHash),
+			Name:            d.Name + "-" + rand.SafeEncodeString(machineTemplateSpecHash)[:5],
 			Namespace:       d.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(d, controllerKind)},
 			Labels:          newISTemplate.Labels,


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, MachineSet names are with variable length of the random hash. The MCM is also not limiting the random hash in the machineset names. But if we limit the length of the random hash, it will help to reduce the occurrences of the CSI issue till it is fixed upstream

**Which issue(s) this PR fixes**:
Fixes #461 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
