### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/development/cp_support_new.md
+++ b/docs/development/cp_support_new.md
@@ -99,7 +99,7 @@ Make sure `$TARGET_KUBECONFIG` points to the cluster where you wish to manage ma
         ```bash
         kubectl apply -f kubernetes/crds.yaml
         ```
-    - Run the machine-controller-manager in the `cmi-client` branch
+    - Run the machine-controller-manager in the `master` branch
         ```bash
         make start
         ```


### PR DESCRIPTION
The documentation was pointing to the wrong branch. This change fixes it.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
