### PR TITLE
Bugfix: Fixed issues with machineClass finalizers 

### DIFF
--- a/pkg/controller/alicloudmachineclass.go
+++ b/pkg/controller/alicloudmachineclass.go
@@ -135,6 +135,14 @@ func (c *controller) reconcileClusterAlicloudMachineClass(class *v1alpha1.Aliclo
 		return nil
 	}
 
+	// Add finalizer to avoid lossing machineClass object
+	if class.DeletionTimestamp == nil {
+		err = c.addAlicloudMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
+	}
+
 	machines, err := c.findMachinesForClass(AlicloudMachineClassKind, class.Name)
 	if err != nil {
 		return err
@@ -144,13 +152,7 @@ func (c *controller) reconcileClusterAlicloudMachineClass(class *v1alpha1.Aliclo
 		// If deletion timestamp doesn't exist
 		_, annotationPresent := class.Annotations[machineutils.MigratedMachineClass]
 
-		if len(machines) > 0 {
-			// If 1 or more machine objects are referring the machineClass
-			err = c.addAlicloudMachineClassFinalizers(class)
-			if err != nil {
-				return err
-			}
-		} else if c.deleteMigratedMachineClass && annotationPresent {
+		if c.deleteMigratedMachineClass && annotationPresent && len(machines) == 0 {
 			// If controller has deleteMigratedMachineClass flag set
 			// and the migratedMachineClass annotation is set
 			err = c.controlMachineClient.AlicloudMachineClasses(class.Namespace).Delete(class.Name, &metav1.DeleteOptions{})

--- a/pkg/controller/alicloudmachineclass.go
+++ b/pkg/controller/alicloudmachineclass.go
@@ -57,7 +57,7 @@ func (c *controller) machineSetToAlicloudMachineClassDelete(obj interface{}) {
 	}
 }
 
-func (c *controller) machineToAlicloudMachineClassDelete(obj interface{}) {
+func (c *controller) machineToAlicloudMachineClassAdd(obj interface{}) {
 	machine, ok := obj.(*v1alpha1.Machine)
 	if machine == nil || !ok {
 		return
@@ -65,6 +65,15 @@ func (c *controller) machineToAlicloudMachineClassDelete(obj interface{}) {
 	if machine.Spec.Class.Kind == AlicloudMachineClassKind {
 		c.alicloudMachineClassQueue.Add(machine.Spec.Class.Name)
 	}
+}
+
+func (c *controller) machineToAlicloudMachineClassUpdate(oldObj, newObj interface{}) {
+	c.machineToAlicloudMachineClassAdd(oldObj)
+	c.machineToAlicloudMachineClassAdd(newObj)
+}
+
+func (c *controller) machineToAlicloudMachineClassDelete(obj interface{}) {
+	c.machineToAlicloudMachineClassAdd(obj)
 }
 
 func (c *controller) alicloudMachineClassAdd(obj interface{}) {
@@ -87,6 +96,10 @@ func (c *controller) alicloudMachineClassUpdate(oldObj, newObj interface{}) {
 	}
 
 	c.alicloudMachineClassAdd(newObj)
+}
+
+func (c *controller) alicloudMachineClassDelete(obj interface{}) {
+	c.alicloudMachineClassAdd(obj)
 }
 
 // reconcileClusterAlicloudMachineClassKey reconciles an AlicloudMachineClass due to controller resync
@@ -135,7 +148,7 @@ func (c *controller) reconcileClusterAlicloudMachineClass(class *v1alpha1.Aliclo
 		return nil
 	}
 
-	// Add finalizer to avoid lossing machineClass object
+	// Add finalizer to avoid losing machineClass object
 	if class.DeletionTimestamp == nil {
 		err = c.addAlicloudMachineClassFinalizers(class)
 		if err != nil {

--- a/pkg/controller/awsmachineclass.go
+++ b/pkg/controller/awsmachineclass.go
@@ -60,6 +60,7 @@ func (c *controller) machineSetToAWSMachineClassDelete(obj interface{}) {
 func (c *controller) machineToAWSMachineClassAdd(obj interface{}) {
 	machine, ok := obj.(*v1alpha1.Machine)
 	if machine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", obj)
 		return
 	}
 	if machine.Spec.Class.Kind == AWSMachineClassKind {
@@ -68,8 +69,33 @@ func (c *controller) machineToAWSMachineClassAdd(obj interface{}) {
 }
 
 func (c *controller) machineToAWSMachineClassUpdate(oldObj, newObj interface{}) {
-	c.machineToAWSMachineClassAdd(oldObj)
-	c.machineToAWSMachineClassAdd(newObj)
+	oldMachine, ok := oldObj.(*v1alpha1.Machine)
+	if oldMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", oldObj)
+		return
+	}
+	newMachine, ok := newObj.(*v1alpha1.Machine)
+	if newMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", newObj)
+		return
+	}
+
+	if oldMachine.Spec.Class.Kind == newMachine.Spec.Class.Kind {
+		if newMachine.Spec.Class.Kind == AWSMachineClassKind {
+			// Both old and new machine refer to the same machineClass object
+			// And the correct kind so enqueuing only one of them.
+			c.awsMachineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	} else {
+		// If both are pointing to different machineClasses
+		// we might have to enqueue both.
+		if oldMachine.Spec.Class.Kind == AWSMachineClassKind {
+			c.awsMachineClassQueue.Add(oldMachine.Spec.Class.Name)
+		}
+		if newMachine.Spec.Class.Kind == AWSMachineClassKind {
+			c.awsMachineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	}
 }
 
 func (c *controller) machineToAWSMachineClassDelete(obj interface{}) {

--- a/pkg/controller/awsmachineclass.go
+++ b/pkg/controller/awsmachineclass.go
@@ -135,6 +135,14 @@ func (c *controller) reconcileClusterAWSMachineClass(class *v1alpha1.AWSMachineC
 		return nil
 	}
 
+	// Add finalizer to avoid lossing machineClass object
+	if class.DeletionTimestamp == nil {
+		err = c.addAWSMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
+	}
+
 	machines, err := c.findMachinesForClass(AWSMachineClassKind, class.Name)
 	if err != nil {
 		return err
@@ -144,13 +152,7 @@ func (c *controller) reconcileClusterAWSMachineClass(class *v1alpha1.AWSMachineC
 		// If deletion timestamp doesn't exist
 		_, annotationPresent := class.Annotations[machineutils.MigratedMachineClass]
 
-		if len(machines) > 0 {
-			// If 1 or more machine objects are referring the machineClass
-			err = c.addAWSMachineClassFinalizers(class)
-			if err != nil {
-				return err
-			}
-		} else if c.deleteMigratedMachineClass && annotationPresent {
+		if c.deleteMigratedMachineClass && annotationPresent && len(machines) == 0 {
 			// If controller has deleteMigratedMachineClass flag set
 			// and the migratedMachineClass annotation is set
 			err = c.controlMachineClient.AWSMachineClasses(class.Namespace).Delete(class.Name, &metav1.DeleteOptions{})

--- a/pkg/controller/azuremachineclass.go
+++ b/pkg/controller/azuremachineclass.go
@@ -60,6 +60,7 @@ func (c *controller) machineSetToAzureMachineClassDelete(obj interface{}) {
 func (c *controller) machineToAzureMachineClassAdd(obj interface{}) {
 	machine, ok := obj.(*v1alpha1.Machine)
 	if machine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", obj)
 		return
 	}
 	if machine.Spec.Class.Kind == AzureMachineClassKind {
@@ -68,8 +69,33 @@ func (c *controller) machineToAzureMachineClassAdd(obj interface{}) {
 }
 
 func (c *controller) machineToAzureMachineClassUpdate(oldObj, newObj interface{}) {
-	c.machineToAzureMachineClassAdd(oldObj)
-	c.machineToAzureMachineClassAdd(newObj)
+	oldMachine, ok := oldObj.(*v1alpha1.Machine)
+	if oldMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", oldObj)
+		return
+	}
+	newMachine, ok := newObj.(*v1alpha1.Machine)
+	if newMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", newObj)
+		return
+	}
+
+	if oldMachine.Spec.Class.Kind == newMachine.Spec.Class.Kind {
+		if newMachine.Spec.Class.Kind == AzureMachineClassKind {
+			// Both old and new machine refer to the same machineClass object
+			// And the correct kind so enqueuing only one of them.
+			c.azureMachineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	} else {
+		// If both are pointing to different machineClasses
+		// we might have to enqueue both.
+		if oldMachine.Spec.Class.Kind == AzureMachineClassKind {
+			c.azureMachineClassQueue.Add(oldMachine.Spec.Class.Name)
+		}
+		if newMachine.Spec.Class.Kind == AzureMachineClassKind {
+			c.azureMachineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	}
 }
 
 func (c *controller) machineToAzureMachineClassDelete(obj interface{}) {

--- a/pkg/controller/azuremachineclass.go
+++ b/pkg/controller/azuremachineclass.go
@@ -136,6 +136,14 @@ func (c *controller) reconcileClusterAzureMachineClass(class *v1alpha1.AzureMach
 		return nil
 	}
 
+	// Add finalizer to avoid lossing machineClass object
+	if class.DeletionTimestamp == nil {
+		err = c.addAzureMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
+	}
+
 	machines, err := c.findMachinesForClass(AzureMachineClassKind, class.Name)
 	if err != nil {
 		return err
@@ -145,13 +153,7 @@ func (c *controller) reconcileClusterAzureMachineClass(class *v1alpha1.AzureMach
 		// If deletion timestamp doesn't exist
 		_, annotationPresent := class.Annotations[machineutils.MigratedMachineClass]
 
-		if len(machines) > 0 {
-			// If 1 or more machine objects are referring the machineClass
-			err = c.addAzureMachineClassFinalizers(class)
-			if err != nil {
-				return err
-			}
-		} else if c.deleteMigratedMachineClass && annotationPresent {
+		if c.deleteMigratedMachineClass && annotationPresent && len(machines) == 0 {
 			// If controller has deleteMigratedMachineClass flag set
 			// and the migratedMachineClass annotation is set
 			err = c.controlMachineClient.AzureMachineClasses(class.Namespace).Delete(class.Name, &metav1.DeleteOptions{})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -215,12 +215,15 @@ func NewController(
 	})
 
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToOpenStackMachineClassAdd,
+		UpdateFunc: controller.machineToOpenStackMachineClassUpdate,
 		DeleteFunc: controller.machineToOpenStackMachineClassDelete,
 	})
 
 	openStackMachineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.openStackMachineClassAdd,
 		UpdateFunc: controller.openStackMachineClassUpdate,
+		DeleteFunc: controller.openStackMachineClassDelete,
 	})
 
 	// AWS Controller Informers
@@ -233,12 +236,15 @@ func NewController(
 	})
 
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToAWSMachineClassAdd,
+		UpdateFunc: controller.machineToAWSMachineClassUpdate,
 		DeleteFunc: controller.machineToAWSMachineClassDelete,
 	})
 
 	awsMachineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.awsMachineClassAdd,
 		UpdateFunc: controller.awsMachineClassUpdate,
+		DeleteFunc: controller.awsMachineClassDelete,
 	})
 
 	// Azure Controller Informers
@@ -251,12 +257,15 @@ func NewController(
 	})
 
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToAzureMachineClassAdd,
+		UpdateFunc: controller.machineToAzureMachineClassUpdate,
 		DeleteFunc: controller.machineToAzureMachineClassDelete,
 	})
 
 	azureMachineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.azureMachineClassAdd,
 		UpdateFunc: controller.azureMachineClassUpdate,
+		DeleteFunc: controller.azureMachineClassDelete,
 	})
 
 	// GCP Controller Informers
@@ -269,12 +278,15 @@ func NewController(
 	})
 
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToGCPMachineClassAdd,
+		UpdateFunc: controller.machineToGCPMachineClassUpdate,
 		DeleteFunc: controller.machineToGCPMachineClassDelete,
 	})
 
 	gcpMachineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.gcpMachineClassAdd,
 		UpdateFunc: controller.gcpMachineClassUpdate,
+		DeleteFunc: controller.gcpMachineClassDelete,
 	})
 
 	// Alicloud Controller Informers
@@ -287,12 +299,15 @@ func NewController(
 	})
 
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToAlicloudMachineClassAdd,
+		UpdateFunc: controller.machineToAlicloudMachineClassUpdate,
 		DeleteFunc: controller.machineToAlicloudMachineClassDelete,
 	})
 
 	alicloudMachineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.alicloudMachineClassAdd,
 		UpdateFunc: controller.alicloudMachineClassUpdate,
+		DeleteFunc: controller.alicloudMachineClassDelete,
 	})
 
 	// Packet Controller Informers
@@ -305,12 +320,15 @@ func NewController(
 	})
 
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToPacketMachineClassAdd,
+		UpdateFunc: controller.machineToPacketMachineClassUpdate,
 		DeleteFunc: controller.machineToPacketMachineClassDelete,
 	})
 
 	packetMachineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.packetMachineClassAdd,
 		UpdateFunc: controller.packetMachineClassUpdate,
+		DeleteFunc: controller.packetMachineClassDelete,
 	})
 
 	/* Node Controller Informers - Don't remove this, saved for future use case.

--- a/pkg/controller/openstackmachineclass.go
+++ b/pkg/controller/openstackmachineclass.go
@@ -57,7 +57,7 @@ func (c *controller) machineSetToOpenStackMachineClassDelete(obj interface{}) {
 	}
 }
 
-func (c *controller) machineToOpenStackMachineClassDelete(obj interface{}) {
+func (c *controller) machineToOpenStackMachineClassAdd(obj interface{}) {
 	machine, ok := obj.(*v1alpha1.Machine)
 	if machine == nil || !ok {
 		return
@@ -65,6 +65,15 @@ func (c *controller) machineToOpenStackMachineClassDelete(obj interface{}) {
 	if machine.Spec.Class.Kind == OpenStackMachineClassKind {
 		c.openStackMachineClassQueue.Add(machine.Spec.Class.Name)
 	}
+}
+
+func (c *controller) machineToOpenStackMachineClassUpdate(oldObj, newObj interface{}) {
+	c.machineToOpenStackMachineClassAdd(oldObj)
+	c.machineToOpenStackMachineClassAdd(newObj)
+}
+
+func (c *controller) machineToOpenStackMachineClassDelete(obj interface{}) {
+	c.machineToOpenStackMachineClassAdd(obj)
 }
 
 func (c *controller) openStackMachineClassAdd(obj interface{}) {
@@ -87,6 +96,10 @@ func (c *controller) openStackMachineClassUpdate(oldObj, newObj interface{}) {
 	}
 
 	c.openStackMachineClassAdd(newObj)
+}
+
+func (c *controller) openStackMachineClassDelete(obj interface{}) {
+	c.openStackMachineClassAdd(obj)
 }
 
 // reconcileClusterOpenStackMachineClassKey reconciles an OpenStackMachineClass due to controller resync
@@ -135,7 +148,7 @@ func (c *controller) reconcileClusterOpenStackMachineClass(class *v1alpha1.OpenS
 		return nil
 	}
 
-	// Add finalizer to avoid lossing machineClass object
+	// Add finalizer to avoid losing machineClass object
 	if class.DeletionTimestamp == nil {
 		err := c.addOpenStackMachineClassFinalizers(class)
 		if err != nil {

--- a/pkg/controller/packetcloudmachineclass.go
+++ b/pkg/controller/packetcloudmachineclass.go
@@ -60,6 +60,7 @@ func (c *controller) machineSetToPacketMachineClassDelete(obj interface{}) {
 func (c *controller) machineToPacketMachineClassAdd(obj interface{}) {
 	machine, ok := obj.(*v1alpha1.Machine)
 	if machine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", obj)
 		return
 	}
 	if machine.Spec.Class.Kind == PacketMachineClassKind {
@@ -68,8 +69,33 @@ func (c *controller) machineToPacketMachineClassAdd(obj interface{}) {
 }
 
 func (c *controller) machineToPacketMachineClassUpdate(oldObj, newObj interface{}) {
-	c.machineToPacketMachineClassAdd(oldObj)
-	c.machineToPacketMachineClassAdd(newObj)
+	oldMachine, ok := oldObj.(*v1alpha1.Machine)
+	if oldMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", oldObj)
+		return
+	}
+	newMachine, ok := newObj.(*v1alpha1.Machine)
+	if newMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", newObj)
+		return
+	}
+
+	if oldMachine.Spec.Class.Kind == newMachine.Spec.Class.Kind {
+		if newMachine.Spec.Class.Kind == PacketMachineClassKind {
+			// Both old and new machine refer to the same machineClass object
+			// And the correct kind so enqueuing only one of them.
+			c.packetMachineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	} else {
+		// If both are pointing to different machineClasses
+		// we might have to enqueue both.
+		if oldMachine.Spec.Class.Kind == PacketMachineClassKind {
+			c.packetMachineClassQueue.Add(oldMachine.Spec.Class.Name)
+		}
+		if newMachine.Spec.Class.Kind == PacketMachineClassKind {
+			c.packetMachineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	}
 }
 
 func (c *controller) machineToPacketMachineClassDelete(obj interface{}) {

--- a/pkg/controller/packetcloudmachineclass.go
+++ b/pkg/controller/packetcloudmachineclass.go
@@ -135,6 +135,14 @@ func (c *controller) reconcileClusterPacketMachineClass(class *v1alpha1.PacketMa
 		return nil
 	}
 
+	// Add finalizer to avoid lossing machineClass object
+	if class.DeletionTimestamp == nil {
+		err = c.addPacketMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
+	}
+
 	machines, err := c.findMachinesForClass(PacketMachineClassKind, class.Name)
 	if err != nil {
 		return err
@@ -144,13 +152,7 @@ func (c *controller) reconcileClusterPacketMachineClass(class *v1alpha1.PacketMa
 		// If deletion timestamp doesn't exist
 		_, annotationPresent := class.Annotations[machineutils.MigratedMachineClass]
 
-		if len(machines) > 0 {
-			// If 1 or more machine objects are referring the machineClass
-			err = c.addPacketMachineClassFinalizers(class)
-			if err != nil {
-				return err
-			}
-		} else if c.deleteMigratedMachineClass && annotationPresent {
+		if c.deleteMigratedMachineClass && annotationPresent && len(machines) == 0 {
 			// If controller has deleteMigratedMachineClass flag set
 			// and the migratedMachineClass annotation is set
 			err = c.controlMachineClient.PacketMachineClasses(class.Namespace).Delete(class.Name, &metav1.DeleteOptions{})

--- a/pkg/controller/packetcloudmachineclass.go
+++ b/pkg/controller/packetcloudmachineclass.go
@@ -57,7 +57,7 @@ func (c *controller) machineSetToPacketMachineClassDelete(obj interface{}) {
 	}
 }
 
-func (c *controller) machineToPacketMachineClassDelete(obj interface{}) {
+func (c *controller) machineToPacketMachineClassAdd(obj interface{}) {
 	machine, ok := obj.(*v1alpha1.Machine)
 	if machine == nil || !ok {
 		return
@@ -65,6 +65,15 @@ func (c *controller) machineToPacketMachineClassDelete(obj interface{}) {
 	if machine.Spec.Class.Kind == PacketMachineClassKind {
 		c.packetMachineClassQueue.Add(machine.Spec.Class.Name)
 	}
+}
+
+func (c *controller) machineToPacketMachineClassUpdate(oldObj, newObj interface{}) {
+	c.machineToPacketMachineClassAdd(oldObj)
+	c.machineToPacketMachineClassAdd(newObj)
+}
+
+func (c *controller) machineToPacketMachineClassDelete(obj interface{}) {
+	c.machineToPacketMachineClassAdd(obj)
 }
 
 func (c *controller) packetMachineClassAdd(obj interface{}) {
@@ -87,6 +96,10 @@ func (c *controller) packetMachineClassUpdate(oldObj, newObj interface{}) {
 	}
 
 	c.packetMachineClassAdd(newObj)
+}
+
+func (c *controller) packetMachineClassDelete(obj interface{}) {
+	c.packetMachineClassAdd(obj)
 }
 
 // reconcileClusterPacketMachineClassKey reconciles a PacketMachineClass due to controller resync
@@ -135,7 +148,7 @@ func (c *controller) reconcileClusterPacketMachineClass(class *v1alpha1.PacketMa
 		return nil
 	}
 
-	// Add finalizer to avoid lossing machineClass object
+	// Add finalizer to avoid losing machineClass object
 	if class.DeletionTimestamp == nil {
 		err = c.addPacketMachineClassFinalizers(class)
 		if err != nil {

--- a/pkg/util/provider/machinecontroller/controller.go
+++ b/pkg/util/provider/machinecontroller/controller.go
@@ -137,13 +137,17 @@ func NewController(
 		DeleteFunc: controller.machineClassToSecretDelete,
 	})
 
+	// Machine Class Controller Informers
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    controller.machineToMachineClassAdd,
+		UpdateFunc: controller.machineToMachineClassUpdate,
 		DeleteFunc: controller.machineToMachineClassDelete,
 	})
 
 	machineClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.machineClassAdd,
 		UpdateFunc: controller.machineClassUpdate,
+		DeleteFunc: controller.machineClassDelete,
 	})
 
 	// Machine Controller Informers

--- a/pkg/util/provider/machinecontroller/machineclass.go
+++ b/pkg/util/provider/machinecontroller/machineclass.go
@@ -107,22 +107,20 @@ func (c *controller) reconcileClusterMachineClass(class *v1alpha1.MachineClass) 
 		return err
 	}
 
+	// Add finalizer to avoid lossing machineClass object
+	if class.DeletionTimestamp == nil {
+		err = c.addMachineClassFinalizers(class)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 	// fetch all machines referring the machineClass
 	machines, err := c.findMachinesForClass(machineutils.MachineClassKind, class.Name)
 	if err != nil {
 		return err
-	}
-
-	if class.DeletionTimestamp == nil {
-		// If deletion timestamp doesn't exist
-		if len(machines) > 0 {
-			// If 1 or more machine objects are referring the machineClass
-			err = c.addMachineClassFinalizers(class)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
 	}
 
 	if len(machines) > 0 {

--- a/pkg/util/provider/machinecontroller/machineclass.go
+++ b/pkg/util/provider/machinecontroller/machineclass.go
@@ -36,6 +36,7 @@ import (
 func (c *controller) machineToMachineClassAdd(obj interface{}) {
 	machine, ok := obj.(*v1alpha1.Machine)
 	if machine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", obj)
 		return
 	}
 	if machine.Spec.Class.Kind == machineutils.MachineClassKind {
@@ -44,8 +45,33 @@ func (c *controller) machineToMachineClassAdd(obj interface{}) {
 }
 
 func (c *controller) machineToMachineClassUpdate(oldObj, newObj interface{}) {
-	c.machineToMachineClassAdd(oldObj)
-	c.machineToMachineClassAdd(newObj)
+	oldMachine, ok := oldObj.(*v1alpha1.Machine)
+	if oldMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", oldObj)
+		return
+	}
+	newMachine, ok := newObj.(*v1alpha1.Machine)
+	if newMachine == nil || !ok {
+		klog.Warningf("Couldn't get machine from object: %+v", newObj)
+		return
+	}
+
+	if oldMachine.Spec.Class.Kind == newMachine.Spec.Class.Kind {
+		if newMachine.Spec.Class.Kind == machineutils.MachineClassKind {
+			// Both old and new machine refer to the same machineClass object
+			// And the correct kind so enqueuing only one of them.
+			c.machineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	} else {
+		// If both are pointing to different machineClasses
+		// we might have to enqueue both.
+		if oldMachine.Spec.Class.Kind == machineutils.MachineClassKind {
+			c.machineClassQueue.Add(oldMachine.Spec.Class.Name)
+		}
+		if newMachine.Spec.Class.Kind == machineutils.MachineClassKind {
+			c.machineClassQueue.Add(newMachine.Spec.Class.Name)
+		}
+	}
 }
 
 func (c *controller) machineToMachineClassDelete(obj interface{}) {

--- a/pkg/util/provider/machinecontroller/machineclass_test.go
+++ b/pkg/util/provider/machinecontroller/machineclass_test.go
@@ -362,6 +362,9 @@ var _ = Describe("machineclass", func() {
 								ObjectMeta: metav1.ObjectMeta{
 									Name:      TestMachineClassName,
 									Namespace: TestNamespace,
+									DeletionTimestamp: &metav1.Time{
+										Time: time.Time{},
+									},
 								},
 								ProviderSpec: runtime.RawExtension{},
 								SecretRef:    &v1.SecretReference{},
@@ -399,6 +402,9 @@ var _ = Describe("machineclass", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      TestMachineClassName,
 								Namespace: TestNamespace,
+								DeletionTimestamp: &metav1.Time{
+									Time: time.Time{},
+								},
 							},
 							ProviderSpec: runtime.RawExtension{},
 							SecretRef:    &v1.SecretReference{},


### PR DESCRIPTION
**What this PR does / why we need it**:
Without proper finalizers, machine classes backing machines were lost on deletions. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This partially reverts this change - https://github.com/gardener/machine-controller-manager/commit/0a568917461a5c6385974322784b36d62762e60a#diff-a327d9bce2e5949213510b45b329fa9d45d2dedfcce11e407e51e876549f265bL130-L137

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Added a more comprehensive set of events to trigger machine class reconciliations.
```
```improvement operator
Finalizers are added by default for all machine class objects.
```
