### PR TITLE
Prevent panic when machine template hash length is < 5

### DIFF
--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -301,11 +301,17 @@ func (dc *controller) getNewMachineSet(d *v1alpha1.MachineDeployment, isList, ol
 	// Add machineTemplateHash label to selector.
 	newISSelector := labelsutil.CloneSelectorAndAddLabel(d.Spec.Selector, v1alpha1.DefaultMachineDeploymentUniqueLabelKey, machineTemplateSpecHash)
 
+	const encodedHashLimit = 5
+	encodedMachineTemplateSpecHash := rand.SafeEncodeString(machineTemplateSpecHash)
+	if len(encodedMachineTemplateSpecHash) > encodedHashLimit {
+		encodedMachineTemplateSpecHash = encodedMachineTemplateSpecHash[:encodedHashLimit]
+	}
+
 	// Create new ReplicaSet
 	newIS := v1alpha1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
 			// Make the name deterministic, to ensure idempotence
-			Name:            d.Name + "-" + rand.SafeEncodeString(machineTemplateSpecHash)[:5],
+			Name:            d.Name + "-" + encodedMachineTemplateSpecHash,
 			Namespace:       d.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(d, controllerKind)},
 			Labels:          newISTemplate.Labels,


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/gardener/machine-controller-manager/pull/500 introduces a change that takes only the first 5 elements of the encoded machine template hash. This actually panics when the endoded machine template hash length is less than 5:

```
E1125 13:35:08.062639       1 runtime.go:78] Observed a panic: runtime.boundsError{x:5, y:4, signed:true, code:0x1} (runtime error: slice bounds out of range [:5] with length 4)
goroutine 713 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x212ff20, 0xc0007ee480)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x212ff20, 0xc0007ee480)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).getNewMachineSet(0xc0000b9180, 0xc00165a000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, ...)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment_sync.go:308 +0x1b3a
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).getAllMachineSetsAndSyncRevision(0xc0000b9180, 0xc00165a000, 0x0, 0x0, 0x0, 0xc000ee1b90, 0xc0009a2201, 0x1, 0x1, 0x23d7240, ...)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment_sync.go:132 +0x202
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).rolloutRolling(0xc0000b9180, 0xc00165a000, 0x0, 0x0, 0x0, 0xc000ee1b90, 0x0, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment_rolling.go:54 +0x13e
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).reconcileClusterMachineDeployment(0xc0000b9180, 0xc0003536d0, 0x47, 0x0, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment.go:551 +0xc8b
github.com/gardener/machine-controller-manager/pkg/controller.worker.func1.1(0x26c3d80, 0xc000608bc0, 0xc000f1aeb0, 0x1, 0xf, 0x232dfa3, 0x18, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:567 +0xff
github.com/gardener/machine-controller-manager/pkg/controller.worker.func1()
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:584 +0x8a
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000144180)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000144180, 0x3b9aca00, 0x0, 0x1, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
github.com/gardener/machine-controller-manager/pkg/controller.createWorker.func1(0x26c3d80, 0xc000608bc0, 0x232dfa3, 0x18, 0xf, 0x1, 0xc000f1aeb0, 0x0, 0xc0004c4040)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:546 +0x9f
created by github.com/gardener/machine-controller-manager/pkg/controller.createWorker
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:545 +0xbe
panic: runtime error: slice bounds out of range [:5] with length 4 [recovered]
	panic: runtime error: slice bounds out of range [:5] with length 4

goroutine 713 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x105
panic(0x212ff20, 0xc0007ee480)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).getNewMachineSet(0xc0000b9180, 0xc00165a000, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, ...)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment_sync.go:308 +0x1b3a
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).getAllMachineSetsAndSyncRevision(0xc0000b9180, 0xc00165a000, 0x0, 0x0, 0x0, 0xc000ee1b90, 0xc0009a2201, 0x1, 0x1, 0x23d7240, ...)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment_sync.go:132 +0x202
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).rolloutRolling(0xc0000b9180, 0xc00165a000, 0x0, 0x0, 0x0, 0xc000ee1b90, 0x0, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment_rolling.go:54 +0x13e
github.com/gardener/machine-controller-manager/pkg/controller.(*controller).reconcileClusterMachineDeployment(0xc0000b9180, 0xc0003536d0, 0x47, 0x0, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/deployment.go:551 +0xc8b
github.com/gardener/machine-controller-manager/pkg/controller.worker.func1.1(0x26c3d80, 0xc000608bc0, 0xc000f1aeb0, 0x1, 0xf, 0x232dfa3, 0x18, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:567 +0xff
github.com/gardener/machine-controller-manager/pkg/controller.worker.func1()
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:584 +0x8a
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000144180)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000144180, 0x3b9aca00, 0x0, 0x1, 0x0)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/gardener/machine-controller-manager/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88
github.com/gardener/machine-controller-manager/pkg/controller.createWorker.func1(0x26c3d80, 0xc000608bc0, 0x232dfa3, 0x18, 0xf, 0x1, 0xc000f1aeb0, 0x0, 0xc0004c4040)
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:546 +0x9f
created by github.com/gardener/machine-controller-manager/pkg/controller.createWorker
	/go/src/github.com/gardener/machine-controller-manager/pkg/controller/controller.go:545 +0xbe
```

For example the following machine template spec returns hash with length 4:

```yaml
    template:
      metadata:
        creationTimestamp: null
        labels:
          name: shoot--hc-dev--i322204-haas-connectivity-z1
      spec:
        class:
          kind: AWSMachineClass
          name: shoot--hc-dev--i322204-haas-connectivity-z1-72f2f
        nodeTemplate:
          metadata:
            creationTimestamp: null
            labels:
              hana-cloud.workload-class/connectivity: "1"
              node-role.kubernetes.io/connectivity: ""
              node.kubernetes.io/role: node
              worker.garden.sapcloud.io/group: connectivity
              worker.gardener.cloud/pool: connectivity
          spec: {}
```

I bult a simple main that computes the hash for the above machine template using the same logic in machine-controller-manager. For the above input, the result is:

```
$ go run -mod=vendor main.go
7bd9
```

Which leads to the above panic.

/kind bug

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
An issue causing panic when the encoded machine template hash length is less than expect limit is now fixed.
```
