### PR TITLE
Make src/dst checks configurable on awsmachineclass

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
@@ -181,6 +181,11 @@ spec:
                     items:
                       type: string
                     type: array
+                  srcAndDstChecksEnabled:
+                    description: If set to false, source and destination checks are
+                      disabled on machine network inferface level, default value is
+                      true
+                    type: boolean
                   subnetID:
                     description: The ID of the subnet associated with the network
                       string. Applies only if creating a network interface when launching
@@ -203,6 +208,8 @@ spec:
                     name must be unique.
                   type: string
               type: object
+            spotPrice:
+              type: string
             tags:
               additionalProperties:
                 type: string

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -60,6 +60,7 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
+          description: Standard object metadata.
           type: object
         spec:
           description: Specification of the desired behavior of the MachineDeployment.
@@ -221,6 +222,28 @@ spec:
                           description: Name of machine class
                           type: string
                       type: object
+                    creationTimeout:
+                      description: MachineCreationTimeout is the timeout after which
+                        machinie creation is declared failed.
+                      type: string
+                    drainTimeout:
+                      description: MachineDraintimeout is the timeout after which
+                        machine is forcefully deleted.
+                      type: string
+                    healthTimeout:
+                      description: MachineHealthTimeout is the timeout after which
+                        machine is declared unhealhty/failed.
+                      type: string
+                    maxEvictRetries:
+                      description: MaxEvictRetries is the number of retries that will
+                        be attempted while draining the node.
+                      format: int32
+                      type: integer
+                    nodeConditions:
+                      description: NodeConditions are the set of conditions if set
+                        to true for MachineHealthTimeOut, machine will be declared
+                        failed.
+                      type: string
                     nodeTemplate:
                       description: NodeTemplateSpec describes the data a node should
                         have when created from a template

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -50,6 +50,27 @@ spec:
                   description: Name of machine class
                   type: string
               type: object
+            creationTimeout:
+              description: MachineCreationTimeout is the timeout after which machinie
+                creation is declared failed.
+              type: string
+            drainTimeout:
+              description: MachineDraintimeout is the timeout after which machine
+                is forcefully deleted.
+              type: string
+            healthTimeout:
+              description: MachineHealthTimeout is the timeout after which machine
+                is declared unhealhty/failed.
+              type: string
+            maxEvictRetries:
+              description: MaxEvictRetries is the number of retries that will be attempted
+                while draining the node.
+              format: int32
+              type: integer
+            nodeConditions:
+              description: NodeConditions are the set of conditions if set to true
+                for MachineHealthTimeOut, machine will be declared failed.
+              type: string
             nodeTemplate:
               description: NodeTemplateSpec describes the data a node should have
                 when created from a template

--- a/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
@@ -148,6 +148,28 @@ spec:
                           description: Name of machine class
                           type: string
                       type: object
+                    creationTimeout:
+                      description: MachineCreationTimeout is the timeout after which
+                        machinie creation is declared failed.
+                      type: string
+                    drainTimeout:
+                      description: MachineDraintimeout is the timeout after which
+                        machine is forcefully deleted.
+                      type: string
+                    healthTimeout:
+                      description: MachineHealthTimeout is the timeout after which
+                        machine is declared unhealhty/failed.
+                      type: string
+                    maxEvictRetries:
+                      description: MaxEvictRetries is the number of retries that will
+                        be attempted while draining the node.
+                      format: int32
+                      type: integer
+                    nodeConditions:
+                      description: NodeConditions are the set of conditions if set
+                        to true for MachineHealthTimeOut, machine will be declared
+                        failed.
+                      type: string
                     nodeTemplate:
                       description: NodeTemplateSpec describes the data a node should
                         have when created from a template

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -829,6 +829,9 @@ type AWSNetworkInterfaceSpec struct {
 	// The ID of the subnet associated with the network string. Applies only if
 	// creating a network interface when launching an machine.
 	SubnetID string
+
+	// If set to false, source and destination checks are disabled on machine network inferface level, default value is true
+	SrcAndDstChecksEnabled *bool
 }
 
 /********************** AzureMachineClass APIs ***************/

--- a/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
@@ -201,4 +201,7 @@ type AWSNetworkInterfaceSpec struct {
 	// The ID of the subnet associated with the network string. Applies only if
 	// creating a network interface when launching an machine.
 	SubnetID string `json:"subnetID,omitempty"`
+
+	// If set to false, source and destination checks are disabled on machine network inferface level, default value is true
+	SrcAndDstChecksEnabled *bool `json:"srcAndDstChecksEnabled,omitempty"`
 }

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -945,6 +945,7 @@ func autoConvert_v1alpha1_AWSNetworkInterfaceSpec_To_machine_AWSNetworkInterface
 	out.Description = (*string)(unsafe.Pointer(in.Description))
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
 	out.SubnetID = in.SubnetID
+	out.SrcAndDstChecksEnabled = (*bool)(unsafe.Pointer(in.SrcAndDstChecksEnabled))
 	return nil
 }
 
@@ -959,6 +960,7 @@ func autoConvert_machine_AWSNetworkInterfaceSpec_To_v1alpha1_AWSNetworkInterface
 	out.Description = (*string)(unsafe.Pointer(in.Description))
 	out.SecurityGroupIDs = *(*[]string)(unsafe.Pointer(&in.SecurityGroupIDs))
 	out.SubnetID = in.SubnetID
+	out.SrcAndDstChecksEnabled = (*bool)(unsafe.Pointer(in.SrcAndDstChecksEnabled))
 	return nil
 }
 

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -222,6 +222,11 @@ func (in *AWSNetworkInterfaceSpec) DeepCopyInto(out *AWSNetworkInterfaceSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SrcAndDstChecksEnabled != nil {
+		in, out := &in.SrcAndDstChecksEnabled, &out.SrcAndDstChecksEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -222,6 +222,11 @@ func (in *AWSNetworkInterfaceSpec) DeepCopyInto(out *AWSNetworkInterfaceSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.SrcAndDstChecksEnabled != nil {
+		in, out := &in.SrcAndDstChecksEnabled, &out.SrcAndDstChecksEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -731,6 +731,13 @@ func schema_pkg_apis_machine_v1alpha1_AWSNetworkInterfaceSpec(ref common.Referen
 							Format:      "",
 						},
 					},
+					"srcAndDstChecksEnabled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If set to false, source and destination checks are disabled on machine network inferface level, default value is true",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the aws src/dst checks configurable on a machine network interface level.
To disable the the src/dst checks the `srcAndDstChecksEnabled` field has to be set to false in the `awsmachineclass`.
The default value is set to true.
```
spec:
  networkInterfaces:
  -   srcAndDstChecksEnabled: false
```
**Which issue(s) this PR fixes**:
Fixes #499

```improvement operator
Src/dst checks are now configurable on awsmachineclass via `spec.networkInterfaces.srcAndDstChecksEnabled` field. The checks are enabled by default.
```
