### PR TITLE
Introduce delay in re-enqueuing machines during creation--deletion failures.

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -222,6 +222,9 @@ const (
 
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
+
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 
 // MachinePhase is a label for the condition of a machines at the current time.

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -146,9 +146,12 @@ const (
 
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
+
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 
-// MachinePhase is a label for the condition of a machines at the current time.
+// MachineState is a current state of the machine.
 type MachineState string
 
 // These are the valid statuses of machines.

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -767,12 +767,13 @@ func (s ActiveMachines) Less(i, j int) bool {
 	// the lower the priority, the more likely
 	// it is to be deleted
 	m := map[v1alpha1.MachinePhase]int{
-		v1alpha1.MachineTerminating: 0,
-		v1alpha1.MachineFailed:      1,
-		v1alpha1.MachineUnknown:     2,
-		v1alpha1.MachinePending:     3,
-		v1alpha1.MachineAvailable:   4,
-		v1alpha1.MachineRunning:     5,
+		v1alpha1.MachineTerminating:      0,
+		v1alpha1.MachineFailed:           1,
+		v1alpha1.MachineCrashLoopBackOff: 2,
+		v1alpha1.MachineUnknown:          3,
+		v1alpha1.MachinePending:          4,
+		v1alpha1.MachineAvailable:        5,
+		v1alpha1.MachineRunning:          6,
 	}
 
 	// Case-1: Initially we try to prioritize machine deletion based on

--- a/pkg/controller/deployment_machineset_util.go
+++ b/pkg/controller/deployment_machineset_util.go
@@ -93,7 +93,7 @@ func calculateMachineSetStatus(is *v1alpha1.MachineSet, filteredMachines []*v1al
 	// Count the number of machines that have labels matching the labels of the machine
 	// template of the machine set, the matching machines may have more
 	// labels than are in the template. Because the label of machineTemplateSpec is
-	// a supeiset of the selector of the machine set, so the possible
+	// a superset of the selector of the machine set, so the possible
 	// matching machines must be part of the filteredmachines.
 	fullyLabeledReplicasCount := 0
 	readyReplicasCount := 0

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -148,8 +148,33 @@ var _ = Describe("machine", func() {
 			machineRet, errRet := c.updateMachineStatus(machine, lastOperation, currentStatus)
 			Expect(errRet).Should(Not(BeNil()))
 			Expect(errRet).Should(BeIdenticalTo(err))
-			Expect(machineRet).Should(Not(BeNil()))
-			Expect(machineRet).Should(BeIdenticalTo(machine))
+			Expect(machineRet).Should(BeNil())
+		})
+
+		It("shouldn't update status when it is already same", func() {
+			machine.Status.LastOperation = lastOperation
+			machine.Status.CurrentStatus = currentStatus
+
+			lastOperation = machinev1.LastOperation{
+				Description:    "test operation dummy",
+				LastUpdateTime: metav1.Now(),
+				State:          machinev1.MachineStateProcessing,
+				Type:           machinev1.MachineOperationCreate,
+			}
+			currentStatus = machinev1.CurrentStatus{
+				LastUpdateTime: lastOperation.LastUpdateTime,
+				Phase:          machinev1.MachinePending,
+				TimeoutActive:  true,
+			}
+
+			fakeMachineClient.AddReactor("get", "machines", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, machine, nil
+			})
+
+			machineRet, errRet := c.updateMachineStatus(machine, lastOperation, currentStatus)
+			Expect(errRet).Should((BeNil()))
+			Expect(machineRet.Status.LastOperation).Should(BeIdenticalTo(machine.Status.LastOperation))
+			Expect(machineRet.Status.CurrentStatus).Should(BeIdenticalTo(machine.Status.CurrentStatus))
 		})
 
 		It("should return success", func() {
@@ -358,6 +383,105 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: field.ErrorList{},
+			}),
+		)
+	})
+
+	Describe("#isMachineStatusEqual", func() {
+		type expect struct {
+			equal bool
+		}
+		type action struct {
+			s1 machinev1.MachineStatus
+			s2 machinev1.MachineStatus
+		}
+		type data struct {
+			action action
+			expect expect
+		}
+
+		lastOperation := machinev1.LastOperation{
+			Description:    "test operation",
+			LastUpdateTime: metav1.Now(),
+			State:          machinev1.MachineStateProcessing,
+			Type:           machinev1.MachineOperationCreate,
+		}
+		currentStatus := machinev1.CurrentStatus{
+			LastUpdateTime: lastOperation.LastUpdateTime,
+			Phase:          machinev1.MachinePending,
+			TimeoutActive:  true,
+		}
+
+		DescribeTable("##table",
+			func(data *data) {
+				stop := make(chan struct{})
+				defer close(stop)
+
+				equal := isMachineStatusEqual(data.action.s1, data.action.s2)
+				Expect(equal).To(Equal(data.expect.equal))
+			},
+			Entry("return true as status is same", &data{
+				action: action{
+					s1: machinev1.MachineStatus{
+						LastOperation: lastOperation,
+						CurrentStatus: currentStatus,
+					},
+					s2: machinev1.MachineStatus{
+						LastOperation: lastOperation,
+						CurrentStatus: currentStatus,
+					},
+				},
+				expect: expect{
+					equal: true,
+				},
+			}),
+			Entry("return false as status is not equal", &data{
+				action: action{
+					s1: machinev1.MachineStatus{
+						LastOperation: lastOperation,
+						CurrentStatus: currentStatus,
+					},
+					s2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "test operation dummy",
+							LastUpdateTime: metav1.Now(),
+							State:          machinev1.MachineStateProcessing,
+							Type:           machinev1.MachineOperationDelete,
+						},
+						CurrentStatus: machinev1.CurrentStatus{
+							LastUpdateTime: lastOperation.LastUpdateTime,
+							Phase:          machinev1.MachinePending,
+							TimeoutActive:  true,
+						},
+					},
+				},
+				expect: expect{
+					equal: false,
+				},
+			}),
+			Entry("return true as only description is not same", &data{
+				action: action{
+					s1: machinev1.MachineStatus{
+						LastOperation: lastOperation,
+						CurrentStatus: currentStatus,
+					},
+					s2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "test operation dummy dummy",
+							LastUpdateTime: metav1.Now(),
+							State:          machinev1.MachineStateProcessing,
+							Type:           machinev1.MachineOperationCreate,
+						},
+						CurrentStatus: machinev1.CurrentStatus{
+							LastUpdateTime: lastOperation.LastUpdateTime,
+							Phase:          machinev1.MachinePending,
+							TimeoutActive:  true,
+						},
+					},
+				},
+				expect: expect{
+					equal: true,
+				},
 			}),
 		)
 	})
@@ -744,7 +868,7 @@ var _ = Describe("machine", func() {
 					err: false,
 				},
 			}),
-			Entry("Orphan VM deletion on faling to find referred machine object", &data{
+			Entry("Orphan VM deletion on failing to find referred machine object", &data{
 				setup: setup{
 					secrets: []*corev1.Secret{
 						{

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -291,6 +291,8 @@ func (c *controller) CollectMachineMetrics(ch chan<- prometheus.Metric) {
 			phase = 2
 		case v1alpha1.MachineFailed:
 			phase = 3
+		case v1alpha1.MachineCrashLoopBackOff:
+			phase = 4
 		}
 		metrics.MachineCSPhase.With(prometheus.Labels{
 			"name":      mMeta.Name,


### PR DESCRIPTION
Co-authored-by: Prashanth <prashanth@sap.com>

**What this PR does / why we need it**:  Currently we immediately re-enqueue the machine-object on creation/deletion failure. This PR adds a constant delay before retrying the operation. Eventually, we must build exponential retry on top or parallel to this solution. 
- PR introduces a new phase `CrashLoopBackOff`. This should be used when machine creation fails, but machine-set doesn't really need to replace the machine-object[as that won't anyways help]. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy operator
Introduce a backoff in re-enqueuing machines on creation/deletion failures. Avoids throttling APIServer & provider calls.
```
```improvement developer
Adds a new phase `CrashLoopBackOff` that is set due to machine creation failures. 
```
