### PR TITLE
Fix Azure machine deletion if resource group is gone

### DIFF
--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -284,6 +284,14 @@ func (d *AzureDriver) Delete(machineID string) error {
 		resourceGroupName = d.AzureMachineClass.Spec.ResourceGroup
 	)
 
+	// Check if the underlying resource group still exists, if not skip the deletion as all resources are gone.
+	if _, err := clients.group.Get(ctx, resourceGroupName); err != nil {
+		if notFound(err) {
+			return nil
+		}
+		return err
+	}
+
 	var dataDiskNames []string
 	if d.AzureMachineClass.Spec.Properties.StorageProfile.DataDisks != nil && len(d.AzureMachineClass.Spec.Properties.StorageProfile.DataDisks) > 0 {
 		dataDiskNames = getAzureDataDiskNames(d.AzureMachineClass.Spec.Properties.StorageProfile.DataDisks, vmName, dataDiskSuffix)
@@ -386,6 +394,7 @@ type azureDriverClients struct {
 	vm          compute.VirtualMachinesClient
 	disk        compute.DisksClient
 	deployments resources.DeploymentsClient
+	group       resources.GroupsClient
 	images      compute.VirtualMachineImagesClient
 	marketplace marketplaceordering.MarketplaceAgreementsClient
 }
@@ -420,13 +429,16 @@ func newClients(subscriptionID, tenantID, clientID, clientSecret string, env azu
 	diskClient := compute.NewDisksClient(subscriptionID)
 	diskClient.Authorizer = authorizer
 
+	groupClient := resources.NewGroupsClient(subscriptionID)
+	groupClient.Authorizer = authorizer
+
 	deploymentsClient := resources.NewDeploymentsClient(subscriptionID)
 	deploymentsClient.Authorizer = authorizer
 
 	marketplaceClient := marketplaceordering.NewMarketplaceAgreementsClient(subscriptionID)
 	marketplaceClient.Authorizer = authorizer
 
-	return &azureDriverClients{subnet: subnetClient, nic: interfacesClient, vm: vmClient, disk: diskClient, deployments: deploymentsClient, images: vmImagesClient, marketplace: marketplaceClient}, nil
+	return &azureDriverClients{subnet: subnetClient, nic: interfacesClient, vm: vmClient, disk: diskClient, deployments: deploymentsClient, images: vmImagesClient, group: groupClient, marketplace: marketplaceClient}, nil
 }
 
 func (d *AzureDriver) createVMNicDisk() (*compute.VirtualMachine, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow MCM to delete Azure machines even if the underlying resource groups are already deleted. E. g. user delete the resource group manually.

**Which issue(s) this PR fixes**:
Fixes #562

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
MCM will delete Azure machines even if the underlying resource group is already deleted.
```

/invite @kon-angelo @ialidzhikov 