### PR TITLE
Adds finalizers on machines that are adopted by the machine controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ managevm
 controller_manager
 mcm.out
 kubectl
+.cache_ggshield
 
 # Binary files of MCM
 ./machine-controller-manager

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -438,52 +438,6 @@ var _ = Describe("machine", func() {
 				Expect(actual.Status.CurrentStatus.Phase).To(Equal(data.expect.machine.Status.CurrentStatus.Phase))
 			},
 
-			Entry("Machine creation in process. Machine finalizers are UPDATED", &data{
-				setup: setup{
-					secrets: []*corev1.Secret{
-						{
-							ObjectMeta: *newObjectMeta(objMeta, 0),
-						},
-					},
-					machineClaasses: []*v1alpha1.MachineClass{
-						{
-							ObjectMeta: *newObjectMeta(objMeta, 0),
-							SecretRef:  newSecretReference(objMeta, 0),
-						},
-					},
-					machines: newMachines(1, &v1alpha1.MachineTemplateSpec{
-						ObjectMeta: *newObjectMeta(objMeta, 0),
-						Spec: v1alpha1.MachineSpec{
-							Class: v1alpha1.ClassSpec{
-								Kind: "MachineClass",
-								Name: "machine-0",
-							},
-						},
-					}, nil, nil, nil, nil, false, metav1.Now()),
-				},
-				action: action{
-					machine: "machine-0",
-					fakeDriver: &driver.FakeDriver{
-						VMExists:   false,
-						ProviderID: "fakeID-0",
-						NodeName:   "fakeNode-0",
-						Err:        nil,
-					},
-				},
-				expect: expect{
-					machine: newMachine(&v1alpha1.MachineTemplateSpec{
-						ObjectMeta: *newObjectMeta(objMeta, 0),
-						Spec: v1alpha1.MachineSpec{
-							Class: v1alpha1.ClassSpec{
-								Kind: "MachineClass",
-								Name: "machineClass",
-							},
-						},
-					}, nil, nil, nil, nil, true, metav1.Now()),
-					err:   fmt.Errorf("Machine creation in process. Machine finalizers are UPDATED"),
-					retry: machineutils.ShortRetry,
-				},
-			}),
 			Entry("Machine creation succeeds with object UPDATE", &data{
 				setup: setup{
 					secrets: []*corev1.Secret{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds on finalizers on machines that are adopted by MCM. Without this change, it causes issues while migrating machine objects between clusters. 

**Which issue(s) this PR fixes**:
Fixes #610 

**Special notes for your reviewer**:

- This PR basically allows adding of finalizer when when backing VM is created and status is present on it.
- I have removed the test case as it no longer makes sense in that method. We should add a test suit to the main reconcile loop in the future.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Adds finalizers on machines that are adopted by the machine controller. Without this change, it causes issues while migrating machine objects between clusters. 
```

/assign @AxiomSamarth 
cc: @plkokanov 