### PR TITLE
Allow migration to continue when machineClass with same name as Provi…

### DIFF
--- a/pkg/util/provider/machinecontroller/migrate_machineclass_test.go
+++ b/pkg/util/provider/machinecontroller/migrate_machineclass_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 package controller
 
 import (
+	"fmt"
+
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	customfake "github.com/gardener/machine-controller-manager/pkg/fakeclient"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
@@ -162,8 +164,10 @@ var _ = Describe("machine", func() {
 				waitForCacheSync(stop, controller)
 
 				action := data.action
-				_, err := controller.controlMachineClient.GCPMachineClasses(TestNamespace).Get(action.classSpec.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				if data.setup.gcpMachineClass != nil {
+					_, err := controller.controlMachineClient.GCPMachineClasses(TestNamespace).Get(action.classSpec.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+				}
 
 				_, _, retry, err := controller.TryMachineClassMigration(data.action.classSpec)
 				Expect(retry).To(Equal(data.expect.retry))
@@ -171,13 +175,15 @@ var _ = Describe("machine", func() {
 
 				if data.expect.err != nil || err != nil {
 					Expect(err).To(HaveOccurred())
-					Expect(err).To(Equal(data.expect.err))
+					Expect(err.Error()).To(Equal(data.expect.err.Error()))
 				} else {
 					Expect(err).ToNot(HaveOccurred())
 
-					actualGCPMachineClass, err := controller.controlMachineClient.GCPMachineClasses(TestNamespace).Get(action.classSpec.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(data.expect.gcpMachineClass).To(Equal(actualGCPMachineClass))
+					if data.expect.gcpMachineClass != nil {
+						actualGCPMachineClass, err := controller.controlMachineClient.GCPMachineClasses(TestNamespace).Get(action.classSpec.Name, metav1.GetOptions{})
+						Expect(err).ToNot(HaveOccurred())
+						Expect(data.expect.gcpMachineClass).To(Equal(actualGCPMachineClass))
+					}
 
 					actualMachineClass, err := controller.controlMachineClient.MachineClasses(TestNamespace).Get(action.classSpec.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
@@ -308,6 +314,90 @@ var _ = Describe("machine", func() {
 						Spec:     v1alpha1.GCPMachineClassSpec{},
 					},
 					err:   nil,
+					retry: machineutils.ShortRetry,
+				},
+			}),
+			Entry("MachineClass migration succeeds by only updating existing machine class references as machineClass with same name was found", &data{
+				setup: setup{
+					machineClass: []*v1alpha1.MachineClass{
+						{
+							TypeMeta: metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      TestMachineClassName,
+								Namespace: TestNamespace,
+							},
+							ProviderSpec: runtime.RawExtension{},
+							SecretRef:    nil,
+							Provider:     "FakeProvider",
+						},
+					},
+				},
+				action: action{
+					classSpec: &v1alpha1.ClassSpec{
+						Kind: GCPMachineClassKind,
+						Name: TestMachineClassName,
+					},
+					fakeDriver: &driver.FakeDriver{
+						VMExists:   false,
+						ProviderID: "fakeID-0",
+						NodeName:   "fakeNode-0",
+						Err:        nil,
+					},
+				},
+				expect: expect{
+					machineClass: &v1alpha1.MachineClass{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      TestMachineClassName,
+							Namespace: TestNamespace,
+						},
+						ProviderSpec: runtime.RawExtension{},
+						SecretRef:    nil,
+						Provider:     "FakeProvider",
+					},
+					err:   nil,
+					retry: machineutils.ShortRetry,
+				},
+			}),
+			Entry("MachineClass migration fails as existing machine class references as machineClass with same name was not found", &data{
+				setup: setup{
+					machineClass: []*v1alpha1.MachineClass{
+						{
+							TypeMeta: metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      TestMachineClassName + "-error",
+								Namespace: TestNamespace,
+							},
+							ProviderSpec: runtime.RawExtension{},
+							SecretRef:    nil,
+							Provider:     "FakeProvider",
+						},
+					},
+				},
+				action: action{
+					classSpec: &v1alpha1.ClassSpec{
+						Kind: GCPMachineClassKind,
+						Name: TestMachineClassName,
+					},
+					fakeDriver: &driver.FakeDriver{
+						VMExists:   false,
+						ProviderID: "fakeID-0",
+						NodeName:   "fakeNode-0",
+						Err:        nil,
+					},
+				},
+				expect: expect{
+					machineClass: &v1alpha1.MachineClass{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      TestMachineClassName,
+							Namespace: TestNamespace,
+						},
+						ProviderSpec: runtime.RawExtension{},
+						SecretRef:    nil,
+						Provider:     "FakeProvider",
+					},
+					err:   fmt.Errorf("gcpmachineclasses.machine.sapcloud.io \"test-mc\" not found"),
 					retry: machineutils.ShortRetry,
 				},
 			}),


### PR DESCRIPTION
…derMachineClass is found

**What this PR does / why we need it**:
I observed a rare occurrence (only 1 cluster until now, tried to look through the code couldn't understand how this could occur) of a machine class migration failing for a shoot where the new machine class was created with the expected data, however, the machine objects were referring to an old non-existing ProviderMachineClass. This PR fixes such race conditions. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have added unit tests to check for these cases as well. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Allow migration to continue when ProviderMachineClass is missing but MachineClass with the same name as ProviderMachineClass is found. Updates Machine object references to the MachineClass.
```
