### PR TITLE
Run update before fetching on CI image

### DIFF
--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -86,6 +86,7 @@ function setup_environment() {
     # If not a local test then install jq
     if [ -z "$LOCAL_TEST" ]; then
         printf "\nDownloading and installing jq\n"
+        apt-get -y update
         apt-get -y install jq
         printf "Successfully installed jq\n"
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Minor fix to update docker image before fetching and installing new libraries on CI pipeline runs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Without this command, the new cc job image is facing issues while running CI tests and failing with the following errors. 

```
.ci/integration-tests: line 98: jq: command not found
.ci/integration-tests: line 99: jq: command not found
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
