### PR TITLE
Use listers to get the machine-object during reconciliation

### DIFF
--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -176,7 +176,7 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 		return nil
 	}
 
-	machine, err = c.controlMachineClient.Machines(machine.Namespace).Get(machine.Name, metav1.GetOptions{})
+	machine, err = c.machineLister.Machines(machine.Namespace).Get(machine.Name)
 	if err != nil {
 		klog.Errorf("Could not fetch machine object %s", err)
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
**What this PR does / why we need it**:  MCM uses the cache-based listers instead of direct client calls while machine-reconciliation. 

**Which issue(s) this PR fixes**:
Fixes #536 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Use cache-based listers to GET the machine-object while reconciling.
```
