### PR TITLE
Machines are reconciled only when MachineClasses have valid finalizers

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -59,9 +59,6 @@ spec:
             object represents. Servers may infer this from the endpoint the client
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
-        metadata:
-          description: Standard object metadata.
-          type: object
         spec:
           description: Specification of the desired behavior of the MachineDeployment.
           properties:

--- a/pkg/util/provider/machinecontroller/controller_suite_test.go
+++ b/pkg/util/provider/machinecontroller/controller_suite_test.go
@@ -542,6 +542,7 @@ func createController(
 		machineSynced:               machines.Informer().HasSynced,
 		nodeSynced:                  nodes.Informer().HasSynced,
 		secretSynced:                secrets.Informer().HasSynced,
+		machineClassQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineclass"),
 		secretQueue:                 workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secret"),
 		nodeQueue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "node"),
 		machineQueue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machine"),

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -134,6 +134,7 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) (machine
 		return machineutils.LongRetry, err
 	}
 
+	// Validate MachineClass
 	machineClass, secretData, retry, err := c.ValidateMachineClass(&machine.Spec.Class)
 	if err != nil {
 		klog.Error(err)

--- a/pkg/util/provider/machinecontroller/machineclass.go
+++ b/pkg/util/provider/machinecontroller/machineclass.go
@@ -146,20 +146,21 @@ func (c *controller) reconcileClusterMachineClass(class *v1alpha1.MachineClass) 
 		return err
 	}
 
+	// fetch all machines referring the machineClass
+	machines, err := c.findMachinesForClass(machineutils.MachineClassKind, class.Name)
+	if err != nil {
+		return err
+	}
+
 	// Add finalizer to avoid losing machineClass object
-	if class.DeletionTimestamp == nil {
+	if class.DeletionTimestamp == nil && len(machines) > 0 {
+		klog.Infof("Adding finalizers to machine class %s", class.Name)
 		err = c.addMachineClassFinalizers(class)
 		if err != nil {
 			return err
 		}
 
 		return nil
-	}
-
-	// fetch all machines referring the machineClass
-	machines, err := c.findMachinesForClass(machineutils.MachineClassKind, class.Name)
-	if err != nil {
-		return err
 	}
 
 	if len(machines) > 0 {

--- a/pkg/util/provider/machinecontroller/machineclass_test.go
+++ b/pkg/util/provider/machinecontroller/machineclass_test.go
@@ -172,6 +172,44 @@ var _ = Describe("machineclass", func() {
 				},
 			),
 			Entry(
+				"Do not add finalizer to machine class because no machines use it",
+				&data{
+					setup: setup{
+						machineClasses: []*v1alpha1.MachineClass{
+							{
+								TypeMeta: metav1.TypeMeta{},
+								ObjectMeta: metav1.ObjectMeta{
+									Name:      TestMachineClassName,
+									Namespace: TestNamespace,
+								},
+								ProviderSpec: runtime.RawExtension{},
+								SecretRef:    &v1.SecretReference{},
+								Provider:     "",
+							},
+						},
+						machines:            []*v1alpha1.Machine{},
+						fakeResourceActions: &customfake.ResourceActions{},
+					},
+					action: action{
+						fakeDriver:       &driver.FakeDriver{},
+						machineClassName: TestMachineClassName,
+					},
+					expect: expect{
+						machineClass: &v1alpha1.MachineClass{
+							TypeMeta: metav1.TypeMeta{},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      TestMachineClassName,
+								Namespace: TestNamespace,
+							},
+							ProviderSpec: runtime.RawExtension{},
+							SecretRef:    &v1.SecretReference{},
+							Provider:     "",
+						},
+						err: nil,
+					},
+				},
+			),
+			Entry(
 				"Finalizer exists, so do nothing",
 				&data{
 					setup: setup{


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements MachineClasses to have finalizers only when machines backing them are present.

**Which issue(s) this PR fixes**:
Fixes #560 

**Special notes for your reviewer**:
The change has been introduced for OOT MCM common library. If there is a need then it shall be introduced in In-Tree too.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Finalizers will be added to the MachineClass which is used by at least one machine. Machines whose backing MachineClass does not have finalizers shall not be reconciled.
```
