### PR TITLE
Set Machine Phase to Terminating & make drain calculations based on deletionTimestamp

### DIFF
--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -312,6 +312,8 @@ func newMachines(
 		labels = make(map[string]string, 0)
 	}
 
+	currentTime := metav1.Now()
+
 	for i := range machines {
 		m := &v1alpha1.Machine{
 			TypeMeta: metav1.TypeMeta{
@@ -324,6 +326,7 @@ func newMachines(
 				Labels:            labels,
 				Annotations:       annotations,
 				CreationTimestamp: metav1.Now(),
+				DeletionTimestamp: &currentTime,
 			},
 			Spec: *newMachineSpec(&specTemplate.Spec, i),
 		}

--- a/pkg/util/provider/machinecontroller/controller_suite_test.go
+++ b/pkg/util/provider/machinecontroller/controller_suite_test.go
@@ -335,6 +335,7 @@ func newMachines(
 				Labels:            labels,
 				Annotations:       annotations,
 				CreationTimestamp: creationTimestamp,
+				DeletionTimestamp: &creationTimestamp, //TODO: Add parametrize this
 			},
 			Spec: *newMachineSpec(&specTemplate.Spec, i),
 		}

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	utilstrings "github.com/gardener/machine-controller-manager/pkg/util/strings"
+	utiltime "github.com/gardener/machine-controller-manager/pkg/util/time"
 
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -912,9 +913,7 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 	if skipDrain {
 		state = v1alpha1.MachineStateProcessing
 	} else {
-		// Timeout value obtained by subtracting last operation with expected time out period
-		timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.Status.CurrentStatus.LastUpdateTime.Time)
-		timeOutOccurred = timeOut > 0
+		timeOutOccurred = utiltime.HasTimeOutOccurred(*machine.DeletionTimestamp, timeOutDuration)
 
 		if forceDeleteLabelPresent || timeOutOccurred {
 			// To perform forceful machine drain/delete either one of the below conditions must be satified

--- a/pkg/util/time/time.go
+++ b/pkg/util/time/time.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package time is used to provide the core functionalities of machine-controller-manager
+package time
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HasTimeOutOccurred returns true, when time.Now() is more than time + period
+func HasTimeOutOccurred(timeStamp metav1.Time, period time.Duration) bool {
+	// Timeout value obtained by subtracting last operation with expected time out period
+	timeOut := metav1.Now().Add(-period).Sub(timeStamp.Time)
+	return timeOut > 0
+}

--- a/pkg/util/time/time_suite_test.go
+++ b/pkg/util/time/time_suite_test.go
@@ -1,0 +1,13 @@
+package time_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTime(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Time Suite")
+}

--- a/pkg/util/time/time_test.go
+++ b/pkg/util/time/time_test.go
@@ -63,7 +63,7 @@ var _ = Describe("time", func() {
 					timeOutOccurred: false,
 				},
 			}),
-			Entry("Time stamp is now and peroid is 5mins", &data{
+			Entry("Time stamp is now and period is 5mins", &data{
 				setup: setup{
 					timeStamp: metav1.Time{Time: time.Now()},
 					period:    5 * time.Minute,

--- a/pkg/util/time/time_test.go
+++ b/pkg/util/time/time_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package time
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("time", func() {
+	Describe("#hasTimeOutOccurred", func() {
+		type setup struct {
+			timeStamp metav1.Time
+			period    time.Duration
+		}
+		type action struct {
+		}
+		type expect struct {
+			timeOutOccurred bool
+		}
+		type data struct {
+			setup  setup
+			action action
+			expect expect
+		}
+		DescribeTable("##TimeOut scenarios",
+			func(data *data) {
+				timeOutOccurred := HasTimeOutOccurred(data.setup.timeStamp, data.setup.period)
+				Expect(timeOutOccurred).To(Equal(data.expect.timeOutOccurred))
+			},
+			Entry("Time stamp is one hour ago and period is 30mins", &data{
+				setup: setup{
+					timeStamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
+					period:    30 * time.Minute,
+				},
+				expect: expect{
+					timeOutOccurred: true,
+				},
+			}),
+			Entry("Time stamp is one hour ago and period is 90mins", &data{
+				setup: setup{
+					timeStamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
+					period:    90 * time.Minute,
+				},
+				expect: expect{
+					timeOutOccurred: false,
+				},
+			}),
+			Entry("Time stamp is now and peroid is 5mins", &data{
+				setup: setup{
+					timeStamp: metav1.Time{Time: time.Now()},
+					period:    5 * time.Minute,
+				},
+				expect: expect{
+					timeOutOccurred: false,
+				},
+			}),
+		)
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the race condition that triggers force deletion of machines which are less than drain timeout minutes old. Fixes regressions from #492 . 

**Which issue(s) this PR fixes**:
Fixes #563 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Set Machine Phase to Terminating before draining. 
```
```noteworthy operator
Machine force deletion computation is based on deletionTimestamp instead of LastUpdatedTimestamp. 
```
/invite @guydaichs 