### PR TITLE
Avoid the deletion of the machines in CrashLoopBackoff state by the safety controller

### DIFF
--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -571,10 +571,9 @@ func (c *controller) checkMachineClass(
 			// Any other types of errors
 			klog.Errorf("SafetyController: Error while trying to GET machines. Error: %s", err)
 		} else if err != nil || machine.Spec.ProviderID != machineID {
-
 			// If machine exists and machine object is still been processed by the machine controller
 			if err == nil &&
-				machine.Status.CurrentStatus.Phase == "" {
+				(machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff) {
 				klog.V(3).Infof("SafetyController: Machine object %q is being processed by machine controller, hence skipping", machine.Name)
 				continue
 			}

--- a/pkg/controller/machine_test.go
+++ b/pkg/controller/machine_test.go
@@ -684,12 +684,15 @@ var _ = Describe("machine", func() {
 					func() (string, string, error) {
 						return action.fakeProviderID, action.fakeNodeName, action.fakeError
 					},
+					func(string, string) error {
+						return nil
+					},
 					func(string) error {
 						return action.fakeError
 					}, nil,
 					func() (driver.VMs, error) {
 						return map[string]string{}, nil
-					},
+					}, nil, nil, nil,
 				))
 
 				if data.expect.err {
@@ -1052,6 +1055,9 @@ var _ = Describe("machine", func() {
 						}
 						return action.fakeProviderID, action.fakeNodeName, action.fakeError
 					},
+					func(string, string) error {
+						return nil
+					},
 					func(string) error {
 						return nil
 					},
@@ -1059,6 +1065,7 @@ var _ = Describe("machine", func() {
 						return action.fakeProviderID, action.fakeError
 					},
 					fakeDriverGetVMsTemp,
+					nil, nil, nil,
 				)
 
 				// Create a machine that is to be deleted later

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -101,16 +101,32 @@ func NewDriver(machineID string, secretData map[string][]byte, classKind string,
 
 	return NewFakeDriver(
 		func() (string, string, error) {
+			fakeVMs["fake"] = "fake_ip"
 			return "fake", "fake_ip", nil
 		},
-		func(string) error {
+		func(machineID string, machineName string) error {
+			fakeVMs[machineID] = machineName
+			return nil
+		},
+		func(machineID string) error {
+			// delete(fakeVMs, "fake")
+			delete(fakeVMs, machineID)
 			return nil
 		},
 		func() (string, error) {
-			return "fake", nil
+			return "", nil
 		},
 		func() (VMs, error) {
-			return nil, nil
+			return fakeVMs, nil
+		},
+		func([]corev1.PersistentVolumeSpec) ([]string, error) {
+			return []string{}, nil
+		},
+		func() string {
+			return ""
+		},
+		func(string) {
+			return
 		},
 	)
 }

--- a/pkg/driver/driver_fake.go
+++ b/pkg/driver/driver_fake.go
@@ -19,29 +19,52 @@ package driver
 
 import corev1 "k8s.io/api/core/v1"
 
+// fakeVMs keep a list of actively using fake machines for test purposes
+var fakeVMs = make(VMs)
+
 // FakeDriver is a fake driver returned when none of the actual drivers match
 type FakeDriver struct {
-	create func() (string, string, error)
-	delete func(string) error
-	//existing func() (string, v1alpha1.MachinePhase, error)
+	create      func() (string, string, error)
+	add         func(string, string) error
+	delete      func(string) error
 	existing    func() (string, error)
 	getVMs      func() (VMs, error)
 	getVolNames func([]corev1.PersistentVolumeSpec) ([]string, error)
+	getUserData func() string
+	setUserData func(string)
 }
 
 // NewFakeDriver returns a new fakedriver object
-func NewFakeDriver(create func() (string, string, error), delete func(string) error, existing func() (string, error), getVMs func() (VMs, error)) Driver {
+func NewFakeDriver(
+	create func() (string, string, error),
+	add func(string, string) error,
+	delete func(string) error,
+	existing func() (string, error),
+	getVMs func() (VMs, error),
+	getVolNames func([]corev1.PersistentVolumeSpec) ([]string, error),
+	getUserData func() string,
+	setUserData func(string),
+) Driver {
 	return &FakeDriver{
-		create:   create,
-		delete:   delete,
-		existing: existing,
-		getVMs:   getVMs,
+		create:      create,
+		add:         add,
+		delete:      delete,
+		existing:    existing,
+		getVMs:      getVMs,
+		getVolNames: getVolNames,
+		getUserData: getUserData,
+		setUserData: setUserData,
 	}
 }
 
 // Create returns a newly created fake driver
 func (d *FakeDriver) Create() (string, string, error) {
 	return d.create()
+}
+
+// Add add a newly created machine to the fakeVMs list
+func (d *FakeDriver) Add(machineID string, machineName string) error {
+	return d.add(machineID, machineName)
 }
 
 // Delete deletes a fake driver

--- a/pkg/util/provider/machinecontroller/machine_safety.go
+++ b/pkg/util/provider/machinecontroller/machine_safety.go
@@ -219,7 +219,7 @@ func (c *controller) checkMachineClass(machineClass *v1alpha1.MachineClass) (mac
 
 			// If machine exists and machine object is still been processed by the machine controller
 			if err == nil &&
-				machine.Status.CurrentStatus.Phase == "" {
+				(machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff) {
 				klog.V(3).Infof("SafetyController: Machine object %q is being processed by machine controller, hence skipping", machine.Name)
 				continue
 			}

--- a/pkg/util/provider/machinecontroller/machine_safety_test.go
+++ b/pkg/util/provider/machinecontroller/machine_safety_test.go
@@ -16,13 +16,16 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"time"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	machinev1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -135,4 +138,108 @@ var _ = Describe("#machine_safety", func() {
 		Entry("Control APIServer: UnReachable, Target APIServer: UnReachable, Inactive Timer: Elapsed, Pre-Frozen: true = Post-Frozen: true",
 			false, false, fiveMinutesDuration, true, true),
 	)
+})
+
+var _ = Describe("machineCrashloopBackoff", func() {
+	objMeta := &metav1.ObjectMeta{
+		GenerateName: "class",
+		Namespace:    testNamespace,
+	}
+
+	// classKind := "MachineClass"
+	secretData := map[string][]byte{
+		"userData":            []byte("dummy-data"),
+		"azureClientId":       []byte("dummy-client-id"),
+		"azureClientSecret":   []byte("dummy-client-secret"),
+		"azureSubscriptionId": []byte("dummy-subcription-id"),
+		"azureTenantId":       []byte("dummy-tenant-id"),
+	}
+
+	Describe("machineCrashloopBackoff", func() {
+
+		It("Should delete the machine (old code)", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+
+			// Create test secret and add it to controlCoreObject list
+			testSecret := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-secret",
+					Namespace: testNamespace,
+				},
+				Data: secretData,
+			}
+
+			// Create a test secretReference because the method checkMachineClass needs it
+			testSecretReference := &v1.SecretReference{
+				Name:      "test-secret",
+				Namespace: testNamespace,
+			}
+
+			testMachineClass := &machinev1.MachineClass{
+				ObjectMeta: *newObjectMeta(objMeta, 0),
+				SecretRef:  testSecretReference,
+			}
+
+			controlCoreObjects := []runtime.Object{}
+			controlCoreObjects = append(controlCoreObjects, testSecret)
+
+			// Create test machine object in CrashloopBackoff state
+			testMachineObject1 := &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testmachine_1",
+					Namespace: testNamespace,
+				},
+				Status: machinev1.MachineStatus{
+					CurrentStatus: machinev1.CurrentStatus{
+						Phase: v1alpha1.MachineCrashLoopBackOff,
+					},
+				},
+			}
+
+			// Create another test machine object in Running state
+			testMachineObject2 := &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testmachine_2",
+					Namespace: testNamespace,
+				},
+				Status: machinev1.MachineStatus{
+					CurrentStatus: machinev1.CurrentStatus{
+						Phase: v1alpha1.MachineRunning,
+					},
+				},
+			}
+
+			controlMachineObjects := []runtime.Object{}
+			controlMachineObjects = append(controlMachineObjects, testMachineObject1)
+			controlMachineObjects = append(controlMachineObjects, testMachineObject2)
+
+			fakeDriver := driver.NewFakeDriver(false, "", "", "", nil, nil)
+
+			c, trackers := createController(stop, testNamespace, controlMachineObjects, controlCoreObjects, nil, fakeDriver)
+			defer trackers.Stop()
+
+			fd := fakeDriver.(*driver.FakeDriver)
+
+			listMachinesRequest := &driver.ListMachinesRequest{
+				MachineClass: testMachineClass,
+				Secret:       testSecret,
+			}
+
+			_ = fd.AddMachine("testmachine-ip1", "testmachine_1")
+			_ = fd.AddMachine("testmachine-ip2", "testmachine_2")
+			waitForCacheSync(stop, c)
+
+			// call checkMachineClass to delete the orphan VMs
+			_, _ = c.checkMachineClass(testMachineClass)
+
+			// after this, the testmachine in crashloopbackoff phase
+			// should remain and the other one should
+			// be deleted because it is an orphan VM
+			listMachinesResponse, _ := fd.ListMachines(context.Background(), listMachinesRequest)
+
+			Expect(listMachinesResponse.MachineList["testmachine-ip1"]).To(Equal("testmachine_1"))
+			Expect(listMachinesResponse.MachineList["testmachine-ip2"]).To(Equal(""))
+		})
+	})
 })

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -392,7 +392,14 @@ var _ = Describe("machine", func() {
 					coreObjects = append(coreObjects, o)
 				}
 
-				fakedriver := driver.NewFakeDriver(data.action.fakeDriver)
+				fakedriver := driver.NewFakeDriver(
+					data.action.fakeDriver.VMExists,
+					data.action.fakeDriver.ProviderID,
+					data.action.fakeDriver.NodeName,
+					data.action.fakeDriver.LastKnownState,
+					data.action.fakeDriver.Err,
+					nil,
+				)
 
 				controller, trackers := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects, fakedriver)
 				defer trackers.Stop()
@@ -915,7 +922,12 @@ var _ = Describe("machine", func() {
 				}
 
 				fakeDriver := driver.NewFakeDriver(
-					data.action.fakeDriver,
+					data.action.fakeDriver.VMExists,
+					data.action.fakeDriver.ProviderID,
+					data.action.fakeDriver.NodeName,
+					data.action.fakeDriver.LastKnownState,
+					data.action.fakeDriver.Err,
+					nil,
 				)
 
 				controller, trackers := createController(stop, objMeta.Namespace, machineObjects, nil, coreObjects, fakeDriver)

--- a/pkg/util/provider/machinecontroller/machineclass_test.go
+++ b/pkg/util/provider/machinecontroller/machineclass_test.go
@@ -75,7 +75,12 @@ var _ = Describe("machineclass", func() {
 				}
 
 				fakeDriver := driver.NewFakeDriver(
-					data.action.fakeDriver,
+					data.action.fakeDriver.VMExists,
+					data.action.fakeDriver.ProviderID,
+					data.action.fakeDriver.NodeName,
+					data.action.fakeDriver.LastKnownState,
+					data.action.fakeDriver.Err,
+					nil,
 				)
 
 				controller, trackers := createController(stop, TestNamespace, machineObjects, nil, nil, fakeDriver)

--- a/pkg/util/provider/machinecontroller/migrate_machineclass_test.go
+++ b/pkg/util/provider/machinecontroller/migrate_machineclass_test.go
@@ -157,7 +157,14 @@ var _ = Describe("machine", func() {
 					machineObjects = append(machineObjects, o)
 				}
 
-				fakedriver := driver.NewFakeDriver(data.action.fakeDriver)
+				fakedriver := driver.NewFakeDriver(
+					data.action.fakeDriver.VMExists,
+					data.action.fakeDriver.ProviderID,
+					data.action.fakeDriver.NodeName,
+					data.action.fakeDriver.LastKnownState,
+					data.action.fakeDriver.Err,
+					nil,
+				)
 
 				controller, trackers := createController(stop, TestNamespace, machineObjects, nil, nil, fakedriver)
 				defer trackers.Stop()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will avoid the deletion of the machines in CrashLoopBackoff state by the safety controller

**Which issue(s) this PR fixes**:
Fixes #583 

**Special notes for your reviewer**:
More UTs shall be added to test this scenario in the near future. This one is an immediate solution to mitigate the issue.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Avoid the deletion of the machines in CrashLoopBackoff state by the safety controller
```
