### PR TITLE
OOT: Introduce backoff in re-enqueuing machines during creation/deletion failures

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -238,7 +238,6 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 	Machine controller - nodeToMachine
 */
 func (c *controller) addNodeToMachine(obj interface{}) {
-
 	node := obj.(*corev1.Node)
 	if node == nil {
 		klog.Errorf("Couldn't convert to node from object")
@@ -260,7 +259,7 @@ func (c *controller) addNodeToMachine(obj interface{}) {
 	}
 
 	if machine.Status.CurrentStatus.Phase != v1alpha1.MachineCrashLoopBackOff && nodeConditionsHaveChanged(machine.Status.Conditions, node.Status.Conditions) {
-		klog.V(2).Infof("Enqueue machine object %q as backing node's conditions have changed", machine.Name)
+		klog.V(4).Infof("Enqueue machine object %q as backing node's conditions have changed", machine.Name)
 		c.enqueueMachine(machine)
 	}
 }
@@ -270,13 +269,6 @@ func (c *controller) updateNodeToMachine(oldObj, newObj interface{}) {
 }
 
 func (c *controller) deleteNodeToMachine(obj interface{}) {
-
-	node := obj.(*corev1.Node)
-	if node == nil {
-		klog.Errorf("Couldn't convert to node from object")
-		return
-	}
-
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		klog.Errorf("Couldn't get key for object %+v: %v", obj, err)

--- a/pkg/util/provider/machinecontroller/controller_suite_test.go
+++ b/pkg/util/provider/machinecontroller/controller_suite_test.go
@@ -288,6 +288,7 @@ func newMachinesFromMachineSet(
 		annotations,
 		finalLabels,
 		addFinalizer,
+		metav1.Now(),
 	)
 }
 
@@ -298,8 +299,9 @@ func newMachine(
 	annotations map[string]string,
 	labels map[string]string,
 	addFinalizer bool,
+	creationTimestamp metav1.Time,
 ) *v1alpha1.Machine {
-	return newMachines(1, specTemplate, statusTemplate, owner, annotations, labels, addFinalizer)[0]
+	return newMachines(1, specTemplate, statusTemplate, owner, annotations, labels, addFinalizer, creationTimestamp)[0]
 }
 
 func newMachines(
@@ -310,6 +312,7 @@ func newMachines(
 	annotations map[string]string,
 	labels map[string]string,
 	addFinalizer bool,
+	creationTimestamp metav1.Time,
 ) []*v1alpha1.Machine {
 	machines := make([]*v1alpha1.Machine, machineCount)
 
@@ -327,10 +330,11 @@ func newMachines(
 				Kind:       "Machine",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        fmt.Sprintf("machine-%d", i),
-				Namespace:   testNamespace,
-				Labels:      labels,
-				Annotations: annotations,
+				Name:              fmt.Sprintf("machine-%d", i),
+				Namespace:         testNamespace,
+				Labels:            labels,
+				Annotations:       annotations,
+				CreationTimestamp: creationTimestamp,
 			},
 			Spec: *newMachineSpec(&specTemplate.Spec, i),
 		}
@@ -562,7 +566,7 @@ var _ = Describe("#createController", func() {
 	It("success", func() {
 		machine0 := newMachine(&v1alpha1.MachineTemplateSpec{
 			ObjectMeta: *objMeta,
-		}, nil, nil, nil, nil, false)
+		}, nil, nil, nil, nil, false, metav1.Now())
 
 		stop := make(chan struct{})
 		defer close(stop)

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -362,7 +362,7 @@ var _ = Describe("machine", func() {
 		type expect struct {
 			machine *v1alpha1.Machine
 			err     error
-			retry   machineutils.Retry
+			retry   machineutils.RetryPeriod
 		}
 		type data struct {
 			setup  setup
@@ -472,7 +472,7 @@ var _ = Describe("machine", func() {
 						},
 					}, nil, nil, nil, nil, true),
 					err:   fmt.Errorf("Machine creation in process. Machine finalizers are UPDATED"),
-					retry: true,
+					retry: machineutils.ShortRetry,
 				},
 			}),
 			Entry("Machine creation succeeds with object UPDATE", &data{
@@ -520,7 +520,7 @@ var _ = Describe("machine", func() {
 						},
 					}, nil, nil, nil, nil, true),
 					err:   fmt.Errorf("Machine creation in process. Machine UPDATE successful"),
-					retry: true,
+					retry: machineutils.ShortRetry,
 				},
 			}),
 			Entry("Machine creation succeeds with status UPDATE", &data{
@@ -594,7 +594,7 @@ var _ = Describe("machine", func() {
 						true,
 					),
 					err:   fmt.Errorf("Machine creation in process. Machine/Status UPDATE successful"),
-					retry: true,
+					retry: machineutils.ShortRetry,
 				},
 			}),
 			Entry("Machine creation has already succeeded, so no update", &data{
@@ -692,7 +692,7 @@ var _ = Describe("machine", func() {
 						true,
 					),
 					err:   nil,
-					retry: false,
+					retry: machineutils.LongRetry,
 				},
 			}),
 
@@ -771,7 +771,7 @@ var _ = Describe("machine", func() {
 			err                           error
 			nodeTerminationConditionIsSet bool
 			nodeDeleted                   bool
-			retry                         machineutils.Retry
+			retry                         machineutils.RetryPeriod
 		}
 		type data struct {
 			setup  setup
@@ -917,7 +917,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Machine \"machine-0\" is missing finalizers. Deletion cannot proceed"),
-					retry: machineutils.DoNotRetryOp,
+					retry: machineutils.LongRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1012,7 +1012,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Machine deletion in process. Phase set to termination"),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1107,7 +1107,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Machine deletion in process. VM with matching ID found"),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1209,7 +1209,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:                           fmt.Errorf("Machine deletion in process. Drain successful. %s", machineutils.InitiateVMDeletion),
-					retry:                         machineutils.RetryOp,
+					retry:                         machineutils.ShortRetry,
 					nodeTerminationConditionIsSet: true,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
@@ -1312,7 +1312,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Skipping drain as nodeName is not a valid one for machine. Initiate VM deletion"),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1414,7 +1414,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Skipping drain as machine is NotReady for over 5minutes. %s", machineutils.InitiateVMDeletion),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1522,7 +1522,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Failed to update node"),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1629,7 +1629,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Failed to update node"),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1736,7 +1736,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("failed to create update conditions for node \"fakeNode-0\": Failed to update node"),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1831,7 +1831,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Machine deletion in process. VM deletion was successful. " + machineutils.InitiateNodeDeletion),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -1933,7 +1933,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:         fmt.Errorf("Machine deletion in process. Deletion of node object was succesful"),
-					retry:       machineutils.RetryOp,
+					retry:       machineutils.ShortRetry,
 					nodeDeleted: true,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
@@ -2028,7 +2028,7 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					retry: machineutils.DoNotRetryOp,
+					retry: machineutils.LongRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
@@ -2123,7 +2123,7 @@ var _ = Describe("machine", func() {
 				},
 				expect: expect{
 					err:   fmt.Errorf("Machine deletion in process. Phase set to termination"),
-					retry: machineutils.RetryOp,
+					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
 							ObjectMeta: *newObjectMeta(objMeta, 0),

--- a/pkg/util/provider/machinecontroller/machine_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_util_test.go
@@ -18,6 +18,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	machinev1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -131,7 +132,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineStatus{
 							Node: "test-node",
 						},
-						nil, nil, nil, true),
+						nil, nil, nil, true, metav1.Now()),
 				},
 				action: action{
 					node: &corev1.Node{
@@ -228,7 +229,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineStatus{
 							Node: "test-node",
 						},
-						nil, nil, nil, true),
+						nil, nil, nil, true, metav1.Now()),
 				},
 				action: action{
 					node: &corev1.Node{
@@ -309,7 +310,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineStatus{
 							Node: "test-node",
 						},
-						nil, nil, nil, true),
+						nil, nil, nil, true, metav1.Now()),
 				},
 				action: action{
 					node: &corev1.Node{},
@@ -363,7 +364,7 @@ var _ = Describe("machine_util", func() {
 						&machinev1.MachineStatus{
 							Node: "test-node",
 						},
-						nil, nil, nil, true),
+						nil, nil, nil, true, metav1.Now()),
 				},
 				action: action{
 					node: &corev1.Node{
@@ -506,7 +507,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -560,7 +561,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -615,7 +616,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -671,7 +672,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -725,7 +726,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -780,7 +781,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -834,7 +835,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -939,7 +940,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -991,7 +992,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1044,7 +1045,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1094,7 +1095,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1146,7 +1147,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1199,7 +1200,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1252,7 +1253,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1367,7 +1368,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1437,7 +1438,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1512,7 +1513,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1592,7 +1593,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1667,7 +1668,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1747,7 +1748,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1821,7 +1822,7 @@ var _ = Describe("machine_util", func() {
 								},
 							},
 						},
-						nil, nil, nil, nil, true),
+						nil, nil, nil, nil, true, metav1.Now()),
 				},
 				expect: expect{
 					node: &corev1.Node{
@@ -1848,6 +1849,144 @@ var _ = Describe("machine_util", func() {
 						},
 					},
 					taintsChanged: true,
+				},
+			}),
+		)
+
+	})
+
+	Describe("#isMachineStatusSimilar", func() {
+
+		type setup struct {
+			m1, m2 machinev1.MachineStatus
+		}
+
+		type expect struct {
+			equal bool
+		}
+		type data struct {
+			setup setup
+
+			expect expect
+		}
+
+		DescribeTable("##table",
+			func(data *data) {
+				equal := isMachineStatusSimilar(data.setup.m1, data.setup.m2)
+				Expect(equal).To(Equal(data.expect.equal))
+			},
+			Entry("when status description is exact match", &data{
+				setup: setup{
+					m1: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+					m2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+				},
+				expect: expect{
+					equal: true,
+				},
+			}),
+			Entry("when status description is exact match but timeout has occurred", &data{
+				setup: setup{
+					m1: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+					m2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+						},
+					},
+				},
+				expect: expect{
+					equal: false,
+				},
+			}),
+			Entry("when status description is exact match but timeout has not occurred", &data{
+				setup: setup{
+					m1: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+					m2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.NewTime(time.Now().Add(-time.Minute)),
+						},
+					},
+				},
+				expect: expect{
+					equal: true,
+				},
+			}),
+			Entry("when status description is long similar", &data{
+				setup: setup{
+					m1: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+					m2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "Error occurred with decoding machine error status while getting VM status, aborting without retry. gRPC code: AuthFailure: AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: dsfddsfd-dsfdfd-dsfdsfds-dsfdkjljl32 Set machine status to termination. Now, getting VM Status",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+				},
+				expect: expect{
+					equal: true,
+				},
+			}),
+			Entry("when status description is short similar", &data{
+				setup: setup{
+					m1: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: fbc513f0-ca27-4a42-a203-42048d5773a2",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+					m2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    "AWS was not able to validate the provided access credentials\n\tstatus code: 401, request id: 23423424-342f-sdff-45cs-3242sdfsdfd",
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+				},
+				expect: expect{
+					equal: true,
+				},
+			}),
+			Entry("when status description is different", &data{
+				setup: setup{
+					m1: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    machineutils.InitiateNodeDeletion,
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+					m2: machinev1.MachineStatus{
+						LastOperation: machinev1.LastOperation{
+							Description:    machineutils.InitiateFinalizerRemoval,
+							LastUpdateTime: metav1.Now(),
+						},
+					},
+				},
+				expect: expect{
+					equal: false,
 				},
 			}),
 		)

--- a/pkg/util/provider/machinecontroller/migrate_machineclass_test.go
+++ b/pkg/util/provider/machinecontroller/migrate_machineclass_test.go
@@ -125,7 +125,7 @@ var _ = Describe("machine", func() {
 			gcpMachineClass *v1alpha1.GCPMachineClass
 			machineClass    *v1alpha1.MachineClass
 
-			retry machineutils.Retry
+			retry machineutils.RetryPeriod
 		}
 		type data struct {
 			setup  setup
@@ -245,7 +245,7 @@ var _ = Describe("machine", func() {
 						Spec:     v1alpha1.GCPMachineClassSpec{},
 					},
 					err:   nil,
-					retry: true,
+					retry: machineutils.ShortRetry,
 				},
 			}),
 			Entry("MachineClass migration successful for GCP machine class by updating existing machine class", &data{
@@ -308,7 +308,7 @@ var _ = Describe("machine", func() {
 						Spec:     v1alpha1.GCPMachineClassSpec{},
 					},
 					err:   nil,
-					retry: true,
+					retry: machineutils.ShortRetry,
 				},
 			}),
 		)

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -17,7 +17,11 @@ limitations under the License.
 // Package machineutils contains the consts and global vaariables for machine operation
 package machineutils
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 const (
 	// GetVMStatus sets machine status to terminating and specifies next step as getting VMs
@@ -51,13 +55,15 @@ const (
 	NodeTerminationCondition v1.NodeConditionType = "Terminating"
 )
 
-// Retry is a label for retrying operation
-type Retry bool
+// RetryPeriod is an alias for specifying the retry period
+type RetryPeriod time.Duration
 
-// These are the valid values for Retry.
+// These are the valid values for RetryPeriod
 const (
-	// RetryOp tells the controller to retry
-	RetryOp Retry = true
-	// DoNotRetryOp tells the controller to not retry for now. Resync after re-sync period
-	DoNotRetryOp Retry = false
+	// ShortRetry tells the controller to retry after a short duration - 15 seconds
+	ShortRetry RetryPeriod = RetryPeriod(15 * time.Second)
+	// MediumRetry tells the controller to retry after a medium duration - 2 minutes
+	MediumRetry RetryPeriod = RetryPeriod(3 * time.Minute)
+	// LongRetry tells the controller to retry after a long duration - 10 minutes
+	LongRetry RetryPeriod = RetryPeriod(10 * time.Minute)
 )

--- a/pkg/util/strings/string.go
+++ b/pkg/util/strings/string.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package strings is used to provide some util string functions
+package strings
+
+// StringSimilarityRatio is used to find the ratio of similarity
+// between two strings using the Levenshtein algorithm below
+func StringSimilarityRatio(str1, str2 string) float64 {
+	avgLen := float64(len(str1)+len(str2)) / 2
+	changes := float64(Levenshtein(str1, str2))
+	return (1.0 - changes/avgLen)
+}
+
+// Levenshtein is used to compare the number of changes required
+// to convert the string from one to another
+func Levenshtein(str1, str2 string) int {
+	s1len := len(str1)
+	s2len := len(str2)
+	column := make([]int, len(str1)+1)
+
+	for y := 1; y <= s1len; y++ {
+		column[y] = y
+	}
+	for x := 1; x <= s2len; x++ {
+		column[0] = x
+		lastkey := x - 1
+		for y := 1; y <= s1len; y++ {
+			oldkey := column[y]
+			var incr int
+			if str1[y-1] != str2[x-1] {
+				incr = 1
+			}
+
+			column[y] = minimum(column[y]+1, column[y-1]+1, lastkey+incr)
+			lastkey = oldkey
+		}
+	}
+	return column[s1len]
+}
+
+// minimum finds the minimum among 3 numbers
+func minimum(a, b, c int) int {
+	if a < b {
+		if a < c {
+			return a
+		}
+	} else {
+		if b < c {
+			return b
+		}
+	}
+	return c
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Changes carried over from in-tree fix - https://github.com/gardener/machine-controller-manager/pull/525/
- Also removes the unused node object - https://github.com/gardener/machine-controller-manager/pull/525/files#diff-d52f3782153512c736878e861c6cafd75dd23f214af3f017eea14de256da458bR274-R278

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```noteworthy operator
OOT: Introduced a backoff in re-enqueuing machines on creation/deletion failures. Avoids throttling APIServer & provider calls.
```
```improvement operator
OOT: Enqueue machine only when node conditions have changed.
```
/kind regression
/size l