### PR TITLE
Support optional secret containing only credentials but no user-data; accept Gardener secret data keys

### DIFF
--- a/cmd/machine-controller-manager-cli/main.go
+++ b/cmd/machine-controller-manager-cli/main.go
@@ -99,7 +99,7 @@ func main() {
 		log.Fatalf("Could not parse machine class yaml: %s", err)
 	}
 
-	driver := driver.NewDriver(machineID, &secret, classKind, machineclass, machineName)
+	driver := driver.NewDriver(machineID, secret.Data, classKind, machineclass, machineName)
 
 	if machineID == "" {
 		id, name, err := driver.Create()

--- a/kubernetes/Secrets/alicloud-secret.yaml
+++ b/kubernetes/Secrets/alicloud-secret.yaml
@@ -9,4 +9,7 @@ data:
   userData: "encoded-cloud-config" # Alicloud cloud config file (base64 encoded)
   alicloudAccessKeyID: "alicloud-access-key-id" # Alicloud access key ID (base64 encoded)
   alicloudAccessKeySecret: "alicloud-access-key-secret" # Alicloud secret access key (base64 encoded)
+### Alternative data keys are:
+# accessKeyID: "alicloud-access-key-id" # Alicloud access key ID (base64 encoded)
+# accessKeySecret: "alicloud-access-key-secret" # Alicloud secret access key (base64 encoded)
 type: Opaque

--- a/kubernetes/Secrets/aws-secret.yaml
+++ b/kubernetes/Secrets/aws-secret.yaml
@@ -9,4 +9,7 @@ data:
   userData: "encoded-cloud-config" # AWS cloud config file (base64 encoded)
   providerAccessKeyId: "pqrstu67890" # AWS access key id (base64 encoded)
   providerSecretAccessKey: "abcdef123456" # AWS secret access key (base64 encoded)
+### Alternative data keys are:
+# accessKeyId: "pqrstu67890" # AWS access key id (base64 encoded)
+# secretAccessKey: "abcdef123456" # AWS secret access key (base64 encoded)
 type: Opaque

--- a/kubernetes/Secrets/azure-secret.yaml
+++ b/kubernetes/Secrets/azure-secret.yaml
@@ -11,4 +11,9 @@ data:
   azureClientSecret: "azure-client-secret" # Azure client secret (base64 encoded)
   azureSubscriptionId: "azure-subscription-id" # Azure subscription id (base64 encoded)
   azureTenantId: "azure-tenant-id" # Azure tenant id (base64 encoded)
+### Alternative data keys are:
+# clientID: "azure-client-id" # Azure client id (base64 encoded)
+# clientSecret: "azure-client-secret" # Azure client secret (base64 encoded)
+# subscriptionID: "azure-subscription-id" # Azure subscription id (base64 encoded)
+# tenantID: "azure-tenant-id" # Azure tenant id (base64 encoded)
 type: Opaque

--- a/kubernetes/Secrets/gcp-secret.yaml
+++ b/kubernetes/Secrets/gcp-secret.yaml
@@ -8,4 +8,6 @@ metadata:
 data:
   userData: "encoded-cloud-config" # GCP cloud config file (base64 encoded)
   serviceAccountJSON: "{...}" # GCP service account json object (base64 encoded)
+### Alternative data keys are:
+# serviceaccount.json: "{...}" # GCP service account json object (base64 encoded)
 type: Opaque

--- a/kubernetes/crds/machine.sapcloud.io_alicloudmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_alicloudmachineclasses.yaml
@@ -51,6 +51,19 @@ spec:
           properties:
             IoOptimized:
               type: string
+            credentialsSecretRef:
+              description: SecretReference represents a Secret Reference. It has enough
+                information to retrieve secret in any namespace
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             dataDisks:
               items:
                 properties:

--- a/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
@@ -135,6 +135,19 @@ spec:
                     type: string
                 type: object
               type: array
+            credentialsSecretRef:
+              description: SecretReference represents a Secret Reference. It has enough
+                information to retrieve secret in any namespace
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             ebsOptimized:
               type: boolean
             iam:

--- a/kubernetes/crds/machine.sapcloud.io_azuremachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_azuremachineclasses.yaml
@@ -49,6 +49,19 @@ spec:
         spec:
           description: AzureMachineClassSpec is the specification of a AzureMachineClass.
           properties:
+            credentialsSecretRef:
+              description: SecretReference represents a Secret Reference. It has enough
+                information to retrieve secret in any namespace
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             location:
               type: string
             properties:

--- a/kubernetes/crds/machine.sapcloud.io_gcpmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_gcpmachineclasses.yaml
@@ -51,6 +51,19 @@ spec:
           properties:
             canIpForward:
               type: boolean
+            credentialsSecretRef:
+              description: SecretReference represents a Secret Reference. It has enough
+                information to retrieve secret in any namespace
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             deletionProtection:
               type: boolean
             description:

--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -25,6 +25,21 @@ spec:
             of an object. Servers should convert recognized schemas to the latest
             internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
+        credentialsSecretRef:
+          description: CredentialsSecretRef can optionally store the credentials (in
+            this case the SecretRef does not need to store them). This might be useful
+            if multiple machine classes with the same credentials but different user-datas
+            are used.
+          properties:
+            name:
+              description: Name is unique within a namespace to reference a secret
+                resource.
+              type: string
+            namespace:
+              description: Namespace defines the space within which the secret name
+                must be unique.
+              type: string
+          type: object
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
@@ -40,8 +55,8 @@ spec:
           description: Provider-specific configuration to use during node creation.
           type: object
         secretRef:
-          description: SecretRef stores the necessary secrets such as credetials or
-            userdata.
+          description: SecretRef stores the necessary secrets such as credentials
+            or userdata.
           properties:
             name:
               description: Name is unique within a namespace to reference a secret

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -59,6 +59,9 @@ spec:
             object represents. Servers may infer this from the endpoint the client
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
+        metadata:
+          description: Standard object metadata.
+          type: object
         spec:
           description: Specification of the desired behavior of the MachineDeployment.
           properties:

--- a/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
@@ -54,6 +54,19 @@ spec:
           properties:
             availabilityZone:
               type: string
+            credentialsSecretRef:
+              description: SecretReference represents a Secret Reference. It has enough
+                information to retrieve secret in any namespace
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             flavorName:
               type: string
             imageID:

--- a/kubernetes/crds/machine.sapcloud.io_packetmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_packetmachineclasses.yaml
@@ -46,6 +46,19 @@ spec:
               type: string
             billingCycle:
               type: string
+            credentialsSecretRef:
+              description: SecretReference represents a Secret Reference. It has enough
+                information to retrieve secret in any namespace
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             facility:
               items:
                 type: string

--- a/kubernetes/machine_classes/alicloud-machine-class.yaml
+++ b/kubernetes/machine_classes/alicloud-machine-class.yaml
@@ -42,3 +42,6 @@ spec:
   secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
     namespace: default  # Namespace
     name: test-secret # Name of the secret
+# credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
+#   name: "test-secret-credentials" # Name of the secret
+#   namespace: "default" # Namespace of secret

--- a/kubernetes/machine_classes/aws-machine-class.yaml
+++ b/kubernetes/machine_classes/aws-machine-class.yaml
@@ -24,6 +24,9 @@ spec:
   secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
     namespace: default  # Namespace
     name: test-secret # Name of the secret
+# credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
+#   name: "test-secret-credentials" # Name of the secret
+#   namespace: "default" # Namespace of secret
   blockDevices:
     - deviceName: /root
       ebs:

--- a/kubernetes/machine_classes/azure-machine-class.yaml
+++ b/kubernetes/machine_classes/azure-machine-class.yaml
@@ -14,6 +14,9 @@ spec:
   secretRef: # Kubernetes secret containing values for provider secrets and user-data
     name: "test-secret" # Name of the secret
     namespace: "default" # Namespace of secret
+# credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
+#   name: "test-secret-credentials" # Name of the secret
+#   namespace: "default" # Namespace of secret
   tags:
     kubernetes.io-cluster-YOUR_CLUSTER_NAME: "1" # This is mandatory as the safety controller uses this tag to identify VMs created by this controller.
     kubernetes.io-role-YOUR_ROLE_NAME: "1" # This is mandatory as the safety controller uses this tag to identify VMs created by this controller.

--- a/kubernetes/machine_classes/gcp-machine-class.yaml
+++ b/kubernetes/machine_classes/gcp-machine-class.yaml
@@ -41,6 +41,9 @@ spec:
   secretRef: # Kubernetes secret containing values for provider secrets and user-data
     name: "test-secret" # Name of the secret
     namespace: "default" # Namespace of secret
+# credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
+#   name: "test-secret-credentials" # Name of the secret
+#   namespace: "default" # Namespace of secret
   serviceAccounts:
   - email: default@project.iam.gserviceaccount.com # Service account email
     scopes: # List of scopes

--- a/kubernetes/machine_classes/openstack-machine-class.yaml
+++ b/kubernetes/machine_classes/openstack-machine-class.yaml
@@ -28,3 +28,6 @@ spec:
   secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
     namespace: default  # Namespace
     name: test-secret # Name of the secret
+# credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
+#   name: "test-secret-credentials" # Name of the secret
+#   namespace: "default" # Namespace of secret

--- a/kubernetes/machine_classes/packet-machine-class.yaml
+++ b/kubernetes/machine_classes/packet-machine-class.yaml
@@ -21,3 +21,6 @@ spec:
   secretRef: # Secret pointing to a secret which contains the provider secret and cloudconfig
     namespace: default  # Namespace
     name: test-secret # Name of the secret
+# credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
+#   name: "test-secret-credentials" # Name of the secret
+#   namespace: "default" # Namespace of secret

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -649,22 +649,23 @@ type OpenStackMachineClassList struct {
 
 // OpenStackMachineClassSpec is the specification of a OpenStackMachineClass.
 type OpenStackMachineClassSpec struct {
-	ImageID          string
-	ImageName        string
-	Region           string
-	AvailabilityZone string
-	FlavorName       string
-	KeyName          string
-	SecurityGroups   []string
-	Tags             map[string]string
-	NetworkID        string
-	Networks         []OpenStackNetwork
-	SubnetID         *string
-	SecretRef        *corev1.SecretReference
-	PodNetworkCidr   string
-	RootDiskSize     int // in GB
-	UseConfigDrive   *bool
-	ServerGroupID    *string
+	ImageID              string
+	ImageName            string
+	Region               string
+	AvailabilityZone     string
+	FlavorName           string
+	KeyName              string
+	SecurityGroups       []string
+	Tags                 map[string]string
+	NetworkID            string
+	Networks             []OpenStackNetwork
+	SubnetID             *string
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
+	PodNetworkCidr       string
+	RootDiskSize         int // in GB
+	UseConfigDrive       *bool
+	ServerGroupID        *string
 }
 
 type OpenStackNetwork struct {
@@ -700,18 +701,19 @@ type AWSMachineClassList struct {
 
 // AWSMachineClassSpec is the specification of a AWSMachineClass.
 type AWSMachineClassSpec struct {
-	AMI               string
-	Region            string
-	BlockDevices      []AWSBlockDeviceMappingSpec
-	EbsOptimized      bool
-	IAM               AWSIAMProfileSpec
-	MachineType       string
-	KeyName           string
-	Monitoring        bool
-	NetworkInterfaces []AWSNetworkInterfaceSpec
-	Tags              map[string]string
-	SpotPrice         *string
-	SecretRef         *corev1.SecretReference
+	AMI                  string
+	Region               string
+	BlockDevices         []AWSBlockDeviceMappingSpec
+	EbsOptimized         bool
+	IAM                  AWSIAMProfileSpec
+	MachineType          string
+	KeyName              string
+	Monitoring           bool
+	NetworkInterfaces    []AWSNetworkInterfaceSpec
+	Tags                 map[string]string
+	SpotPrice            *string
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
 
 	// TODO add more here
 }
@@ -863,12 +865,13 @@ type AzureMachineClassList struct {
 
 // AzureMachineClassSpec is the specification of a AzureMachineClass.
 type AzureMachineClassSpec struct {
-	Location      string
-	Tags          map[string]string
-	Properties    AzureVirtualMachineProperties
-	ResourceGroup string
-	SubnetInfo    AzureSubnetInfo
-	SecretRef     *corev1.SecretReference
+	Location             string
+	Tags                 map[string]string
+	Properties           AzureVirtualMachineProperties
+	ResourceGroup        string
+	SubnetInfo           AzureSubnetInfo
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
 }
 
 // AzureVirtualMachineProperties is describes the properties of a Virtual Machine.
@@ -1029,20 +1032,21 @@ type GCPMachineClassList struct {
 
 // GCPMachineClassSpec is the specification of a GCPMachineClass.
 type GCPMachineClassSpec struct {
-	CanIpForward       bool
-	DeletionProtection bool
-	Description        *string
-	Disks              []*GCPDisk
-	Labels             map[string]string
-	MachineType        string
-	Metadata           []*GCPMetadata
-	NetworkInterfaces  []*GCPNetworkInterface
-	Scheduling         GCPScheduling
-	SecretRef          *corev1.SecretReference
-	ServiceAccounts    []GCPServiceAccount
-	Tags               []string
-	Region             string
-	Zone               string
+	CanIpForward         bool
+	DeletionProtection   bool
+	Description          *string
+	Disks                []*GCPDisk
+	Labels               map[string]string
+	MachineType          string
+	Metadata             []*GCPMetadata
+	NetworkInterfaces    []*GCPNetworkInterface
+	Scheduling           GCPScheduling
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
+	ServiceAccounts      []GCPServiceAccount
+	Tags                 []string
+	Region               string
+	Zone                 string
 }
 
 // GCPDisk describes disks for GCP.
@@ -1127,6 +1131,7 @@ type AlicloudMachineClassSpec struct {
 	Tags                    map[string]string
 	KeyPairName             string
 	SecretRef               *corev1.SecretReference
+	CredentialsSecretRef    *corev1.SecretReference
 }
 
 // AlicloudSystemDisk describes SystemDisk for Alicloud.
@@ -1181,7 +1186,8 @@ type PacketMachineClassSpec struct {
 	SSHKeys      []string
 	UserData     string
 
-	SecretRef *corev1.SecretReference
+	SecretRef            *corev1.SecretReference
+	CredentialsSecretRef *corev1.SecretReference
 
 	// TODO add more here
 }

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -1206,8 +1206,11 @@ type MachineClass struct {
 	metav1.ObjectMeta
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension
-	// SecretRef stores the necessary secrets such as credetials or userdata.
+	// SecretRef stores the necessary secrets such as credentials or userdata.
 	SecretRef *corev1.SecretReference
+	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
+	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
+	CredentialsSecretRef *corev1.SecretReference
 	// Provider is the combination of name and location of cloud-specific drivers.
 	// eg. awsdriver//127.0.0.1:8080
 	Provider string

--- a/pkg/apis/machine/v1alpha1/alicoud_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/alicoud_machineclass_types.go
@@ -84,6 +84,7 @@ type AlicloudMachineClassSpec struct {
 	Tags                    map[string]string       `json:"tags,omitempty"`
 	KeyPairName             string                  `json:"keyPairName"`
 	SecretRef               *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef    *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
 }
 
 type AlicloudDataDisk struct {

--- a/pkg/apis/machine/v1alpha1/alicoud_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/alicoud_machineclass_types.go
@@ -28,6 +28,13 @@ const (
 	AlicloudAccessKeyID string = "alicloudAccessKeyID"
 	// AlicloudAccessKeySecret is a constant for a key name that is part of the Alibaba cloud credentials.
 	AlicloudAccessKeySecret string = "alicloudAccessKeySecret"
+
+	// AlicloudAlternativeAccessKeyID is a constant for a key name of a secret containing the Alibaba cloud
+	// credentials (access key id).
+	AlicloudAlternativeAccessKeyID = "accessKeyID"
+	// AlicloudAlternativeAccessKeySecret is a constant for a key name of a secret containing the Alibaba cloud
+	// credentials (access key secret).
+	AlicloudAlternativeAccessKeySecret = "accessKeySecret"
 )
 
 // +genclient

--- a/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
@@ -67,18 +67,19 @@ type AWSMachineClassList struct {
 
 // AWSMachineClassSpec is the specification of a AWSMachineClass.
 type AWSMachineClassSpec struct {
-	AMI               string                      `json:"ami,omitempty"`
-	Region            string                      `json:"region,omitempty"`
-	BlockDevices      []AWSBlockDeviceMappingSpec `json:"blockDevices,omitempty"`
-	EbsOptimized      bool                        `json:"ebsOptimized,omitempty"`
-	IAM               AWSIAMProfileSpec           `json:"iam,omitempty"`
-	MachineType       string                      `json:"machineType,omitempty"`
-	KeyName           string                      `json:"keyName,omitempty"`
-	Monitoring        bool                        `json:"monitoring,omitempty"`
-	NetworkInterfaces []AWSNetworkInterfaceSpec   `json:"networkInterfaces,omitempty"`
-	Tags              map[string]string           `json:"tags,omitempty"`
-	SpotPrice         *string                     `json:"spotPrice,omitempty"`
-	SecretRef         *corev1.SecretReference     `json:"secretRef,omitempty"`
+	AMI                  string                      `json:"ami,omitempty"`
+	Region               string                      `json:"region,omitempty"`
+	BlockDevices         []AWSBlockDeviceMappingSpec `json:"blockDevices,omitempty"`
+	EbsOptimized         bool                        `json:"ebsOptimized,omitempty"`
+	IAM                  AWSIAMProfileSpec           `json:"iam,omitempty"`
+	MachineType          string                      `json:"machineType,omitempty"`
+	KeyName              string                      `json:"keyName,omitempty"`
+	Monitoring           bool                        `json:"monitoring,omitempty"`
+	NetworkInterfaces    []AWSNetworkInterfaceSpec   `json:"networkInterfaces,omitempty"`
+	Tags                 map[string]string           `json:"tags,omitempty"`
+	SpotPrice            *string                     `json:"spotPrice,omitempty"`
+	SecretRef            *corev1.SecretReference     `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference     `json:"credentialsSecretRef,omitempty"`
 
 	// TODO add more here
 }

--- a/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
@@ -28,6 +28,13 @@ const (
 	AWSAccessKeyID string = "providerAccessKeyId"
 	// AWSSecretAccessKey is a constant for a key name that is part of the AWS cloud credentials.
 	AWSSecretAccessKey string = "providerSecretAccessKey"
+
+	// AWSAlternativeAccessKeyID is a constant for a key name of a secret containing the AWS credentials (access key
+	// id).
+	AWSAlternativeAccessKeyID = "accessKeyID"
+	// AWSAlternativeAccessKeySecret is a constant for a key name of a secret containing the AWS credentials (access key
+	// secret).
+	AWSAlternativeSecretAccessKey = "secretAccessKey"
 )
 
 // +genclient

--- a/pkg/apis/machine/v1alpha1/azure_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/azure_machineclass_types.go
@@ -70,12 +70,13 @@ type AzureMachineClassList struct {
 
 // AzureMachineClassSpec is the specification of a AzureMachineClass.
 type AzureMachineClassSpec struct {
-	Location      string                        `json:"location,omitempty"`
-	Tags          map[string]string             `json:"tags,omitempty"`
-	Properties    AzureVirtualMachineProperties `json:"properties,omitempty"`
-	ResourceGroup string                        `json:"resourceGroup,omitempty"`
-	SubnetInfo    AzureSubnetInfo               `json:"subnetInfo,omitempty"`
-	SecretRef     *corev1.SecretReference       `json:"secretRef,omitempty"`
+	Location             string                        `json:"location,omitempty"`
+	Tags                 map[string]string             `json:"tags,omitempty"`
+	Properties           AzureVirtualMachineProperties `json:"properties,omitempty"`
+	ResourceGroup        string                        `json:"resourceGroup,omitempty"`
+	SubnetInfo           AzureSubnetInfo               `json:"subnetInfo,omitempty"`
+	SecretRef            *corev1.SecretReference       `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference       `json:"credentialsSecretRef,omitempty"`
 }
 
 // AzureVirtualMachineProperties is describes the properties of a Virtual Machine.

--- a/pkg/apis/machine/v1alpha1/azure_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/azure_machineclass_types.go
@@ -32,6 +32,17 @@ const (
 	AzureSubscriptionID string = "azureSubscriptionId"
 	// AzureTenantID is a constant for a key name that is part of the Azure cloud credentials.
 	AzureTenantID string = "azureTenantId"
+
+	// AzureAlternativeClientID is a constant for a key name of a secret containing the Azure credentials (client id).
+	AzureAlternativeClientID = "clientID"
+	// AzureAlternativeClientSecret is a constant for a key name of a secret containing the Azure credentials (client
+	// secret).
+	AzureAlternativeClientSecret = "clientSecret"
+	// AzureAlternativeSubscriptionID is a constant for a key name of a secret containing the Azure credentials
+	// (subscription id).
+	AzureAlternativeSubscriptionID = "subscriptionID"
+	// AzureAlternativeTenantID is a constant for a key name of a secret containing the Azure credentials (tenant id).
+	AzureAlternativeTenantID = "tenantID"
 )
 
 // +genclient

--- a/pkg/apis/machine/v1alpha1/gcp_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/gcp_machineclass_types.go
@@ -26,6 +26,10 @@ import (
 const (
 	// GCPServiceAccountJSON is a constant for a key name that is part of the GCP cloud credentials.
 	GCPServiceAccountJSON string = "serviceAccountJSON"
+
+	// GCPAlternativeServiceAccountJSON is a constant for a key name of a secret containing the GCP credentials (service
+	// account json).
+	GCPAlternativeServiceAccountJSON = "serviceaccount.json"
 )
 
 // +genclient

--- a/pkg/apis/machine/v1alpha1/gcp_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/gcp_machineclass_types.go
@@ -64,20 +64,21 @@ type GCPMachineClassList struct {
 
 // GCPMachineClassSpec is the specification of a GCPMachineClass.
 type GCPMachineClassSpec struct {
-	CanIpForward       bool                    `json:"canIpForward"`
-	DeletionProtection bool                    `json:"deletionProtection"`
-	Description        *string                 `json:"description,omitempty"`
-	Disks              []*GCPDisk              `json:"disks,omitempty"`
-	Labels             map[string]string       `json:"labels,omitempty"`
-	MachineType        string                  `json:"machineType"`
-	Metadata           []*GCPMetadata          `json:"metadata,omitempty"`
-	NetworkInterfaces  []*GCPNetworkInterface  `json:"networkInterfaces,omitempty"`
-	Scheduling         GCPScheduling           `json:"scheduling"`
-	SecretRef          *corev1.SecretReference `json:"secretRef,omitempty"`
-	ServiceAccounts    []GCPServiceAccount     `json:"serviceAccounts"`
-	Tags               []string                `json:"tags,omitempty"`
-	Region             string                  `json:"region"`
-	Zone               string                  `json:"zone"`
+	CanIpForward         bool                    `json:"canIpForward"`
+	DeletionProtection   bool                    `json:"deletionProtection"`
+	Description          *string                 `json:"description,omitempty"`
+	Disks                []*GCPDisk              `json:"disks,omitempty"`
+	Labels               map[string]string       `json:"labels,omitempty"`
+	MachineType          string                  `json:"machineType"`
+	Metadata             []*GCPMetadata          `json:"metadata,omitempty"`
+	NetworkInterfaces    []*GCPNetworkInterface  `json:"networkInterfaces,omitempty"`
+	Scheduling           GCPScheduling           `json:"scheduling"`
+	SecretRef            *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
+	ServiceAccounts      []GCPServiceAccount     `json:"serviceAccounts"`
+	Tags                 []string                `json:"tags,omitempty"`
+	Region               string                  `json:"region"`
+	Zone                 string                  `json:"zone"`
 }
 
 // GCPDisk describes disks for GCP.

--- a/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -39,8 +39,11 @@ type MachineClass struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension `json:"providerSpec"`
-	// SecretRef stores the necessary secrets such as credetials or userdata.
+	// SecretRef stores the necessary secrets such as credentials or userdata.
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
+	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
+	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
 	// Provider is the combination of name and location of cloud-specific drivers.
 	Provider string `json:"provider,omitempty"`
 }

--- a/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/openstack_machineclass_types.go
@@ -88,22 +88,23 @@ type OpenStackMachineClassList struct {
 
 // OpenStackMachineClassSpec is the specification of a OpenStackMachineClass.
 type OpenStackMachineClassSpec struct {
-	ImageID          string                  `json:"imageID"`
-	ImageName        string                  `json:"imageName"`
-	Region           string                  `json:"region"`
-	AvailabilityZone string                  `json:"availabilityZone"`
-	FlavorName       string                  `json:"flavorName"`
-	KeyName          string                  `json:"keyName"`
-	SecurityGroups   []string                `json:"securityGroups"`
-	Tags             map[string]string       `json:"tags,omitempty"`
-	NetworkID        string                  `json:"networkID"`
-	Networks         []OpenStackNetwork      `json:"networks,omitempty"`
-	SubnetID         *string                 `json:"subnetID,omitempty"`
-	SecretRef        *corev1.SecretReference `json:"secretRef,omitempty"`
-	PodNetworkCidr   string                  `json:"podNetworkCidr"`
-	RootDiskSize     int                     `json:"rootDiskSize,omitempty"` // in GB
-	UseConfigDrive   *bool                   `json:"useConfigDrive,omitempty"`
-	ServerGroupID    *string                 `json:"serverGroupID,omitempty"`
+	ImageID              string                  `json:"imageID"`
+	ImageName            string                  `json:"imageName"`
+	Region               string                  `json:"region"`
+	AvailabilityZone     string                  `json:"availabilityZone"`
+	FlavorName           string                  `json:"flavorName"`
+	KeyName              string                  `json:"keyName"`
+	SecurityGroups       []string                `json:"securityGroups"`
+	Tags                 map[string]string       `json:"tags,omitempty"`
+	NetworkID            string                  `json:"networkID"`
+	Networks             []OpenStackNetwork      `json:"networks,omitempty"`
+	SubnetID             *string                 `json:"subnetID,omitempty"`
+	SecretRef            *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
+	PodNetworkCidr       string                  `json:"podNetworkCidr"`
+	RootDiskSize         int                     `json:"rootDiskSize,omitempty"` // in GB
+	UseConfigDrive       *bool                   `json:"useConfigDrive,omitempty"`
+	ServerGroupID        *string                 `json:"serverGroupID,omitempty"`
 }
 
 type OpenStackNetwork struct {

--- a/pkg/apis/machine/v1alpha1/packet_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/packet_machineclass_types.go
@@ -71,5 +71,6 @@ type PacketMachineClassSpec struct {
 	SSHKeys      []string `json:"sshKeys,omitempty"`
 	UserData     string   `json:"userdata,omitempty"`
 
-	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
+	SecretRef            *corev1.SecretReference `json:"secretRef,omitempty"`
+	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
 }

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -2041,6 +2041,7 @@ func autoConvert_v1alpha1_MachineClass_To_machine_MachineClass(in *MachineClass,
 	out.ObjectMeta = in.ObjectMeta
 	out.ProviderSpec = in.ProviderSpec
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.Provider = in.Provider
 	return nil
 }
@@ -2054,6 +2055,7 @@ func autoConvert_machine_MachineClass_To_v1alpha1_MachineClass(in *machine.Machi
 	out.ObjectMeta = in.ObjectMeta
 	out.ProviderSpec = in.ProviderSpec
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.Provider = in.Provider
 	return nil
 }

--- a/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.conversion.go
@@ -918,6 +918,7 @@ func autoConvert_v1alpha1_AWSMachineClassSpec_To_machine_AWSMachineClassSpec(in 
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.SpotPrice = (*string)(unsafe.Pointer(in.SpotPrice))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -941,6 +942,7 @@ func autoConvert_machine_AWSMachineClassSpec_To_v1alpha1_AWSMachineClassSpec(in 
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.SpotPrice = (*string)(unsafe.Pointer(in.SpotPrice))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1104,6 +1106,7 @@ func autoConvert_v1alpha1_AlicloudMachineClassSpec_To_machine_AlicloudMachineCla
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.KeyPairName = in.KeyPairName
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1141,6 +1144,7 @@ func autoConvert_machine_AlicloudMachineClassSpec_To_v1alpha1_AlicloudMachineCla
 	out.Tags = *(*map[string]string)(unsafe.Pointer(&in.Tags))
 	out.KeyPairName = in.KeyPairName
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1326,6 +1330,7 @@ func autoConvert_v1alpha1_AzureMachineClassSpec_To_machine_AzureMachineClassSpec
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1345,6 +1350,7 @@ func autoConvert_machine_AzureMachineClassSpec_To_v1alpha1_AzureMachineClassSpec
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -1842,6 +1848,7 @@ func autoConvert_v1alpha1_GCPMachineClassSpec_To_machine_GCPMachineClassSpec(in 
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.ServiceAccounts = *(*[]machine.GCPServiceAccount)(unsafe.Pointer(&in.ServiceAccounts))
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Region = in.Region
@@ -1867,6 +1874,7 @@ func autoConvert_machine_GCPMachineClassSpec_To_v1alpha1_GCPMachineClassSpec(in 
 		return err
 	}
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.ServiceAccounts = *(*[]GCPServiceAccount)(unsafe.Pointer(&in.ServiceAccounts))
 	out.Tags = *(*[]string)(unsafe.Pointer(&in.Tags))
 	out.Region = in.Region
@@ -2678,6 +2686,7 @@ func autoConvert_v1alpha1_OpenStackMachineClassSpec_To_machine_OpenStackMachineC
 	out.Networks = *(*[]machine.OpenStackNetwork)(unsafe.Pointer(&in.Networks))
 	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
@@ -2703,6 +2712,7 @@ func autoConvert_machine_OpenStackMachineClassSpec_To_v1alpha1_OpenStackMachineC
 	out.Networks = *(*[]OpenStackNetwork)(unsafe.Pointer(&in.Networks))
 	out.SubnetID = (*string)(unsafe.Pointer(in.SubnetID))
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	out.PodNetworkCidr = in.PodNetworkCidr
 	out.RootDiskSize = in.RootDiskSize
 	out.UseConfigDrive = (*bool)(unsafe.Pointer(in.UseConfigDrive))
@@ -2797,6 +2807,7 @@ func autoConvert_v1alpha1_PacketMachineClassSpec_To_machine_PacketMachineClassSp
 	out.SSHKeys = *(*[]string)(unsafe.Pointer(&in.SSHKeys))
 	out.UserData = in.UserData
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 
@@ -2815,6 +2826,7 @@ func autoConvert_machine_PacketMachineClassSpec_To_v1alpha1_PacketMachineClassSp
 	out.SSHKeys = *(*[]string)(unsafe.Pointer(&in.SSHKeys))
 	out.UserData = in.UserData
 	out.SecretRef = (*v1.SecretReference)(unsafe.Pointer(in.SecretRef))
+	out.CredentialsSecretRef = (*v1.SecretReference)(unsafe.Pointer(in.CredentialsSecretRef))
 	return nil
 }
 

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *AWSMachineClassSpec) DeepCopyInto(out *AWSMachineClassSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	return
 }
 
@@ -350,6 +355,11 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -531,6 +541,11 @@ func (in *AzureMachineClassSpec) DeepCopyInto(out *AzureMachineClassSpec) {
 	in.SubnetInfo.DeepCopyInto(&out.SubnetInfo)
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -979,6 +994,11 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 	out.Scheduling = in.Scheduling
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -1769,6 +1789,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	if in.UseConfigDrive != nil {
 		in, out := &in.UseConfigDrive, &out.UseConfigDrive
 		*out = new(bool)
@@ -1888,6 +1913,11 @@ func (in *PacketMachineClassSpec) DeepCopyInto(out *PacketMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}

--- a/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1alpha1/zz_generated.deepcopy.go
@@ -1157,6 +1157,11 @@ func (in *MachineClass) DeepCopyInto(out *MachineClass) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -186,6 +186,11 @@ func (in *AWSMachineClassSpec) DeepCopyInto(out *AWSMachineClassSpec) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	return
 }
 
@@ -350,6 +355,11 @@ func (in *AlicloudMachineClassSpec) DeepCopyInto(out *AlicloudMachineClassSpec) 
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -531,6 +541,11 @@ func (in *AzureMachineClassSpec) DeepCopyInto(out *AzureMachineClassSpec) {
 	in.SubnetInfo.DeepCopyInto(&out.SubnetInfo)
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -979,6 +994,11 @@ func (in *GCPMachineClassSpec) DeepCopyInto(out *GCPMachineClassSpec) {
 	out.Scheduling = in.Scheduling
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
@@ -1862,6 +1882,11 @@ func (in *OpenStackMachineClassSpec) DeepCopyInto(out *OpenStackMachineClassSpec
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	if in.UseConfigDrive != nil {
 		in, out := &in.UseConfigDrive, &out.UseConfigDrive
 		*out = new(bool)
@@ -1981,6 +2006,11 @@ func (in *PacketMachineClassSpec) DeepCopyInto(out *PacketMachineClassSpec) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
 		*out = new(v1.SecretReference)
 		**out = **in
 	}

--- a/pkg/apis/machine/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/zz_generated.deepcopy.go
@@ -1157,6 +1157,11 @@ func (in *MachineClass) DeepCopyInto(out *MachineClass) {
 		*out = new(v1.SecretReference)
 		**out = **in
 	}
+	if in.CredentialsSecretRef != nil {
+		in, out := &in.CredentialsSecretRef, &out.CredentialsSecretRef
+		*out = new(v1.SecretReference)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -162,13 +162,13 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 	}
 
 	// Validate MachineClass
-	MachineClass, secretRef, err := c.validateMachineClass(&machine.Spec.Class)
-	if err != nil || secretRef == nil {
+	MachineClass, secretData, err := c.validateMachineClass(&machine.Spec.Class)
+	if err != nil || secretData == nil {
 		c.enqueueMachineAfter(machine, MachineEnqueueRetryPeriod)
 		return nil
 	}
 
-	driver := driver.NewDriver(machine.Spec.ProviderID, secretRef.Data, machine.Spec.Class.Kind, MachineClass, machine.Name)
+	driver := driver.NewDriver(machine.Spec.ProviderID, secretData, machine.Spec.Class.Kind, MachineClass, machine.Name)
 	actualProviderID, err := driver.GetExisting()
 	if err != nil {
 		return err

--- a/pkg/controller/machine.go
+++ b/pkg/controller/machine.go
@@ -168,7 +168,7 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) error {
 		return nil
 	}
 
-	driver := driver.NewDriver(machine.Spec.ProviderID, secretRef, machine.Spec.Class.Kind, MachineClass, machine.Name)
+	driver := driver.NewDriver(machine.Spec.ProviderID, secretRef.Data, machine.Spec.Class.Kind, MachineClass, machine.Name)
 	actualProviderID, err := driver.GetExisting()
 	if err != nil {
 		return err

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -536,7 +536,7 @@ func (c *controller) checkMachineClass(
 	// Dummy driver object being created to invoke GetVMs
 	dvr := driver.NewDriver(
 		"",
-		secret,
+		secret.Data,
 		classKind,
 		machineClass,
 		"",
@@ -626,7 +626,7 @@ func (c *controller) deleteOrphanVM(vm driver.VMs, secretRef *corev1.Secret, kin
 
 	dvr := driver.NewDriver(
 		machineID,
-		secretRef,
+		secretRef.Data,
 		kind,
 		machineClass,
 		machineName,

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -562,11 +562,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("non-existing secret", &data{
 				setup: setup{
-					secrets: []*corev1.Secret{
-						{
-							ObjectMeta: *newObjectMeta(objMeta, 0),
-						},
-					},
+					secrets: []*corev1.Secret{},
 					aws: []*machinev1.AWSMachineClass{
 						{
 							ObjectMeta: *newObjectMeta(objMeta, 0),

--- a/pkg/controller/secret_util.go
+++ b/pkg/controller/secret_util.go
@@ -76,7 +76,8 @@ func (c *controller) findOpenStackMachineClassForSecret(name string) ([]*v1alpha
 	}
 	var filtered []*v1alpha1.OpenStackMachineClass
 	for _, machineClass := range machineClasses {
-		if machineClass.Spec.SecretRef.Name == name {
+		if (machineClass.Spec.SecretRef != nil && machineClass.Spec.SecretRef.Name == name) ||
+			(machineClass.Spec.CredentialsSecretRef != nil && machineClass.Spec.CredentialsSecretRef.Name == name) {
 			filtered = append(filtered, machineClass)
 		}
 	}
@@ -92,7 +93,8 @@ func (c *controller) findGCPMachineClassForSecret(name string) ([]*v1alpha1.GCPM
 	}
 	var filtered []*v1alpha1.GCPMachineClass
 	for _, machineClass := range machineClasses {
-		if machineClass.Spec.SecretRef.Name == name {
+		if (machineClass.Spec.SecretRef != nil && machineClass.Spec.SecretRef.Name == name) ||
+			(machineClass.Spec.CredentialsSecretRef != nil && machineClass.Spec.CredentialsSecretRef.Name == name) {
 			filtered = append(filtered, machineClass)
 		}
 	}
@@ -108,7 +110,8 @@ func (c *controller) findAzureMachineClassForSecret(name string) ([]*v1alpha1.Az
 	}
 	var filtered []*v1alpha1.AzureMachineClass
 	for _, machineClass := range machineClasses {
-		if machineClass.Spec.SecretRef.Name == name {
+		if (machineClass.Spec.SecretRef != nil && machineClass.Spec.SecretRef.Name == name) ||
+			(machineClass.Spec.CredentialsSecretRef != nil && machineClass.Spec.CredentialsSecretRef.Name == name) {
 			filtered = append(filtered, machineClass)
 		}
 	}
@@ -124,7 +127,8 @@ func (c *controller) findAlicloudMachineClassForSecret(name string) ([]*v1alpha1
 	}
 	var filtered []*v1alpha1.AlicloudMachineClass
 	for _, machineClass := range machineClasses {
-		if machineClass.Spec.SecretRef.Name == name {
+		if (machineClass.Spec.SecretRef != nil && machineClass.Spec.SecretRef.Name == name) ||
+			(machineClass.Spec.CredentialsSecretRef != nil && machineClass.Spec.CredentialsSecretRef.Name == name) {
 			filtered = append(filtered, machineClass)
 		}
 	}
@@ -140,7 +144,8 @@ func (c *controller) findAWSMachineClassForSecret(name string) ([]*v1alpha1.AWSM
 	}
 	var filtered []*v1alpha1.AWSMachineClass
 	for _, machineClass := range machineClasses {
-		if machineClass.Spec.SecretRef.Name == name {
+		if (machineClass.Spec.SecretRef != nil && machineClass.Spec.SecretRef.Name == name) ||
+			(machineClass.Spec.CredentialsSecretRef != nil && machineClass.Spec.CredentialsSecretRef.Name == name) {
 			filtered = append(filtered, machineClass)
 		}
 	}
@@ -156,7 +161,8 @@ func (c *controller) findPacketMachineClassForSecret(name string) ([]*v1alpha1.P
 	}
 	var filtered []*v1alpha1.PacketMachineClass
 	for _, machineClass := range machineClasses {
-		if machineClass.Spec.SecretRef.Name == name {
+		if (machineClass.Spec.SecretRef != nil && machineClass.Spec.SecretRef.Name == name) ||
+			(machineClass.Spec.CredentialsSecretRef != nil && machineClass.Spec.CredentialsSecretRef.Name == name) {
 			filtered = append(filtered, machineClass)
 		}
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -39,14 +39,14 @@ type Driver interface {
 type VMs map[string]string
 
 // NewDriver creates a new driver object based on the classKind
-func NewDriver(machineID string, secretRef *corev1.Secret, classKind string, machineClass interface{}, machineName string) Driver {
+func NewDriver(machineID string, secretData map[string][]byte, classKind string, machineClass interface{}, machineName string) Driver {
 
 	switch classKind {
 	case "OpenStackMachineClass":
 		return &OpenStackDriver{
 			OpenStackMachineClass: machineClass.(*v1alpha1.OpenStackMachineClass),
-			CloudConfig:           secretRef,
-			UserData:              string(secretRef.Data["userData"]),
+			CredentialsData:       secretData,
+			UserData:              string(secretData["userData"]),
 			MachineID:             machineID,
 			MachineName:           machineName,
 		}
@@ -54,8 +54,8 @@ func NewDriver(machineID string, secretRef *corev1.Secret, classKind string, mac
 	case "AWSMachineClass":
 		return &AWSDriver{
 			AWSMachineClass: machineClass.(*v1alpha1.AWSMachineClass),
-			CloudConfig:     secretRef,
-			UserData:        string(secretRef.Data["userData"]),
+			CredentialsData: secretData,
+			UserData:        string(secretData["userData"]),
 			MachineID:       machineID,
 			MachineName:     machineName,
 		}
@@ -63,8 +63,8 @@ func NewDriver(machineID string, secretRef *corev1.Secret, classKind string, mac
 	case "AzureMachineClass":
 		return &AzureDriver{
 			AzureMachineClass: machineClass.(*v1alpha1.AzureMachineClass),
-			CloudConfig:       secretRef,
-			UserData:          string(secretRef.Data["userData"]),
+			CredentialsData:   secretData,
+			UserData:          string(secretData["userData"]),
 			MachineID:         machineID,
 			MachineName:       machineName,
 		}
@@ -72,8 +72,8 @@ func NewDriver(machineID string, secretRef *corev1.Secret, classKind string, mac
 	case "GCPMachineClass":
 		return &GCPDriver{
 			GCPMachineClass: machineClass.(*v1alpha1.GCPMachineClass),
-			CloudConfig:     secretRef,
-			UserData:        string(secretRef.Data["userData"]),
+			CredentialsData: secretData,
+			UserData:        string(secretData["userData"]),
 			MachineID:       machineID,
 			MachineName:     machineName,
 		}
@@ -81,16 +81,16 @@ func NewDriver(machineID string, secretRef *corev1.Secret, classKind string, mac
 	case "AlicloudMachineClass":
 		return &AlicloudDriver{
 			AlicloudMachineClass: machineClass.(*v1alpha1.AlicloudMachineClass),
-			CloudConfig:          secretRef,
-			UserData:             string(secretRef.Data["userData"]),
+			CredentialsData:      secretData,
+			UserData:             string(secretData["userData"]),
 			MachineID:            machineID,
 			MachineName:          machineName,
 		}
 	case "PacketMachineClass":
 		return &PacketDriver{
 			PacketMachineClass: machineClass.(*v1alpha1.PacketMachineClass),
-			CloudConfig:        secretRef,
-			UserData:           string(secretRef.Data["userData"]),
+			CredentialsData:    secretData,
+			UserData:           string(secretData["userData"]),
 			MachineID:          machineID,
 			MachineName:        machineName,
 		}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -18,7 +18,10 @@ limitations under the License.
 package driver
 
 import (
+	"strings"
+
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -110,4 +113,15 @@ func NewDriver(machineID string, secretData map[string][]byte, classKind string,
 			return nil, nil
 		},
 	)
+}
+
+// ExtractCredentialsFromData extracts and trims a value from the given data map. The first key that exists is being
+// returned, otherwise, the next key is tried, etc. If no key exists then an empty string is returned.
+func ExtractCredentialsFromData(data map[string][]byte, keys ...string) string {
+	for _, key := range keys {
+		if val, ok := data[key]; ok {
+			return strings.TrimSpace(string(val))
+		}
+	}
+	return ""
 }

--- a/pkg/driver/driver_alicloud.go
+++ b/pkg/driver/driver_alicloud.go
@@ -44,7 +44,7 @@ const (
 // AlicloudDriver is the driver struct for holding Alicloud machine information
 type AlicloudDriver struct {
 	AlicloudMachineClass *v1alpha1.AlicloudMachineClass
-	CloudConfig          *corev1.Secret
+	CredentialsData      map[string][]byte
 	UserData             string
 	MachineID            string
 	MachineName          string
@@ -263,8 +263,8 @@ func (c *AlicloudDriver) decodeMachineID(id string) string {
 }
 
 func (c *AlicloudDriver) getEcsClient() (*ecs.Client, error) {
-	accessKeyID := strings.TrimSpace(string(c.CloudConfig.Data[v1alpha1.AlicloudAccessKeyID]))
-	accessKeySecret := strings.TrimSpace(string(c.CloudConfig.Data[v1alpha1.AlicloudAccessKeySecret]))
+	accessKeyID := strings.TrimSpace(string(c.CredentialsData[v1alpha1.AlicloudAccessKeyID]))
+	accessKeySecret := strings.TrimSpace(string(c.CredentialsData[v1alpha1.AlicloudAccessKeySecret]))
 	region := c.AlicloudMachineClass.Spec.Region
 
 	var ecsClient *ecs.Client

--- a/pkg/driver/driver_alicloud.go
+++ b/pkg/driver/driver_alicloud.go
@@ -263,8 +263,8 @@ func (c *AlicloudDriver) decodeMachineID(id string) string {
 }
 
 func (c *AlicloudDriver) getEcsClient() (*ecs.Client, error) {
-	accessKeyID := strings.TrimSpace(string(c.CredentialsData[v1alpha1.AlicloudAccessKeyID]))
-	accessKeySecret := strings.TrimSpace(string(c.CredentialsData[v1alpha1.AlicloudAccessKeySecret]))
+	accessKeyID := ExtractCredentialsFromData(c.CredentialsData, v1alpha1.AlicloudAccessKeyID, v1alpha1.AlicloudAlternativeAccessKeyID)
+	accessKeySecret := ExtractCredentialsFromData(c.CredentialsData, v1alpha1.AlicloudAccessKeySecret, v1alpha1.AlicloudAlternativeAccessKeySecret)
 	region := c.AlicloudMachineClass.Spec.Region
 
 	var ecsClient *ecs.Client

--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -49,7 +49,7 @@ const (
 // AWSDriver is the driver struct for holding AWS machine information
 type AWSDriver struct {
 	AWSMachineClass *v1alpha1.AWSMachineClass
-	CloudConfig     *corev1.Secret
+	CredentialsData map[string][]byte
 	UserData        string
 	MachineID       string
 	MachineName     string
@@ -452,8 +452,8 @@ func (d *AWSDriver) createSVC() (*ec2.EC2, error) {
 			Region: aws.String(d.AWSMachineClass.Spec.Region),
 		}
 
-		accessKeyID     = strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.AWSAccessKeyID]))
-		secretAccessKey = strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.AWSSecretAccessKey]))
+		accessKeyID     = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AWSAccessKeyID]))
+		secretAccessKey = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AWSSecretAccessKey]))
 	)
 
 	if accessKeyID != "" && secretAccessKey != "" {

--- a/pkg/driver/driver_aws.go
+++ b/pkg/driver/driver_aws.go
@@ -452,8 +452,8 @@ func (d *AWSDriver) createSVC() (*ec2.EC2, error) {
 			Region: aws.String(d.AWSMachineClass.Spec.Region),
 		}
 
-		accessKeyID     = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AWSAccessKeyID]))
-		secretAccessKey = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AWSSecretAccessKey]))
+		accessKeyID     = ExtractCredentialsFromData(d.CredentialsData, v1alpha1.AWSAccessKeyID, v1alpha1.AWSAlternativeAccessKeyID)
+		secretAccessKey = ExtractCredentialsFromData(d.CredentialsData, v1alpha1.AWSSecretAccessKey, v1alpha1.AWSAlternativeSecretAccessKey)
 	)
 
 	if accessKeyID != "" && secretAccessKey != "" {

--- a/pkg/driver/driver_aws_test.go
+++ b/pkg/driver/driver_aws_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Driver AWS", func() {
 		It("should convert multiples tags successfully", func() {
 			awsDriver := &AWSDriver{
 				AWSMachineClass: &v1alpha1.AWSMachineClass{},
-				CloudConfig:     &corev1.Secret{},
+				CredentialsData: map[string][]byte{},
 				UserData:        "dXNlciBkYXRhCg==",
 				MachineID:       "ami-99fn8a892f94e765a",
 				MachineName:     "machine-name",

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -395,10 +395,10 @@ func (d *AzureDriver) SetUserData(userData string) {
 
 func (d *AzureDriver) setup() (*azureDriverClients, error) {
 	var (
-		subscriptionID = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureSubscriptionID]))
-		tenantID       = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureTenantID]))
-		clientID       = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureClientID]))
-		clientSecret   = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureClientSecret]))
+		subscriptionID = ExtractCredentialsFromData(d.CredentialsData, v1alpha1.AzureSubscriptionID, v1alpha1.AzureAlternativeSubscriptionID)
+		tenantID       = ExtractCredentialsFromData(d.CredentialsData, v1alpha1.AzureTenantID, v1alpha1.AzureAlternativeTenantID)
+		clientID       = ExtractCredentialsFromData(d.CredentialsData, v1alpha1.AzureClientID, v1alpha1.AzureAlternativeClientID)
+		clientSecret   = ExtractCredentialsFromData(d.CredentialsData, v1alpha1.AzureClientSecret, v1alpha1.AzureAlternativeClientSecret)
 		env            = azure.PublicCloud
 	)
 	return newClients(subscriptionID, tenantID, clientID, clientSecret, env)

--- a/pkg/driver/driver_azure.go
+++ b/pkg/driver/driver_azure.go
@@ -52,7 +52,7 @@ const (
 // AzureDriver is the driver struct for holding azure machine information
 type AzureDriver struct {
 	AzureMachineClass *v1alpha1.AzureMachineClass
-	CloudConfig       *corev1.Secret
+	CredentialsData   map[string][]byte
 	UserData          string
 	MachineID         string
 	MachineName       string
@@ -395,10 +395,10 @@ func (d *AzureDriver) SetUserData(userData string) {
 
 func (d *AzureDriver) setup() (*azureDriverClients, error) {
 	var (
-		subscriptionID = strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.AzureSubscriptionID]))
-		tenantID       = strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.AzureTenantID]))
-		clientID       = strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.AzureClientID]))
-		clientSecret   = strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.AzureClientSecret]))
+		subscriptionID = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureSubscriptionID]))
+		tenantID       = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureTenantID]))
+		clientID       = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureClientID]))
+		clientSecret   = strings.TrimSpace(string(d.CredentialsData[v1alpha1.AzureClientSecret]))
 		env            = azure.PublicCloud
 	)
 	return newClients(subscriptionID, tenantID, clientID, clientSecret, env)

--- a/pkg/driver/driver_gcp.go
+++ b/pkg/driver/driver_gcp.go
@@ -45,7 +45,7 @@ const (
 // GCPDriver is the driver struct for holding GCP machine information
 type GCPDriver struct {
 	GCPMachineClass *v1alpha1.GCPMachineClass
-	CloudConfig     *corev1.Secret
+	CredentialsData map[string][]byte
 	UserData        string
 	MachineID       string
 	MachineName     string
@@ -58,7 +58,7 @@ func (d *GCPDriver) Create() (string, string, error) {
 		return "Error", "Error", err
 	}
 
-	project, err := extractProject(d.CloudConfig.Data[v1alpha1.GCPServiceAccountJSON])
+	project, err := extractProject(d.CredentialsData[v1alpha1.GCPServiceAccountJSON])
 	if err != nil {
 		return "Error", "Error", err
 	}
@@ -255,7 +255,7 @@ func (d *GCPDriver) GetVMs(machineID string) (VMs, error) {
 		return listOfVMs, err
 	}
 
-	project, err := extractProject(d.CloudConfig.Data[v1alpha1.GCPServiceAccountJSON])
+	project, err := extractProject(d.CredentialsData[v1alpha1.GCPServiceAccountJSON])
 	if err != nil {
 		klog.Error(err)
 		return listOfVMs, err
@@ -303,7 +303,7 @@ func (d *GCPDriver) GetVMs(machineID string) (VMs, error) {
 func (d *GCPDriver) createComputeService() (context.Context, *compute.Service, error) {
 	ctx := context.Background()
 
-	jwt, err := google.JWTConfigFromJSON(d.CloudConfig.Data[v1alpha1.GCPServiceAccountJSON], compute.CloudPlatformScope)
+	jwt, err := google.JWTConfigFromJSON(d.CredentialsData[v1alpha1.GCPServiceAccountJSON], compute.CloudPlatformScope)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/driver/driver_openstack.go
+++ b/pkg/driver/driver_openstack.go
@@ -86,7 +86,7 @@ func (l logger) Printf(format string, args ...interface{}) {
 // OpenStackDriver is the driver struct for holding OS machine information
 type OpenStackDriver struct {
 	OpenStackMachineClass *v1alpha1.OpenStackMachineClass
-	CloudConfig           *corev1.Secret
+	CredentialsData       map[string][]byte
 	UserData              string
 	MachineID             string
 	MachineName           string
@@ -446,41 +446,41 @@ func (d *OpenStackDriver) createNovaClient() (*gophercloud.ServiceClient, error)
 func (d *OpenStackDriver) createOpenStackClient() (*gophercloud.ProviderClient, error) {
 	config := &tls.Config{}
 
-	authURL, ok := d.CloudConfig.Data[v1alpha1.OpenStackAuthURL]
+	authURL, ok := d.CredentialsData[v1alpha1.OpenStackAuthURL]
 	if !ok {
 		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackAuthURL)
 	}
-	username, ok := d.CloudConfig.Data[v1alpha1.OpenStackUsername]
+	username, ok := d.CredentialsData[v1alpha1.OpenStackUsername]
 	if !ok {
 		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackUsername)
 	}
-	password, ok := d.CloudConfig.Data[v1alpha1.OpenStackPassword]
+	password, ok := d.CredentialsData[v1alpha1.OpenStackPassword]
 	if !ok {
 		return nil, fmt.Errorf("missing %s in secret", v1alpha1.OpenStackPassword)
 	}
 
 	// optional OS_USER_DOMAIN_NAME
-	userDomainName := d.CloudConfig.Data[v1alpha1.OpenStackUserDomainName]
+	userDomainName := d.CredentialsData[v1alpha1.OpenStackUserDomainName]
 	// optional OS_USER_DOMAIN_ID
-	userDomainID := d.CloudConfig.Data[v1alpha1.OpenStackUserDomainID]
+	userDomainID := d.CredentialsData[v1alpha1.OpenStackUserDomainID]
 
-	domainName, ok := d.CloudConfig.Data[v1alpha1.OpenStackDomainName]
-	domainID, ok2 := d.CloudConfig.Data[v1alpha1.OpenStackDomainID]
+	domainName, ok := d.CredentialsData[v1alpha1.OpenStackDomainName]
+	domainID, ok2 := d.CredentialsData[v1alpha1.OpenStackDomainID]
 	if !ok && !ok2 {
 		return nil, fmt.Errorf("missing %s or %s in secret", v1alpha1.OpenStackDomainName, v1alpha1.OpenStackDomainID)
 	}
-	tenantName, ok := d.CloudConfig.Data[v1alpha1.OpenStackTenantName]
-	tenantID, ok2 := d.CloudConfig.Data[v1alpha1.OpenStackTenantID]
+	tenantName, ok := d.CredentialsData[v1alpha1.OpenStackTenantName]
+	tenantID, ok2 := d.CredentialsData[v1alpha1.OpenStackTenantID]
 	if !ok && !ok2 {
 		return nil, fmt.Errorf("missing %s or %s in secret", v1alpha1.OpenStackTenantName, v1alpha1.OpenStackTenantID)
 	}
 
-	caCert, ok := d.CloudConfig.Data[v1alpha1.OpenStackCACert]
+	caCert, ok := d.CredentialsData[v1alpha1.OpenStackCACert]
 	if !ok {
 		caCert = nil
 	}
 
-	insecure, ok := d.CloudConfig.Data[v1alpha1.OpenStackInsecure]
+	insecure, ok := d.CredentialsData[v1alpha1.OpenStackInsecure]
 	if ok && strings.TrimSpace(string(insecure)) == "true" {
 		config.InsecureSkipVerify = true
 	}
@@ -491,9 +491,9 @@ func (d *OpenStackDriver) createOpenStackClient() (*gophercloud.ProviderClient, 
 		config.RootCAs = caCertPool
 	}
 
-	clientCert, ok := d.CloudConfig.Data[v1alpha1.OpenStackClientCert]
+	clientCert, ok := d.CredentialsData[v1alpha1.OpenStackClientCert]
 	if ok {
-		clientKey, ok := d.CloudConfig.Data[v1alpha1.OpenStackClientKey]
+		clientKey, ok := d.CredentialsData[v1alpha1.OpenStackClientKey]
 		if ok {
 			cert, err := tls.X509KeyPair([]byte(clientCert), []byte(clientKey))
 			if err != nil {

--- a/pkg/driver/driver_packet.go
+++ b/pkg/driver/driver_packet.go
@@ -31,7 +31,7 @@ import (
 // PacketDriver is the driver struct for holding Packet machine information
 type PacketDriver struct {
 	PacketMachineClass *v1alpha1.PacketMachineClass
-	CloudConfig        *corev1.Secret
+	CredentialsData    map[string][]byte
 	UserData           string
 	MachineID          string
 	MachineName        string
@@ -155,7 +155,7 @@ func (d *PacketDriver) GetVMs(machineID string) (VMs, error) {
 // Helper function to create SVC
 func (d *PacketDriver) createSVC() *packngo.Client {
 
-	token := strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.PacketAPIKey]))
+	token := strings.TrimSpace(string(d.CredentialsData[v1alpha1.PacketAPIKey]))
 
 	if token != "" {
 		return packngo.NewClientWithAuth("gardener", token, nil)

--- a/pkg/driver/driver_suite_test.go
+++ b/pkg/driver/driver_suite_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver
+
+import (
+	"testing"
+)
+import . "github.com/onsi/ginkgo"
+import . "github.com/onsi/gomega"
+
+func TestDriverSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Driver Suite")
+}

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -1,12 +1,49 @@
-package driver
+/*
+Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driver_test
 
 import (
-	"testing"
-)
-import . "github.com/onsi/ginkgo"
-import . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
-func TestDriverSuite(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Driver Suite")
-}
+	. "github.com/gardener/machine-controller-manager/pkg/driver"
+)
+
+var _ = Describe("Driver", func() {
+	Describe("#ExtractCredentialsFromData", func() {
+		It("should return an empty string because data map is nil", func() {
+			Expect(ExtractCredentialsFromData(nil, "foo", "bar")).To(BeEmpty())
+		})
+
+		It("should return an empty string because data map is empty", func() {
+			Expect(ExtractCredentialsFromData(map[string][]byte{}, "foo", "bar")).To(BeEmpty())
+		})
+
+		It("should return an empty string because no keys provided", func() {
+			Expect(ExtractCredentialsFromData(map[string][]byte{"foo": []byte("bar")})).To(BeEmpty())
+		})
+
+		It("should return the value of the first matching key", func() {
+			Expect(ExtractCredentialsFromData(map[string][]byte{"foo": []byte(" bar")}, "foo", "bar")).To(Equal("bar"))
+		})
+
+		It("should return the value of the first matching key", func() {
+			Expect(ExtractCredentialsFromData(map[string][]byte{"foo": []byte(`  bar   
+`)}, "bar", "foo")).To(Equal("bar"))
+		})
+	})
+})

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -675,6 +675,11 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClassSpec(ref common.ReferenceCa
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},
+					"credentialsSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.SecretReference"),
+						},
+					},
 				},
 			},
 		},
@@ -999,6 +1004,11 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassSpec(ref common.Refere
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},
+					"credentialsSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.SecretReference"),
+						},
+					},
 				},
 				Required: []string{"imageID", "instanceType", "region", "vSwitchID", "keyPairName"},
 			},
@@ -1276,6 +1286,11 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClassSpec(ref common.Reference
 						},
 					},
 					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.SecretReference"),
+						},
+					},
+					"credentialsSecretRef": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},
@@ -1990,6 +2005,11 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 						},
 					},
 					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.SecretReference"),
+						},
+					},
+					"credentialsSecretRef": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},
@@ -3435,6 +3455,11 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},
+					"credentialsSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.SecretReference"),
+						},
+					},
 					"podNetworkCidr": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
@@ -3662,6 +3687,11 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClassSpec(ref common.Referenc
 						},
 					},
 					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.SecretReference"),
+						},
+					},
+					"credentialsSecretRef": {
 						SchemaProps: spec.SchemaProps{
 							Ref: ref("k8s.io/api/core/v1.SecretReference"),
 						},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2305,7 +2305,13 @@ func schema_pkg_apis_machine_v1alpha1_MachineClass(ref common.ReferenceCallback)
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretRef stores the necessary secrets such as credetials or userdata.",
+							Description: "SecretRef stores the necessary secrets such as credentials or userdata.",
+							Ref:         ref("k8s.io/api/core/v1.SecretReference"),
+						},
+					},
+					"credentialsSecretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them). This might be useful if multiple machine classes with the same credentials but different user-datas are used.",
 							Ref:         ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -134,7 +134,7 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) (machine
 		return machineutils.LongRetry, err
 	}
 
-	machineClass, secret, retry, err := c.ValidateMachineClass(&machine.Spec.Class)
+	machineClass, secretData, retry, err := c.ValidateMachineClass(&machine.Spec.Class)
 	if err != nil {
 		klog.Error(err)
 		return retry, err
@@ -145,7 +145,7 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) (machine
 		return c.triggerDeletionFlow(&driver.DeleteMachineRequest{
 			Machine:      machine,
 			MachineClass: machineClass,
-			Secret:       secret,
+			Secret:       &corev1.Secret{Data: secretData},
 		})
 	}
 
@@ -161,12 +161,11 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) (machine
 			return retry, err
 		}
 	}
-
 	if machine.Spec.ProviderID == "" || machine.Status.CurrentStatus.Phase == "" || machine.Status.Node == "" {
 		return c.triggerCreationFlow(&driver.CreateMachineRequest{
 			Machine:      machine,
 			MachineClass: machineClass,
-			Secret:       secret,
+			Secret:       &corev1.Secret{Data: secretData},
 		})
 	}
 

--- a/pkg/util/provider/machinecontroller/machine_safety.go
+++ b/pkg/util/provider/machinecontroller/machine_safety.go
@@ -170,10 +170,7 @@ func (c *controller) checkMachineClasses() (machineutils.RetryPeriod, error) {
 	}
 
 	for _, machineClass := range MachineClasses {
-		retry, err := c.checkMachineClass(
-			machineClass,
-			machineClass.SecretRef,
-		)
+		retry, err := c.checkMachineClass(machineClass)
 		if err != nil {
 			return retry, err
 		}
@@ -183,20 +180,18 @@ func (c *controller) checkMachineClasses() (machineutils.RetryPeriod, error) {
 }
 
 // checkMachineClass checks a particular machineClass for orphan instances
-func (c *controller) checkMachineClass(
-	machineClass *v1alpha1.MachineClass,
-	secretRef *corev1.SecretReference) (machineutils.RetryPeriod, error) {
+func (c *controller) checkMachineClass(machineClass *v1alpha1.MachineClass) (machineutils.RetryPeriod, error) {
 
-	// Get secret
-	secret, err := c.getSecret(secretRef, machineClass.Name)
-	if err != nil || secret == nil {
-		klog.Errorf("SafetyController: Secret reference not found for MachineClass: %q", machineClass.Name)
+	// Get secret data
+	secretData, err := c.getSecretData(machineClass.Name, machineClass.SecretRef, machineClass.CredentialsSecretRef)
+	if err != nil {
+		klog.Errorf("SafetyController: Secret Data could not be computed for MachineClass: %q", machineClass.Name)
 		return machineutils.LongRetry, err
 	}
 
 	listMachineResponse, err := c.driver.ListMachines(context.TODO(), &driver.ListMachinesRequest{
 		MachineClass: machineClass,
-		Secret:       secret,
+		Secret:       &corev1.Secret{Data: secretData},
 	})
 	if err != nil {
 		klog.Errorf("SafetyController: Failed to LIST VMs at provider. Error: %s", err)
@@ -242,7 +237,7 @@ func (c *controller) checkMachineClass(
 			_, err := c.driver.DeleteMachine(context.TODO(), &driver.DeleteMachineRequest{
 				Machine:      machine,
 				MachineClass: machineClass,
-				Secret:       secret,
+				Secret:       &corev1.Secret{Data: secretData},
 			})
 			if err != nil {
 				klog.Errorf("SafetyController: Error while trying to DELETE VM on CP - %s. Shall retry in next safety controller sync.", err)

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -229,7 +229,7 @@ var _ = Describe("machine", func() {
 		}
 		type expect struct {
 			machineClass interface{}
-			secret       *corev1.Secret
+			secretData   map[string][]byte
 			err          bool
 		}
 		type data struct {
@@ -262,17 +262,17 @@ var _ = Describe("machine", func() {
 				defer trackers.Stop()
 
 				waitForCacheSync(stop, controller)
-				machineClass, secret, _, err := controller.ValidateMachineClass(data.action)
+				machineClass, secretData, _, err := controller.ValidateMachineClass(data.action)
 
 				if data.expect.machineClass == nil {
 					Expect(machineClass).To(BeNil())
 				} else {
 					Expect(machineClass).To(Equal(data.expect.machineClass))
 				}
-				if data.expect.secret == nil {
-					Expect(secret).To(BeNil())
+				if data.expect.secretData == nil {
+					Expect(secretData).To(BeNil())
 				} else {
-					Expect(secret).To(Equal(data.expect.secret))
+					Expect(secretData).To(Equal(data.expect.secretData))
 				}
 				if !data.expect.err {
 					Expect(err).To(BeNil())
@@ -323,6 +323,7 @@ var _ = Describe("machine", func() {
 					secrets: []*corev1.Secret{
 						{
 							ObjectMeta: *newObjectMeta(objMeta, 0),
+							Data:       map[string][]byte{"foo": []byte("bar")},
 						},
 					},
 					aws: []*v1alpha1.MachineClass{
@@ -341,10 +342,8 @@ var _ = Describe("machine", func() {
 						ObjectMeta: *newObjectMeta(objMeta, 0),
 						SecretRef:  newSecretReference(objMeta, 0),
 					},
-					secret: &corev1.Secret{
-						ObjectMeta: *newObjectMeta(objMeta, 0),
-					},
-					err: false,
+					secretData: map[string][]byte{"foo": []byte("bar")},
+					err:        false,
 				},
 			}),
 		)

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -93,10 +93,9 @@ func UpdateMachineWithRetries(machineClient v1alpha1client.MachineInterface, mac
 */
 
 // ValidateMachineClass validates the machine class.
-func (c *controller) ValidateMachineClass(classSpec *v1alpha1.ClassSpec) (*v1alpha1.MachineClass, *v1.Secret, machineutils.RetryPeriod, error) {
+func (c *controller) ValidateMachineClass(classSpec *v1alpha1.ClassSpec) (*v1alpha1.MachineClass, map[string][]byte, machineutils.RetryPeriod, error) {
 	var (
 		machineClass *v1alpha1.MachineClass
-		secretRef    *v1.Secret
 		err          error
 		retry        = machineutils.LongRetry
 	)
@@ -118,16 +117,38 @@ func (c *controller) ValidateMachineClass(classSpec *v1alpha1.ClassSpec) (*v1alp
 		return nil, nil, retry, err
 	}
 
-	secretRef, err = c.getSecret(machineClass.SecretRef, machineClass.Name)
+	secretData, err := c.getSecretData(machineClass.Name, machineClass.SecretRef, machineClass.CredentialsSecretRef)
 	if err != nil {
-		klog.Errorf("Secret not found for %q", machineClass.SecretRef.Name)
+		klog.V(2).Infof("Could not compute secret data: %+v", err)
 		return nil, nil, retry, err
 	}
 
-	return machineClass, secretRef, retry, nil
+	return machineClass, secretData, retry, nil
 }
 
-// getSecret retrives the kubernetes secret if found
+func (c *controller) getSecretData(machineClassName string, secretRefs ...*v1.SecretReference) (map[string][]byte, error) {
+	var secretData map[string][]byte
+
+	for _, secretRef := range secretRefs {
+		if secretRef == nil {
+			continue
+		}
+
+		secretRef, err := c.getSecret(secretRef, machineClassName)
+		if err != nil {
+			klog.V(2).Infof("Secret reference %s/%s not found", secretRef.Namespace, secretRef.Name)
+			return nil, err
+		}
+
+		if secretRef != nil {
+			secretData = mergeDataMaps(secretData, secretRef.Data)
+		}
+	}
+
+	return secretData, nil
+}
+
+// getSecret retrieves the kubernetes secret if found
 func (c *controller) getSecret(ref *v1.SecretReference, MachineClassName string) (*v1.Secret, error) {
 	if ref == nil {
 		// If no secretRef, return nil
@@ -159,6 +180,18 @@ func nodeConditionsHaveChanged(machineConditions []v1.NodeCondition, nodeConditi
 	}
 
 	return false
+}
+
+func mergeDataMaps(in map[string][]byte, maps ...map[string][]byte) map[string][]byte {
+	out := make(map[string][]byte)
+
+	for _, m := range append([]map[string][]byte{in}, maps...) {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+
+	return out
 }
 
 // syncMachineNodeTemplate syncs nodeTemplates between machine and corresponding node-object.

--- a/pkg/util/provider/machinecontroller/migrate_machineclass.go
+++ b/pkg/util/provider/machinecontroller/migrate_machineclass.go
@@ -5,17 +5,17 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
+
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 )
 
 const (
@@ -110,7 +110,7 @@ func (c *controller) createMachineClass(providerSpecificMachineClass interface{}
 		}
 
 	} else if err != nil {
-		// Anyother kind of error while fetching the machineClass object
+		// Another kind of error while fetching the machineClass object
 		return machineutils.ShortRetry, err
 	}
 
@@ -387,7 +387,7 @@ func (c *controller) addMigratedAnnotationForProviderMachineClass(classSpec *v1a
 }
 
 // TryMachineClassMigration tries to migrate the provider-specific machine class to the generic machine-class.
-func (c *controller) TryMachineClassMigration(classSpec *v1alpha1.ClassSpec) (*v1alpha1.MachineClass, *v1.Secret, machineutils.RetryPeriod, error) {
+func (c *controller) TryMachineClassMigration(classSpec *v1alpha1.ClassSpec) (*v1alpha1.MachineClass, map[string][]byte, machineutils.RetryPeriod, error) {
 	var (
 		err                          error
 		providerSpecificMachineClass interface{}

--- a/pkg/util/provider/machinecontroller/secret_util.go
+++ b/pkg/util/provider/machinecontroller/secret_util.go
@@ -47,7 +47,8 @@ func (c *controller) findMachineClassForSecret(name string) ([]*v1alpha1.Machine
 	}
 	var filtered []*v1alpha1.MachineClass
 	for _, machineClass := range machineClasses {
-		if machineClass.SecretRef != nil && machineClass.SecretRef.Name == name {
+		if (machineClass.SecretRef != nil && machineClass.SecretRef.Name == name) ||
+			(machineClass.CredentialsSecretRef != nil && machineClass.CredentialsSecretRef.Name == name) {
 			filtered = append(filtered, machineClass)
 		}
 	}


### PR DESCRIPTION
/area open-source usability
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR extends all in-tree and the out-of-tree machine classes with a new `.{spec.}credentialsSecretRef` field. It is an optional reference to a secret containing only the credentials, while today's `.{spec.}secretRef` still contains the user-data.
This is helpful for scenarios like Gardeners where the credentials for all machine classes are the same while only the user-data differs.

Additionally, all the secret keys used by Gardener are now also allowed as alternatives for the machine-controller-manager. This helps to not make mappings for the data keys.

**Special notes for your reviewer**:
The implementation is entirely backwards-compatible and optional, both for the in-tree and the out-of-tree implementations. The in-tree drivers have been simplified by only working with the secret data map instead of the whole `v1.Secret` object. The out-of-tree contract is untouched. If a credentials secret reference is provided then its content will be merged into the secret that is passed to the provider.

ℹ️ For simplification of the review process the PR is split into 4 different commits that could be reviewed individually.

/assign @hardikdr @prashanth26 @AxiomSamarth 
/invite @hardikdr @prashanth26 @AxiomSamarth 

/cc @vpnachev @timuthy 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```feature operator
All machine classes do now support an optional `.{spec.}credentialsSecretRef` field in addition to today's `.{spec.}secretRef` field. If `.{spec.}credentialsSecretRef` is non-nil then the provider credentials will be read out of this secret. The user-data for the machine bring-up is still required to be part of the secret referenced by `.{spec.}secretRef`.
```
```feature operator
Some machine class secrets are now supporting alternative data keys:
* The machine class secret for Alicloud machines does now also accept the data keys `accessKeyID` and `accessKeySecret` as alternatives for today's keys.
* The machine class secret for AWS machines does now also accept the data keys `accessKeyID` and `secretAccessKey` as alternatives for today's keys.
* The machine class secret for Azure machines does now also accept the data keys `clientID`, `clientSecret`, `subscriptionID` and `tenantID` as alternatives for today's keys.
* The machine class secret for GCP machines does now also accept the data key `serviceaccount.json` as alternatives for today's key.
```