### PR TITLE
fix to propagate the error on to the dashboard

### DIFF
--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -838,7 +838,7 @@ func (c *controller) getVMStatus(getMachineStatusRequest *driver.GetMachineStatu
 	} else {
 		if machineErr, ok := status.FromError(err); !ok {
 			// Error occurred with decoding machine error status, aborting without retry.
-			description = "Error occurred with decoding machine error status while getting VM status, aborting without retry. " + machineutils.GetVMStatus
+			description = "Error occurred with decoding machine error status while getting VM status, aborting without retry. " + err.Error() + " " + machineutils.GetVMStatus
 			state = v1alpha1.MachineStateFailed
 			retry = machineutils.LongRetry
 
@@ -867,7 +867,7 @@ func (c *controller) getVMStatus(getMachineStatusRequest *driver.GetMachineStatu
 
 			default:
 				// Error occurred with decoding machine error status, abort with retry.
-				description = "Error occurred with decoding machine error status while getting VM status, aborting without retry. machine code: " + machineErr.Message() + " " + machineutils.GetVMStatus
+				description = "Error occurred with decoding machine error status while getting VM status, aborting without retry. machine code: " + err.Error() + " " + machineutils.GetVMStatus
 				state = v1alpha1.MachineStateFailed
 				retry = machineutils.MediumRetry
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will propagate the error message from the providers onto the dashboard properly

**Which issue(s) this PR fixes**:
Fixes [#33](https://github.com/gardener/machine-controller-manager-provider-azure/issues/33)

**Special notes for your reviewer**:
The PR is yet to be tested against a cluster

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
