### PR TITLE
ServerGroup option for Openstack MachineClass

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
@@ -98,6 +98,8 @@ spec:
               items:
                 type: string
               type: array
+            serverGroupID:
+              type: string
             tags:
               additionalProperties:
                 type: string

--- a/kubernetes/machine_classes/openstack-machine-class.yaml
+++ b/kubernetes/machine_classes/openstack-machine-class.yaml
@@ -10,6 +10,7 @@ spec:
   keyName: <keypair_name> # Name of the ssh key pair
   imageName: <image_name> # Machine image name
   imageID: <image_name> # Machine image id (either name or id needs to be present)
+  serverGroupID: <server_group_id> # Server group ID where the machine should be scheduled
   networkID: <network_id> # Network ID where the machine should be placed
   securityGroups:
   - <security_group_name> # List of security groups which should be used for this machine

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -660,6 +660,7 @@ type OpenStackMachineClassSpec struct {
 	PodNetworkCidr   string
 	RootDiskSize     int // in GB
 	UseConfigDrive   *bool
+	ServerGroupID    *string
 }
 
 type OpenStackNetwork struct {

--- a/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
@@ -102,6 +102,7 @@ type OpenStackMachineClassSpec struct {
 	PodNetworkCidr   string                  `json:"podNetworkCidr"`
 	RootDiskSize     int                     `json:"rootDiskSize,omitempty"` // in GB
 	UseConfigDrive   *bool                   `json:"useConfigDrive,omitempty"`
+	ServerGroupID    *string                 `json:"serverGroupID,omitempty"`
 }
 
 type OpenStackNetwork struct {

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -2646,6 +2646,7 @@ func autoConvert_v1alpha1_OpenStackMachineClassSpec_To_machine_OpenStackMachineC
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
+	out.ServerGroupID = (*string)(unsafe.Pointer(in.ServerGroupID))
 	return nil
 }
 
@@ -2669,6 +2670,7 @@ func autoConvert_machine_OpenStackMachineClassSpec_To_v1alpha1_OpenStackMachineC
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
+	out.ServerGroupID = (*string)(unsafe.Pointer(in.ServerGroupID))
 	return nil
 }
 

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -1748,6 +1748,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ServerGroupID != nil {
+		in, out := &in.ServerGroupID, &out.ServerGroupID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -1841,6 +1841,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ServerGroupID != nil {
+		in, out := &in.ServerGroupID, &out.ServerGroupID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/images"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
@@ -182,6 +183,17 @@ func (d *OpenStackDriver) Create() (string, string, error) {
 		CreateOptsBuilder: createOpts,
 		KeyName:           keyName,
 	}
+
+	if d.OpenStackMachineClass.Spec.ServerGroupID != nil {
+		hints := schedulerhints.SchedulerHints{
+			Group: *d.OpenStackMachineClass.Spec.ServerGroupID,
+		}
+		createOpts = schedulerhints.CreateOptsExt{
+			CreateOptsBuilder: createOpts,
+			SchedulerHints:    hints,
+		}
+	}
+
 
 	if rootDiskSize > 0 {
 		blockDevices, err := resourceInstanceBlockDevicesV2(rootDiskSize, imageRef)

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -3416,6 +3416,12 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 							Format:      "",
 						},
 					},
+					"serverGroupID": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"imageID", "imageName", "region", "availabilityZone", "flavorName", "keyName", "securityGroups", "networkID", "podNetworkCidr"},
 			},

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/doc.go
@@ -1,0 +1,76 @@
+/*
+Package schedulerhints extends the server create request with the ability to
+specify additional parameters which determine where the server will be
+created in the OpenStack cloud.
+
+Example to Add a Server to a Server Group
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		Group: "servergroup-uuid",
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_name",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Place Server B on a Different Host than Server A
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		DifferentHost: []string{
+			"server-a-uuid",
+		}
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Place Server B on the Same Host as Server A
+
+	schedulerHints := schedulerhints.SchedulerHints{
+		SameHost: []string{
+			"server-a-uuid",
+		}
+	}
+
+	serverCreateOpts := servers.CreateOpts{
+		Name:      "server_b",
+		ImageRef:  "image-uuid",
+		FlavorRef: "flavor-uuid",
+	}
+
+	createOpts := schedulerhints.CreateOptsExt{
+		CreateOptsBuilder: serverCreateOpts,
+		SchedulerHints:    schedulerHints,
+	}
+
+	server, err := servers.Create(computeClient, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+*/
+package schedulerhints

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints/requests.go
@@ -1,0 +1,176 @@
+package schedulerhints
+
+import (
+	"encoding/json"
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
+)
+
+// SchedulerHints represents a set of scheduling hints that are passed to the
+// OpenStack scheduler.
+type SchedulerHints struct {
+	// Group specifies a Server Group to place the instance in.
+	Group string
+
+	// DifferentHost will place the instance on a compute node that does not
+	// host the given instances.
+	DifferentHost []string
+
+	// SameHost will place the instance on a compute node that hosts the given
+	// instances.
+	SameHost []string
+
+	// Query is a conditional statement that results in compute nodes able to
+	// host the instance.
+	Query []interface{}
+
+	// TargetCell specifies a cell name where the instance will be placed.
+	TargetCell string `json:"target_cell,omitempty"`
+
+	// BuildNearHostIP specifies a subnet of compute nodes to host the instance.
+	BuildNearHostIP string
+
+	// AdditionalProperies are arbitrary key/values that are not validated by nova.
+	AdditionalProperties map[string]interface{}
+}
+
+// CreateOptsBuilder builds the scheduler hints into a serializable format.
+type CreateOptsBuilder interface {
+	ToServerSchedulerHintsCreateMap() (map[string]interface{}, error)
+}
+
+// ToServerSchedulerHintsMap builds the scheduler hints into a serializable format.
+func (opts SchedulerHints) ToServerSchedulerHintsCreateMap() (map[string]interface{}, error) {
+	sh := make(map[string]interface{})
+
+	uuidRegex, _ := regexp.Compile("^[a-z0-9]{8}-[a-z0-9]{4}-[1-5][a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{12}$")
+
+	if opts.Group != "" {
+		if !uuidRegex.MatchString(opts.Group) {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.Group"
+			err.Value = opts.Group
+			err.Info = "Group must be a UUID"
+			return nil, err
+		}
+		sh["group"] = opts.Group
+	}
+
+	if len(opts.DifferentHost) > 0 {
+		for _, diffHost := range opts.DifferentHost {
+			if !uuidRegex.MatchString(diffHost) {
+				err := gophercloud.ErrInvalidInput{}
+				err.Argument = "schedulerhints.SchedulerHints.DifferentHost"
+				err.Value = opts.DifferentHost
+				err.Info = "The hosts must be in UUID format."
+				return nil, err
+			}
+		}
+		sh["different_host"] = opts.DifferentHost
+	}
+
+	if len(opts.SameHost) > 0 {
+		for _, sameHost := range opts.SameHost {
+			if !uuidRegex.MatchString(sameHost) {
+				err := gophercloud.ErrInvalidInput{}
+				err.Argument = "schedulerhints.SchedulerHints.SameHost"
+				err.Value = opts.SameHost
+				err.Info = "The hosts must be in UUID format."
+				return nil, err
+			}
+		}
+		sh["same_host"] = opts.SameHost
+	}
+
+	/*
+		Query can be something simple like:
+			 [">=", "$free_ram_mb", 1024]
+
+			Or more complex like:
+				['and',
+					['>=', '$free_ram_mb', 1024],
+					['>=', '$free_disk_mb', 200 * 1024]
+				]
+
+		Because of the possible complexity, just make sure the length is a minimum of 3.
+	*/
+	if len(opts.Query) > 0 {
+		if len(opts.Query) < 3 {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.Query"
+			err.Value = opts.Query
+			err.Info = "Must be a conditional statement in the format of [op,variable,value]"
+			return nil, err
+		}
+
+		// The query needs to be sent as a marshalled string.
+		b, err := json.Marshal(opts.Query)
+		if err != nil {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.Query"
+			err.Value = opts.Query
+			err.Info = "Must be a conditional statement in the format of [op,variable,value]"
+			return nil, err
+		}
+
+		sh["query"] = string(b)
+	}
+
+	if opts.TargetCell != "" {
+		sh["target_cell"] = opts.TargetCell
+	}
+
+	if opts.BuildNearHostIP != "" {
+		if _, _, err := net.ParseCIDR(opts.BuildNearHostIP); err != nil {
+			err := gophercloud.ErrInvalidInput{}
+			err.Argument = "schedulerhints.SchedulerHints.BuildNearHostIP"
+			err.Value = opts.BuildNearHostIP
+			err.Info = "Must be a valid subnet in the form 192.168.1.1/24"
+			return nil, err
+		}
+		ipParts := strings.Split(opts.BuildNearHostIP, "/")
+		sh["build_near_host_ip"] = ipParts[0]
+		sh["cidr"] = "/" + ipParts[1]
+	}
+
+	if opts.AdditionalProperties != nil {
+		for k, v := range opts.AdditionalProperties {
+			sh[k] = v
+		}
+	}
+
+	return sh, nil
+}
+
+// CreateOptsExt adds a SchedulerHints option to the base CreateOpts.
+type CreateOptsExt struct {
+	servers.CreateOptsBuilder
+
+	// SchedulerHints provides a set of hints to the scheduler.
+	SchedulerHints CreateOptsBuilder
+}
+
+// ToServerCreateMap adds the SchedulerHints option to the base server creation options.
+func (opts CreateOptsExt) ToServerCreateMap() (map[string]interface{}, error) {
+	base, err := opts.CreateOptsBuilder.ToServerCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	schedulerHints, err := opts.SchedulerHints.ToServerSchedulerHintsCreateMap()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(schedulerHints) == 0 {
+		return base, nil
+	}
+
+	base["os:scheduler_hints"] = schedulerHints
+
+	return base, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -113,6 +113,7 @@ github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs
+github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/schedulerhints
 github.com/gophercloud/gophercloud/openstack/compute/v2/flavors
 github.com/gophercloud/gophercloud/openstack/compute/v2/images
 github.com/gophercloud/gophercloud/openstack/compute/v2/servers


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an extra optional field for specifying the ServerGroup in a machineClass. The PR is a preparation for managing workergroup anti-affinity via ServerGroups. ServerGroup creation and management will be implemented on the Openstack-extension side.

**Which issue(s) this PR fixes**:
Fixes #30 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Add support for ServerGroups in the Openstack driver. VMs can now be created in the ServerGroup specified in the respective `MachineClass`.
```
