### PR TITLE
Update docker images to use gcr copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM golang:1.13.5 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM alpine:3.11.2 as base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /


### PR DESCRIPTION
  - Updated from golang:1.13.5 to eu.gcr.io/gardener-project/3rd/golang:1.15.5
  - Updated from alpine:3.11.2 to eu.gcr.io/gardener-project/3rd/alpine:3.12.1

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement developer
Update docker images to use gcr copy
```
```improvement developer
Update docker image versions to `golang:1.15.5` & `alpine:3.12.1`
```
