### PR TITLE
Fix the OpenAPI validation of the machine-deployment crd

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -59,9 +59,6 @@ spec:
             object represents. Servers may infer this from the endpoint the client
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
-        metadata:
-          description: Standard object metadata.
-          type: object
         spec:
           description: Specification of the desired behavior of the MachineDeployment.
           properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the OpenAPI validation of the machine-deployment crd
Related to: kubernetes/kubernetes#80493 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager/pull/551 this PR which was merged already by Hardik is somehow overwritten. 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
