### PR TITLE
Support AWS Capacity Reservations

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
@@ -148,6 +148,18 @@ spec:
                     name must be unique.
                   type: string
               type: object
+            capacityReservation:
+              description: The Capacity Reservation that this machine should be launched into. Either the reservation or
+                the reservation group needs to be provided - not both.
+              properties:
+                capacityReservationId:
+                  description: Target this existing Capacity Reservation.
+                  type: string
+                capacityReservationResourceGroupArn:
+                  description: Target this existing Capacity Reservation Group. Perhaps more useful than using capacity reservations
+                    directly since groups can be created much ahead of time.
+                  type: string
+              type: object
             ebsOptimized:
               type: boolean
             iam:

--- a/kubernetes/machine_classes/aws-machine-class.yaml
+++ b/kubernetes/machine_classes/aws-machine-class.yaml
@@ -27,6 +27,9 @@ spec:
 # credentialsSecretRef: # Optional - Kubernetes secret containing only provider secrets (in this case the Secret in the secretRef does not need them)
 #   name: "test-secret-credentials" # Name of the secret
 #   namespace: "default" # Namespace of secret
+#  capacityReservation: # Optional - allows targetting a capacity reservation. Either a reservation id or group arn is needed - not both.
+#    capacityReservationId: "cr-05c28b843c05acc11"
+#    capacityReservationResourceGroupArn: "arn:aws:resource-groups:us-west-1:123456789012:group/my-cr-group"
   blockDevices:
     - deviceName: /root
       ebs:

--- a/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/aws_machineclass_types.go
@@ -74,21 +74,31 @@ type AWSMachineClassList struct {
 
 // AWSMachineClassSpec is the specification of a AWSMachineClass.
 type AWSMachineClassSpec struct {
-	AMI                  string                      `json:"ami,omitempty"`
-	Region               string                      `json:"region,omitempty"`
-	BlockDevices         []AWSBlockDeviceMappingSpec `json:"blockDevices,omitempty"`
-	EbsOptimized         bool                        `json:"ebsOptimized,omitempty"`
-	IAM                  AWSIAMProfileSpec           `json:"iam,omitempty"`
-	MachineType          string                      `json:"machineType,omitempty"`
-	KeyName              string                      `json:"keyName,omitempty"`
-	Monitoring           bool                        `json:"monitoring,omitempty"`
-	NetworkInterfaces    []AWSNetworkInterfaceSpec   `json:"networkInterfaces,omitempty"`
-	Tags                 map[string]string           `json:"tags,omitempty"`
-	SpotPrice            *string                     `json:"spotPrice,omitempty"`
-	SecretRef            *corev1.SecretReference     `json:"secretRef,omitempty"`
-	CredentialsSecretRef *corev1.SecretReference     `json:"credentialsSecretRef,omitempty"`
+	AMI                       string                           `json:"ami,omitempty"`
+	Region                    string                           `json:"region,omitempty"`
+	BlockDevices              []AWSBlockDeviceMappingSpec      `json:"blockDevices,omitempty"`
+	EbsOptimized              bool                             `json:"ebsOptimized,omitempty"`
+	IAM                       AWSIAMProfileSpec                `json:"iam,omitempty"`
+	MachineType               string                           `json:"machineType,omitempty"`
+	KeyName                   string                           `json:"keyName,omitempty"`
+	Monitoring                bool                             `json:"monitoring,omitempty"`
+	NetworkInterfaces         []AWSNetworkInterfaceSpec        `json:"networkInterfaces,omitempty"`
+	Tags                      map[string]string                `json:"tags,omitempty"`
+	SpotPrice                 *string                          `json:"spotPrice,omitempty"`
+	SecretRef                 *corev1.SecretReference          `json:"secretRef,omitempty"`
+	CredentialsSecretRef      *corev1.SecretReference          `json:"credentialsSecretRef,omitempty"`
+	CapacityReservationTarget *AWSCapacityReservationTargetSpec `json:"capacityReservation,omitempty"`
 
 	// TODO add more here
+}
+
+type AWSCapacityReservationTargetSpec struct {
+
+	// The ID of the Capacity Reservation in which to run the instance.
+	CapacityReservationId *string `json:"capacityReservationId,omitempty"`
+
+	// The ARN of the Capacity Reservation resource group in which to run the instance.
+	CapacityReservationResourceGroupArn *string `json:"capacityReservationResourceGroupArn,omitempty"`
 }
 
 type AWSBlockDeviceMappingSpec struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR passes the ID of an [AWS Capacity Reservation (or reservation group)](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/capacity-reservations-using.html#create-cr-group) to the EC2 instances.

Sometimes AWS is unable to create new instances due to a temporary shortage of capacity in an AZ. AWS Capacity Reservations minimise the risk of stalling deployments; especially ones that use a large maxSurge (which creates more instances than you're currently running).

The default reservation target type is `open` so you can create the reservation group ahead of time without any reservations in it. If machines are created and can't match any reservations then they're created using On-Demand capacity (like the usual way).

Typically you'd create a reservation for `replicas + maxSurge` instances. Then when a deployment happens, the existing nodes are added to the reservation and now you have a buffer to rotate the new instances into the deployment.

**Special notes for your reviewer**:

- Didn't seem like these fields are tested for in the unit tests. Wasn't sure if that was a conscious decision or not because it's relatively simple.
- I wasn't sure if I needed to do anything with deepcopy-gen, any advice would be appreciated!

**Release note**:
```feature operator
Bumped AWS SDK version to v1.33.21
Allows passing through an AWS Capacity Reservation ID or Group ARN so capacity can be reserved to guarantee deployments that use large maxSurge values.
```
