### PR TITLE
Added a new Creating phase

### DIFF
--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -149,6 +149,9 @@ const (
 
 	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
 	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
+
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. TODO
+	MachineCreating MachinePhase = "Creating"
 )
 
 // MachineState is a current state of the machine.

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -770,10 +770,11 @@ func (s ActiveMachines) Less(i, j int) bool {
 		v1alpha1.MachineTerminating:      0,
 		v1alpha1.MachineFailed:           1,
 		v1alpha1.MachineCrashLoopBackOff: 2,
-		v1alpha1.MachineUnknown:          3,
-		v1alpha1.MachinePending:          4,
-		v1alpha1.MachineAvailable:        5,
-		v1alpha1.MachineRunning:          6,
+		v1alpha1.MachineCreating:         3,
+		v1alpha1.MachineUnknown:          4,
+		v1alpha1.MachinePending:          5,
+		v1alpha1.MachineAvailable:        6,
+		v1alpha1.MachineRunning:          7,
 	}
 
 	// Case-1: Initially we try to prioritize machine deletion based on

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -293,6 +293,8 @@ func (c *controller) CollectMachineMetrics(ch chan<- prometheus.Metric) {
 			phase = 3
 		case v1alpha1.MachineCrashLoopBackOff:
 			phase = 4
+		case v1alpha1.MachineCreating:
+			phase = 5
 		}
 		metrics.MachineCSPhase.With(prometheus.Labels{
 			"name":      mMeta.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new "Creating" phase, which ensures correct VM creation when using non-atomic cloud APIs.

**Which issue(s) this PR fixes**:
Band-aid for #444 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Added a new "Creating" Phase. Machines transition to this phase immediately upon entering the creation flow. If the Machine is already in the "Creating" phase, and it enters the creation flow again, that means that the Machine was not fully created on the cloud provider, and we move it to the Failed state. 
```
