### PR TITLE
Fixed regression (OOT) with maxEvictRetries and defaulted drain timeout to 2hours

### DIFF
--- a/pkg/controller/drain.go
+++ b/pkg/controller/drain.go
@@ -85,7 +85,7 @@ const (
 	EvictionSubresource = "pods/eviction"
 
 	// DefaultMachineDrainTimeout is the default value for MachineDrainTimeout
-	DefaultMachineDrainTimeout = 12 * time.Hour
+	DefaultMachineDrainTimeout = 2 * time.Hour
 
 	// PodsWithoutPVDrainGracePeriod defines the grace period to wait for the pods without PV during machine drain.
 	// This is in addition to the maximum terminationGracePeriod amount the pods.

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -84,7 +84,7 @@ const (
 	EvictionSubresource = "pods/eviction"
 
 	// DefaultMachineDrainTimeout is the default value for MachineDrainTimeout
-	DefaultMachineDrainTimeout = 12 * time.Hour
+	DefaultMachineDrainTimeout = 2 * time.Hour
 
 	// PodsWithoutPVDrainGracePeriod defines the grace period to wait for the pods without PV during machine drain.
 	// This is in addition to the maximum terminationGracePeriod amount the pods.

--- a/pkg/util/provider/machinecontroller/controller_suite_test.go
+++ b/pkg/util/provider/machinecontroller/controller_suite_test.go
@@ -26,6 +26,7 @@ import (
 	faketyped "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/typed/machine/v1alpha1/fake"
 	machineinformers "github.com/gardener/machine-controller-manager/pkg/client/informers/externalversions"
 	customfake "github.com/gardener/machine-controller-manager/pkg/fakeclient"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/drain"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/options"
 	. "github.com/onsi/ginkgo"
@@ -504,6 +505,7 @@ func createController(
 		MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 30 * time.Minute},
 		MachineSafetyAPIServerStatusCheckPeriod:  metav1.Duration{Duration: 1 * time.Minute},
 		MachineSafetyAPIServerStatusCheckTimeout: metav1.Duration{Duration: 30 * time.Second},
+		MaxEvictRetries:                          drain.DefaultMaxEvictRetries,
 	}
 
 	controller := &controller{

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -836,7 +837,7 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 
 		// Initialization
 		machine                 = deleteMachineRequest.Machine
-		maxEvictRetries         = *c.getEffectiveMaxEvictRetries(machine)
+		maxEvictRetries         = int32(math.Min(float64(*c.getEffectiveMaxEvictRetries(machine)), c.getEffectiveDrainTimeout(machine).Seconds()/drain.PodEvictionRetryInterval.Seconds()))
 		pvDetachTimeOut         = c.safetyOptions.PvDetachTimeout.Duration
 		timeOutDuration         = c.getEffectiveDrainTimeout(deleteMachineRequest.Machine).Duration
 		forceDeleteLabelPresent = machine.Labels["force-deletion"] == "True"
@@ -883,10 +884,17 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 			maxEvictRetries = 1
 
 			klog.V(2).Infof(
-				"Force deletion has been triggerred for machine %q due to Label:%t, timeout:%t",
+				"Force delete/drain has been triggerred for machine %q due to Label:%t, timeout:%t",
 				machine.Name,
 				forceDeleteLabelPresent,
 				timeOutOccurred,
+			)
+		} else {
+			klog.V(2).Infof(
+				"Normal delete/drain has been triggerred for machine %q with drain-timeout:%v & maxEvictRetries:%d",
+				machine.Name,
+				timeOutDuration,
+				maxEvictRetries,
 			)
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- The maxEvictRetries parameter was being computed wrongly with the OOT leading to longer (12hours) drain timeouts. Now this value is computed as it is with in-tree. Refer -[in-tree code]( https://github.com/gardener/machine-controller-manager/blob/master/pkg/controller/machine.go#L629). 
- The default drainTimeout value has been updated from 12hours to 2hours. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager-provider-gcp/issues/9

**Special notes for your reviewer**:
I have tested this PR and is in line with the in-tree implementation now. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
The default drainTimeout value has been updated from 12hours to 2hours. 
```
```improvement user
OOT: Fixed regression with maxEvictRetries
```
