### PR TITLE
Back off failed Machine operations

### DIFF
--- a/pkg/util/backoff_manager/backoff_manager.go
+++ b/pkg/util/backoff_manager/backoff_manager.go
@@ -1,0 +1,44 @@
+package backoff_manager
+
+import (
+	"time"
+
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+type KeyFunc func(interface{}) string
+
+type BackoffManager struct {
+	safeBackoffer *flowcontrol.Backoff
+	keyFunc       KeyFunc
+}
+
+func NewBackoffManager(keyFunc KeyFunc, initialDelay, maxDelay time.Duration) *BackoffManager {
+	return &BackoffManager{
+		safeBackoffer: flowcontrol.NewBackOff(initialDelay, maxDelay),
+		keyFunc:       keyFunc,
+	}
+}
+
+func (b *BackoffManager) When(item interface{}) time.Duration {
+	key := b.keyFunc(item)
+	if len(key) == 0 {
+		return 0
+	}
+
+	b.safeBackoffer.Next(key, time.Now())
+	return b.safeBackoffer.Get(key)
+}
+
+func (b *BackoffManager) Forget(item interface{}) {
+	key := b.keyFunc(item)
+	if len(key) == 0 {
+		return
+	}
+
+	b.safeBackoffer.DeleteEntry(key)
+}
+
+func (b *BackoffManager) NumRequeues(_ interface{}) int {
+	return 0
+}

--- a/pkg/util/backoff_manager/key_funcs.go
+++ b/pkg/util/backoff_manager/key_funcs.go
@@ -1,0 +1,15 @@
+package backoff_manager
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+func MachineSetKeyedMachine(i interface{}) (key string) {
+	object := i.(metav1.Object)
+
+	for _, owner := range object.GetOwnerReferences() {
+		if owner.Kind == "MachineSet" {
+			key = owner.Name
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR retries failed Machine operations with exponential back off.

**Which issue(s) this PR fixes**:
Fixes #483 

**Special notes for your reviewer**:

I've keyed back off to MachineSet since a group of identical Machines should have the same error cause.

Some things still require ironing out before moving from a Draft state.
- [ ] Unit tests for backoff_manager
- [ ] Consider whether we'd like to back off on every error or just on errors returned by cloud APIs ones. If only from cloud APIs, wrap a custom error from Driver. I can see some problems with frozen MachineSets already.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Failed Machine operations will exponentially backoff before being executed again
```
