### PR TITLE
Fix the OpenAPI validation of the machine-deployment crd

### DIFF
--- a/docs/development/cp_support_new.md
+++ b/docs/development/cp_support_new.md
@@ -97,7 +97,7 @@ Make sure `$TARGET_KUBECONFIG` points to the cluster where you wish to manage ma
         ```
     - Deploy the required CRDs from the machine-controller-manager repo,
         ```bash
-        kubectl apply -f kubernetes/crds.yaml
+        kubectl apply -f kubernetes/crds
         ```
     - Run the machine-controller-manager in the `master` branch
         ```bash

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -59,9 +59,6 @@ spec:
             object represents. Servers may infer this from the endpoint the client
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
-        metadata:
-          description: Standard object metadata.
-          type: object
         spec:
           description: Specification of the desired behavior of the MachineDeployment.
           properties:


### PR DESCRIPTION
**What this PR does / why we need it**:  Fix the OpenAPI validation of the machine-deployment crd
Related to: https://github.com/kubernetes/kubernetes/issues/80493

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Fix the OpenAPI validation of the machine-deployment crd
```
