### PR TITLE
OOT: Drain call is now invoked with the effective timeout

### DIFF
--- a/pkg/controller/drain.go
+++ b/pkg/controller/drain.go
@@ -85,7 +85,7 @@ const (
 	EvictionSubresource = "pods/eviction"
 
 	// DefaultMachineDrainTimeout is the default value for MachineDrainTimeout
-	DefaultMachineDrainTimeout = 12 * time.Hour
+	DefaultMachineDrainTimeout = 2 * time.Hour
 
 	// PodsWithoutPVDrainGracePeriod defines the grace period to wait for the pods without PV during machine drain.
 	// This is in addition to the maximum terminationGracePeriod amount the pods.

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -84,7 +84,7 @@ const (
 	EvictionSubresource = "pods/eviction"
 
 	// DefaultMachineDrainTimeout is the default value for MachineDrainTimeout
-	DefaultMachineDrainTimeout = 12 * time.Hour
+	DefaultMachineDrainTimeout = 2 * time.Hour
 
 	// PodsWithoutPVDrainGracePeriod defines the grace period to wait for the pods without PV during machine drain.
 	// This is in addition to the maximum terminationGracePeriod amount the pods.

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -911,7 +911,7 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 
 			drainOptions := drain.NewDrainOptions(
 				c.targetCoreClient,
-				timeOutDuration,
+				timeOut,
 				maxEvictRetries,
 				pvDetachTimeOut,
 				nodeName,


### PR DESCRIPTION
Drain call was taking in the default drain timeout of 12hours. This change reverts the value to the effective value.

**What this PR does / why we need it**:
The drain call was made with the default timeout of 12hours. This PR reverts this change to use the effective timeout value to 2hours. This also makes the default drain timeout to 2hours.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy user
Reduces default drain timeout from 12hours to 2hours.   
```
```improvement operator
OOT: Drain call was taking in the default drain timeout of 12hours. This change reverts the value to the effective value.
```
