### PR TITLE
Cherrypick PR#575 into MCM rel-v0.35 

### DIFF
--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -301,11 +301,17 @@ func (dc *controller) getNewMachineSet(d *v1alpha1.MachineDeployment, isList, ol
 	// Add machineTemplateHash label to selector.
 	newISSelector := labelsutil.CloneSelectorAndAddLabel(d.Spec.Selector, v1alpha1.DefaultMachineDeploymentUniqueLabelKey, machineTemplateSpecHash)
 
+	const encodedHashLimit = 5
+	encodedMachineTemplateSpecHash := rand.SafeEncodeString(machineTemplateSpecHash)
+	if len(encodedMachineTemplateSpecHash) > encodedHashLimit {
+		encodedMachineTemplateSpecHash = encodedMachineTemplateSpecHash[:encodedHashLimit]
+	}
+
 	// Create new ReplicaSet
 	newIS := v1alpha1.MachineSet{
 		ObjectMeta: metav1.ObjectMeta{
 			// Make the name deterministic, to ensure idempotence
-			Name:            d.Name + "-" + rand.SafeEncodeString(machineTemplateSpecHash)[:5],
+			Name:            d.Name + "-" + encodedMachineTemplateSpecHash,
 			Namespace:       d.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(d, controllerKind)},
 			Labels:          newISTemplate.Labels,


### PR DESCRIPTION
Signed-off-by: ialidzhikov <i.alidjikov@gmail.com>

**What this PR does / why we need it**:
#500 introduces a change that takes only the first 5 elements of the encoded machine template hash. This actually panics when the endoded machine template hash length is less than 5

**Which issue(s) this PR fixes**:
Fixes #461 
Hotfix for a bug introduced by #500 

**Special notes for your reviewer**:

**Release note**:
```improvement operator
None
```
