### PR TITLE
Cherrypick PR#564 to v0.34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM golang:1.13.5 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM alpine:3.11.2 as base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -312,6 +312,8 @@ func newMachines(
 		labels = make(map[string]string, 0)
 	}
 
+	currentTime := metav1.Now()
+
 	for i := range machines {
 		m := &v1alpha1.Machine{
 			TypeMeta: metav1.TypeMeta{
@@ -324,6 +326,7 @@ func newMachines(
 				Labels:            labels,
 				Annotations:       annotations,
 				CreationTimestamp: metav1.Now(),
+				DeletionTimestamp: &currentTime,
 			},
 			Spec: *newMachineSpec(&specTemplate.Spec, i),
 		}

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/validation"
 	"github.com/gardener/machine-controller-manager/pkg/driver"
+	utiltime "github.com/gardener/machine-controller-manager/pkg/util/time"
 )
 
 const (
@@ -632,42 +633,6 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 			forceDeleteLabelPresent = machine.Labels["force-deletion"] == "True"
 		)
 
-		// Timeout value obtained by subtracting last operation with expected time out period
-		timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.Status.CurrentStatus.LastUpdateTime.Time)
-		timeOutOccurred = timeOut > 0
-
-		if forceDeleteLabelPresent || timeOutOccurred {
-			// To perform forceful machine drain/delete either one of the below conditions must be satified
-			// 1. force-deletion: "True" label must be present
-			// 2. Deletion operation is more than drain-timeout minutes old
-			forceDeleteMachine = true
-			forceDeletePods = true
-			timeOutDuration = 1 * time.Minute
-			maxEvictRetries = 1
-
-			klog.V(2).Infof(
-				"Force deletion has been triggerred for machine %q due to ForceDeletionLabel:%t, Timeout:%t",
-				machine.Name,
-				forceDeleteLabelPresent,
-				timeOutOccurred,
-			)
-		}
-
-		// If machine was created on the cloud provider
-		machineID, _ := driver.GetExisting()
-
-		// update node with the machine's state prior to termination
-		if nodeName != "" && machineID != "" {
-			if err = c.UpdateNodeTerminationCondition(machine); err != nil {
-				if forceDeleteMachine {
-					klog.Warningf("failed to update node conditions: %v. However, since it's a force deletion shall continue deletion of VM.", err)
-				} else {
-					klog.Error(err)
-					return err
-				}
-			}
-		}
-
 		if machine.Status.CurrentStatus.Phase != v1alpha1.MachineTerminating {
 			lastOperation := v1alpha1.LastOperation{
 				Description:    "Deleting machine from cloud provider",
@@ -695,6 +660,47 @@ func (c *controller) machineDelete(machine *v1alpha1.Machine, driver driver.Driv
 				// Any other type of errors
 				klog.Error(err)
 				return err
+			}
+		}
+
+		timeOutOccurred = utiltime.HasTimeOutOccurred(*machine.DeletionTimestamp, timeOutDuration)
+
+		if forceDeleteLabelPresent || timeOutOccurred {
+			// To perform forceful machine drain/delete either one of the below conditions must be satified
+			// 1. force-deletion: "True" label must be present
+			// 2. Deletion operation is more than drain-timeout minutes old
+			forceDeleteMachine = true
+			forceDeletePods = true
+			timeOutDuration = 1 * time.Minute
+			maxEvictRetries = 1
+
+			klog.V(2).Infof(
+				"Force delete/drain has been triggerred for machine %q due to Label:%t, timeout:%t",
+				machine.Name,
+				forceDeleteLabelPresent,
+				timeOutOccurred,
+			)
+		} else {
+			klog.V(2).Infof(
+				"Normal delete/drain has been triggerred for machine %q with drain-timeout:%v & maxEvictRetries:%d",
+				machine.Name,
+				timeOutDuration,
+				maxEvictRetries,
+			)
+		}
+
+		// If machine was created on the cloud provider
+		machineID, _ := driver.GetExisting()
+
+		// update node with the machine's state prior to termination
+		if nodeName != "" && machineID != "" {
+			if err = c.UpdateNodeTerminationCondition(machine); err != nil {
+				if forceDeleteMachine {
+					klog.Warningf("failed to update node conditions: %v. However, since it's a force deletion shall continue deletion of VM.", err)
+				} else {
+					klog.Error(err)
+					return err
+				}
 			}
 		}
 

--- a/pkg/util/provider/machinecontroller/controller_suite_test.go
+++ b/pkg/util/provider/machinecontroller/controller_suite_test.go
@@ -287,6 +287,7 @@ func newMachinesFromMachineSet(
 		annotations,
 		finalLabels,
 		addFinalizer,
+		metav1.Now(),
 	)
 }
 
@@ -298,7 +299,7 @@ func newMachine(
 	labels map[string]string,
 	addFinalizer bool,
 ) *v1alpha1.Machine {
-	return newMachines(1, specTemplate, statusTemplate, owner, annotations, labels, addFinalizer)[0]
+	return newMachines(1, specTemplate, statusTemplate, owner, annotations, labels, addFinalizer, metav1.Now())[0]
 }
 
 func newMachines(
@@ -309,6 +310,7 @@ func newMachines(
 	annotations map[string]string,
 	labels map[string]string,
 	addFinalizer bool,
+	creationTimestamp metav1.Time,
 ) []*v1alpha1.Machine {
 	machines := make([]*v1alpha1.Machine, machineCount)
 
@@ -326,10 +328,12 @@ func newMachines(
 				Kind:       "Machine",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        fmt.Sprintf("machine-%d", i),
-				Namespace:   testNamespace,
-				Labels:      labels,
-				Annotations: annotations,
+				Name:              fmt.Sprintf("machine-%d", i),
+				Namespace:         testNamespace,
+				Labels:            labels,
+				Annotations:       annotations,
+				CreationTimestamp: creationTimestamp,
+				DeletionTimestamp: &creationTimestamp, //TODO: Add parametrize this
 			},
 			Spec: *newMachineSpec(&specTemplate.Spec, i),
 		}

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -38,6 +38,8 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
+	utiltime "github.com/gardener/machine-controller-manager/pkg/util/time"
+
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -868,9 +870,7 @@ func (c *controller) drainNode(deleteMachineRequest *driver.DeleteMachineRequest
 		state = v1alpha1.MachineStateProcessing
 		phase = v1alpha1.MachineTerminating
 	} else {
-		// Timeout value obtained by subtracting last operation with expected time out period
-		timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.Status.CurrentStatus.LastUpdateTime.Time)
-		timeOutOccurred = timeOut > 0
+		timeOutOccurred = utiltime.HasTimeOutOccurred(*machine.DeletionTimestamp, timeOutDuration)
 
 		if forceDeleteLabelPresent || timeOutOccurred {
 			// To perform forceful machine drain/delete either one of the below conditions must be satified

--- a/pkg/util/time/time.go
+++ b/pkg/util/time/time.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package time is used to provide the core functionalities of machine-controller-manager
+package time
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HasTimeOutOccurred returns true, when time.Now() is more than time + period
+func HasTimeOutOccurred(timeStamp metav1.Time, period time.Duration) bool {
+	// Timeout value obtained by subtracting last operation with expected time out period
+	timeOut := metav1.Now().Add(-period).Sub(timeStamp.Time)
+	return timeOut > 0
+}

--- a/pkg/util/time/time_suite_test.go
+++ b/pkg/util/time/time_suite_test.go
@@ -1,0 +1,13 @@
+package time_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTime(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Time Suite")
+}

--- a/pkg/util/time/time_test.go
+++ b/pkg/util/time/time_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2017 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package time
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("time", func() {
+	Describe("#hasTimeOutOccurred", func() {
+		type setup struct {
+			timeStamp metav1.Time
+			period    time.Duration
+		}
+		type action struct {
+		}
+		type expect struct {
+			timeOutOccurred bool
+		}
+		type data struct {
+			setup  setup
+			action action
+			expect expect
+		}
+		DescribeTable("##TimeOut scenarios",
+			func(data *data) {
+				timeOutOccurred := HasTimeOutOccurred(data.setup.timeStamp, data.setup.period)
+				Expect(timeOutOccurred).To(Equal(data.expect.timeOutOccurred))
+			},
+			Entry("Time stamp is one hour ago and period is 30mins", &data{
+				setup: setup{
+					timeStamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
+					period:    30 * time.Minute,
+				},
+				expect: expect{
+					timeOutOccurred: true,
+				},
+			}),
+			Entry("Time stamp is one hour ago and period is 90mins", &data{
+				setup: setup{
+					timeStamp: metav1.Time{Time: time.Now().Add(-time.Hour)},
+					period:    90 * time.Minute,
+				},
+				expect: expect{
+					timeOutOccurred: false,
+				},
+			}),
+			Entry("Time stamp is now and period is 5mins", &data{
+				setup: setup{
+					timeStamp: metav1.Time{Time: time.Now()},
+					period:    5 * time.Minute,
+				},
+				expect: expect{
+					timeOutOccurred: false,
+				},
+			}),
+		)
+	})
+})


### PR DESCRIPTION
…eletionTimestamp (#564)

* Fixes issues with machines being force drained

The machines were being force drained during race conditions due to PR #492.
This commit fixes that by
	- Make the drain calculation based on deletion timestamp
	- Reverted logic from PR #492 to first set machine Termination phase

* Update pkg/util/time/time_test.go

Fixed typo

Co-authored-by: Hardik Dodiya <hardik.dodiya@sap.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Set Machine Phase to Terminating before draining. 
```
```noteworthy operator
Machine force deletion computation is based on deletionTimestamp instead of LastUpdatedTimestamp. 
```