### PR TITLE
Add NetworkUnavailable as node condition

### DIFF
--- a/cmd/machine-controller-manager/app/options/options.go
+++ b/cmd/machine-controller-manager/app/options/options.go
@@ -56,7 +56,7 @@ func NewMCMServer() *MCMServer {
 			Address:                 "0.0.0.0",
 			ConcurrentNodeSyncs:     10,
 			ContentType:             "application/vnd.kubernetes.protobuf",
-			NodeConditions:          "KernelDeadlock,ReadonlyFilesystem,DiskPressure",
+			NodeConditions:          "KernelDeadlock,ReadonlyFilesystem,DiskPressure,NetworkUnavailable",
 			MinResyncPeriod:         metav1.Duration{Duration: 12 * time.Hour},
 			KubeAPIQPS:              20.0,
 			KubeAPIBurst:            30,

--- a/kubernetes/deployment/in-tree/deployment.yaml
+++ b/kubernetes/deployment/in-tree/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           - --machine-health-timeout=10m  # Optional Parameter - Default value 10mins - Timeout (in time) used while joining (during creation) or re-joining (in case of temporary health issues) of machine before it is declared as failed.
           - --machine-safety-orphan-vms-period=30m # Optional Parameter - Default value 30mins - Time period (in time) used to poll for orphan VMs by safety controller.
           - --machine-safety-overshooting-period=1m # Optional Parameter - Default value 1min - Time period (in time) used to poll for overshooting of machine objects backing a machineSet by safety controller.
-          - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
+          - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure,NetworkUnavailable # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
           - --v=2
         livenessProbe:
           failureThreshold: 3

--- a/kubernetes/deployment/out-of-tree/deployment.yaml
+++ b/kubernetes/deployment/out-of-tree/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           - --machine-health-timeout=10m  # Optional Parameter - Default value 10mins - Timeout (in time) used while joining (during creation) or re-joining (in case of temporary health issues) of machine before it is declared as failed.
           - --machine-safety-orphan-vms-period=30 # Optional Parameter - Default value 30mins - Time period (in time) used to poll for orphan VMs by safety controller.
           - --machine-safety-overshooting-period=1 # Optional Parameter - Default value 1min - Time period (in time) used to poll for overshooting of machine objects backing a machineSet by safety controller.
-          - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
+          - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure,NetworkUnavailable # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
           - --v=2
         livenessProbe:
           failureThreshold: 3
@@ -47,7 +47,7 @@ spec:
         - --machine-drain-timeout=5m # Optional Parameter - Timeout (in time) used while draining of machine before deletion, beyond which MCM forcefully deletes machine.
         - --machine-health-timeout=10m  # Optional Parameter - Default value 10mins - Timeout (in time) used while joining (during creation) or re-joining (in case of temporary health issues) of machine before it is declared as failed.
         - --machine-safety-orphan-vms-period=30m # Optional Parameter - Default value 30mins - Time period (in time) used to poll for orphan VMs by safety controller.
-        - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
+        - --node-conditions=ReadonlyFilesystem,KernelDeadlock,DiskPressure,NetworkUnavailable # List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.
         - --v=3
         image: gcr.io/gardener-project/gardener/machine-controller-manager-provider-aws:0.1.0-dev-47bc8cf5b02affba97bfb7b0e57202947d397b4c
         imagePullPolicy: IfNotPresent

--- a/kubernetes/machine_objects/machine-deployment.yaml
+++ b/kubernetes/machine_objects/machine-deployment.yaml
@@ -31,4 +31,4 @@ spec:
     # healthTimeout: 5m
     # creationTimeout: 5m
     # maxEvictRetries: 25
-    # nodeConditions: "ReadonlyFilesystem,KernelDeadlock,DiskPressure"
+    # nodeConditions: "ReadonlyFilesystem,KernelDeadlock,DiskPressure,NetworkUnavailable"

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -222,7 +222,7 @@ var _ = Describe("machine", func() {
 			}
 			c = &controller{
 				controlMachineClient: fakeMachineClient,
-				nodeConditions:       "ReadonlyFilesystem,KernelDeadlock,DiskPressure",
+				nodeConditions:       "ReadonlyFilesystem,KernelDeadlock,DiskPressure,NetworkUnavailable",
 			}
 		})
 

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -276,16 +276,16 @@ var _ = Describe("machine", func() {
 			Entry("with NodeDiskPressure is Unknown", corev1.NodeDiskPressure, corev1.ConditionUnknown, false),
 
 			Entry("with NodeMemoryPressure is True", corev1.NodeMemoryPressure, corev1.ConditionTrue, true),
-			Entry("with NodeMemoryPressure is Unknown", corev1.NodeMemoryPressure, corev1.ConditionUnknown, true),
 			Entry("with NodeMemoryPressure is False", corev1.NodeMemoryPressure, corev1.ConditionFalse, true),
+			Entry("with NodeMemoryPressure is Unknown", corev1.NodeMemoryPressure, corev1.ConditionUnknown, true),
 
-			Entry("with NodeNetworkUnavailable is True", corev1.NodeNetworkUnavailable, corev1.ConditionTrue, true),
-			Entry("with NodeNetworkUnavailable is Unknown", corev1.NodeNetworkUnavailable, corev1.ConditionUnknown, true),
+			Entry("with NodeNetworkUnavailable is True", corev1.NodeNetworkUnavailable, corev1.ConditionTrue, false),
 			Entry("with NodeNetworkUnavailable is False", corev1.NodeNetworkUnavailable, corev1.ConditionFalse, true),
+			Entry("with NodeNetworkUnavailable is Unknown", corev1.NodeNetworkUnavailable, corev1.ConditionUnknown, false),
 
 			Entry("with NodeReady is True", corev1.NodeReady, corev1.ConditionTrue, true),
-			Entry("with NodeReady is Unknown", corev1.NodeReady, corev1.ConditionUnknown, false),
 			Entry("with NodeReady is False", corev1.NodeReady, corev1.ConditionFalse, false),
+			Entry("with NodeReady is Unknown", corev1.NodeReady, corev1.ConditionUnknown, false),
 		)
 	})
 

--- a/pkg/util/provider/app/options/options.go
+++ b/pkg/util/provider/app/options/options.go
@@ -56,7 +56,7 @@ func NewMCServer() *MCServer {
 			Address:                 "0.0.0.0",
 			ConcurrentNodeSyncs:     10,
 			ContentType:             "application/vnd.kubernetes.protobuf",
-			NodeConditions:          "KernelDeadlock,ReadonlyFilesystem,DiskPressure",
+			NodeConditions:          "KernelDeadlock,ReadonlyFilesystem,DiskPressure,NetworkUnavailable",
 			MinResyncPeriod:         metav1.Duration{Duration: 12 * time.Hour},
 			KubeAPIQPS:              20.0,
 			KubeAPIBurst:            30,

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -53,7 +53,7 @@ var _ = Describe("machine", func() {
 			}
 			c = &controller{
 				controlMachineClient: fakeMachineClient,
-				nodeConditions:       "ReadonlyFilesystem,KernelDeadlock,DiskPressure",
+				nodeConditions:       "ReadonlyFilesystem,KernelDeadlock,DiskPressure,NetworkUnavailable",
 			}
 		})
 

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -107,16 +107,16 @@ var _ = Describe("machine", func() {
 			Entry("with NodeDiskPressure is Unknown", corev1.NodeDiskPressure, corev1.ConditionUnknown, false),
 
 			Entry("with NodeMemoryPressure is True", corev1.NodeMemoryPressure, corev1.ConditionTrue, true),
-			Entry("with NodeMemoryPressure is Unknown", corev1.NodeMemoryPressure, corev1.ConditionUnknown, true),
 			Entry("with NodeMemoryPressure is False", corev1.NodeMemoryPressure, corev1.ConditionFalse, true),
+			Entry("with NodeMemoryPressure is Unknown", corev1.NodeMemoryPressure, corev1.ConditionUnknown, true),
 
-			Entry("with NodeNetworkUnavailable is True", corev1.NodeNetworkUnavailable, corev1.ConditionTrue, true),
-			Entry("with NodeNetworkUnavailable is Unknown", corev1.NodeNetworkUnavailable, corev1.ConditionUnknown, true),
+			Entry("with NodeNetworkUnavailable is True", corev1.NodeNetworkUnavailable, corev1.ConditionTrue, false),
 			Entry("with NodeNetworkUnavailable is False", corev1.NodeNetworkUnavailable, corev1.ConditionFalse, true),
+			Entry("with NodeNetworkUnavailable is Unknown", corev1.NodeNetworkUnavailable, corev1.ConditionUnknown, false),
 
 			Entry("with NodeReady is True", corev1.NodeReady, corev1.ConditionTrue, true),
-			Entry("with NodeReady is Unknown", corev1.NodeReady, corev1.ConditionUnknown, false),
 			Entry("with NodeReady is False", corev1.NodeReady, corev1.ConditionFalse, false),
+			Entry("with NodeReady is Unknown", corev1.NodeReady, corev1.ConditionUnknown, false),
 		)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Machine-controller-manager should also check for the NetworkUnavailable nodeCondition, some CNI will update this condition depending on the state of the CNI or the network availability.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/machine-controller-manager/issues/469

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement
- target_group:   operator
-->
```improvement operator
NetworkUnavailable nodeCondition added to the example, some CNI will update this condition depending on the state of the CNI or the network availability.
```
