### PR TITLE
Wait also for CSI PVs during serial eviction

### DIFF
--- a/pkg/driver/driver_alicloud.go
+++ b/pkg/driver/driver_alicloud.go
@@ -36,6 +36,11 @@ import (
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 )
 
+const (
+	// alicloudDriverName is the name of the CSI driver for Alibaba Cloud
+	alicloudDriverName = "diskplugin.csi.alibabacloud.com"
+)
+
 // AlicloudDriver is the driver struct for holding Alicloud machine information
 type AlicloudDriver struct {
 	AlicloudMachineClass *v1alpha1.AlicloudMachineClass
@@ -314,7 +319,7 @@ func (c *AlicloudDriver) GetVolNames(specs []corev1.PersistentVolumeSpec) ([]str
 			if name, ok := spec.FlexVolume.Options["volumeId"]; ok {
 				names = append(names, name)
 			}
-		} else if spec.CSI != nil && spec.CSI.Driver == "diskplugin.csi.alibabacloud.com" && spec.CSI.VolumeHandle != "" {
+		} else if spec.CSI != nil && spec.CSI.Driver == alicloudDriverName && spec.CSI.VolumeHandle != "" {
 			names = append(names, spec.CSI.VolumeHandle)
 		}
 	}

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -43,6 +43,11 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	// azureDiskDriverName is the name of the CSI driver for Azure Disk
+	azureDiskDriverName = "disk.csi.azure.com"
+)
+
 // AzureDriver is the driver struct for holding azure machine information
 type AzureDriver struct {
 	AzureMachineClass *v1alpha1.AzureMachineClass
@@ -1165,12 +1170,13 @@ func (d *AzureDriver) GetVolNames(specs []corev1.PersistentVolumeSpec) ([]string
 	names := []string{}
 	for i := range specs {
 		spec := &specs[i]
-		if spec.AzureDisk == nil {
-			// Not an azure volume
-			continue
+		if spec.AzureDisk != nil {
+			name := spec.AzureDisk.DiskName
+			names = append(names, name)
+		} else if spec.CSI != nil && spec.CSI.Driver == azureDiskDriverName && spec.CSI.VolumeHandle != "" {
+			name := spec.CSI.VolumeHandle
+			names = append(names, name)
 		}
-		name := spec.AzureDisk.DiskName
-		names = append(names, name)
 	}
 	return names, nil
 }

--- a/pkg/driver/driver_azure_test.go
+++ b/pkg/driver/driver_azure_test.go
@@ -17,15 +17,17 @@ limitations under the License.
 package driver
 
 import (
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var _ = Describe("Driver Azure", func() {
 
-	Context("GenerateDataDisks Driver Azure Spec", func() {
+	Context("#generateDataDisks", func() {
 
 		It("should convert multiple dataDisks successfully", func() {
 			azureDriver := &AzureDriver{}
@@ -145,6 +147,60 @@ var _ = Describe("Driver Azure", func() {
 
 			Expect(disksGenerated).To(Equal(expectedDisks))
 		})
+	})
 
+	Context("#GetVolNames", func() {
+		var hostPathPVSpec = corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/mnt/data",
+				},
+			},
+		}
+
+		It("should handle in-tree PV (with .spec.azureDisk)", func() {
+			driver := &AzureDriver{}
+			pvs := []corev1.PersistentVolumeSpec{
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureDisk: &corev1.AzureDiskVolumeSource{
+							DiskName: "disk-1",
+						},
+					},
+				},
+				hostPathPVSpec,
+			}
+
+			actual, err := driver.GetVolNames(pvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal([]string{"disk-1"}))
+		})
+
+		It("should handle out-of-tree PV (with .spec.csi.volumeHandle)", func() {
+			driver := &AzureDriver{}
+			pvs := []corev1.PersistentVolumeSpec{
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       "io.kubernetes.storage.mock",
+							VolumeHandle: "vol-2",
+						},
+					},
+				},
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       "disk.csi.azure.com",
+							VolumeHandle: "vol-1",
+						},
+					},
+				},
+				hostPathPVSpec,
+			}
+
+			actual, err := driver.GetVolNames(pvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal([]string{"vol-1"}))
+		})
 	})
 })

--- a/pkg/driver/driver_gcp_test.go
+++ b/pkg/driver/driver_gcp_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Driver GCP", func() {
+	Context("#GetVolNames", func() {
+		var hostPathPVSpec = corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/mnt/data",
+				},
+			},
+		}
+
+		It("should handle in-tree PV (with .spec.gcePersistentDisk)", func() {
+			driver := &GCPDriver{}
+			pvs := []corev1.PersistentVolumeSpec{
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						GCEPersistentDisk: &corev1.GCEPersistentDiskVolumeSource{
+							PDName: "vol-1",
+						},
+					},
+				},
+				hostPathPVSpec,
+			}
+
+			actual, err := driver.GetVolNames(pvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal([]string{"vol-1"}))
+		})
+
+		It("should handle out-of-tree PV (with .spec.csi.volumeHandle)", func() {
+			driver := &GCPDriver{}
+			pvs := []corev1.PersistentVolumeSpec{
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       "io.kubernetes.storage.mock",
+							VolumeHandle: "vol-2",
+						},
+					},
+				},
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       "pd.csi.storage.gke.io",
+							VolumeHandle: "vol-1",
+						},
+					},
+				},
+				hostPathPVSpec,
+			}
+
+			actual, err := driver.GetVolNames(pvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal([]string{"vol-1"}))
+		})
+	})
+})

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -44,6 +44,11 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 )
 
+const (
+	// CinderDriverName is the name of the CSI driver for Cinder
+	cinderDriverName = "cinder.csi.openstack.org"
+)
+
 type logger struct{}
 
 func (l logger) Printf(format string, args ...interface{}) {
@@ -537,12 +542,13 @@ func (d *OpenStackDriver) GetVolNames(specs []corev1.PersistentVolumeSpec) ([]st
 	names := []string{}
 	for i := range specs {
 		spec := &specs[i]
-		if spec.Cinder == nil {
-			// Not a openStack volume
-			continue
+		if spec.Cinder != nil {
+			name := spec.Cinder.VolumeID
+			names = append(names, name)
+		} else if spec.CSI != nil && spec.CSI.Driver == cinderDriverName && spec.CSI.VolumeHandle != "" {
+			name := spec.CSI.VolumeHandle
+			names = append(names, name)
 		}
-		name := spec.Cinder.VolumeID
-		names = append(names, name)
 	}
 	return names, nil
 }

--- a/pkg/driver/driver_openstack_test.go
+++ b/pkg/driver/driver_openstack_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("Driver Openstack", func() {
+
+	Context("#GetVolNames", func() {
+		var hostPathPVSpec = corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: "/mnt/data",
+				},
+			},
+		}
+
+		It("should handle in-tree PV (with .spec.cinder)", func() {
+			driver := &OpenStackDriver{}
+			pvs := []corev1.PersistentVolumeSpec{
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						Cinder: &corev1.CinderPersistentVolumeSource{
+							VolumeID: "a5ebd05f-934f-480d-b06f-41b372ed631e",
+						},
+					},
+				},
+				hostPathPVSpec,
+			}
+
+			actual, err := driver.GetVolNames(pvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal([]string{"a5ebd05f-934f-480d-b06f-41b372ed631e"}))
+		})
+
+		It("should handle out-of-tree PV (with .spec.csi.volumeHandle)", func() {
+			driver := &OpenStackDriver{}
+			pvs := []corev1.PersistentVolumeSpec{
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       "io.kubernetes.storage.mock",
+							VolumeHandle: "vol-2",
+						},
+					},
+				},
+				{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       "cinder.csi.openstack.org",
+							VolumeHandle: "a5ebd05f-934f-480d-b06f-41b372ed631e",
+						},
+					},
+				},
+				hostPathPVSpec,
+			}
+
+			actual, err := driver.GetVolNames(pvs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(actual).To(Equal([]string{"a5ebd05f-934f-480d-b06f-41b372ed631e"}))
+		})
+	})
+})

--- a/pkg/util/provider/machinecontroller/controller.go
+++ b/pkg/util/provider/machinecontroller/controller.go
@@ -57,7 +57,7 @@ const (
 	// MCFinalizerName is the finalizer created for the external
 	// machine controller to differentiate it from the MCMFinalizerName
 	// This finalizer is added only on secret-objects to avoid race between in-tree and out-of-tree controllers.
-	// This is a stopgap solution to resolve: https://github.com/gardener/machine-controller-manager/issues/486. 
+	// This is a stopgap solution to resolve: https://github.com/gardener/machine-controller-manager/issues/486.
 	MCFinalizerName = "machine.sapcloud.io/machine-controller"
 )
 

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -1383,7 +1383,7 @@ var _ = Describe("machine", func() {
 								LastUpdateTime: metav1.Now(),
 							},
 							Conditions: []corev1.NodeCondition{
-								corev1.NodeCondition{
+								{
 									Type:               corev1.NodeReady,
 									Status:             corev1.ConditionUnknown,
 									LastTransitionTime: metav1.NewTime(time.Now().Add(-6 * time.Minute)),


### PR DESCRIPTION
**What this PR does / why we need it**:
Wait also for CSI PVs during serial eviction.

/kind bug

**Which issue(s) this PR fixes**:
Fixes #508

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing machine-controller-manager to not consider CSI PersistentVolumes during the eviction of Pods with PersistentVolumes is now fixed.
```
