### PR TITLE
Replace integration test with unit test to test the functionality to freeze MachineSet

### DIFF
--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -366,10 +366,10 @@ function tc_machine_deployment() {
     printf "\n\tWaiting 1800s for 3 machines to join the cluster"
     hf_wait_on "hf_num_of_ready_nodes" nodes 3 1800
 
-    # Scale up the number of nodes to 6 and rapidly scale back to 2
-    hf_object_configure $provider/md-scale-up.yaml
-    printf "\n\tScale up the number of nodes to 6 and rapidly scale back to 2 leading to a freezing and unfreezing"
-    sleep 20
+    # # Scale up the number of nodes to 6 and rapidly scale back to 2
+    # hf_object_configure $provider/md-scale-up.yaml
+    # printf "\n\tScale up the number of nodes to 6 and rapidly scale back to 2 leading to a freezing and unfreezing"
+    # sleep 20
 
     # Scale down the number of nodes to 2
     hf_object_configure $provider/md-scale-down.yaml
@@ -386,10 +386,10 @@ function tc_machine_deployment() {
     printf "\n\tWaiting 1800s for machine to be deleted"
     hf_wait_on "hf_num_of_objects" machdeploy 0 1800
 
-    # Scaling from 6 to 2 should lead to freezing and unfreezing of machine-set
-    printf "\n\tCheck for freezing and unfreezing of machine-set due to rapid scaleUp and scaleDown"
-    hf_check_ms_freeze
-    printf "\n\tFreezing and unfreezing of machineSet was observed"
+    # # Scaling from 6 to 2 should lead to freezing and unfreezing of machine-set
+    # printf "\n\tCheck for freezing and unfreezing of machine-set due to rapid scaleUp and scaleDown"
+    # hf_check_ms_freeze
+    # printf "\n\tFreezing and unfreezing of machineSet was observed"
 
     printf "\nCompleted TestCase\n"
 }

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -184,8 +184,8 @@ func (c *controller) reconcileClusterMachine(machine *v1alpha1.Machine) (machine
 	Machine controller - nodeToMachine
 */
 var (
-	multipleMachineMatchError = errors.New("Multiple machines matching node")
-	noMachineMatchError       = errors.New("No machines matching node found")
+	errMultipleMachineMatch = errors.New("Multiple machines matching node")
+	errNoMachineMatch       = errors.New("No machines matching node found")
 )
 
 func (c *controller) addNodeToMachine(obj interface{}) {
@@ -196,7 +196,7 @@ func (c *controller) addNodeToMachine(obj interface{}) {
 		return
 	}
 
-	 // If NotManagedByMCM annotation is present on node, don't process this node object
+	// If NotManagedByMCM annotation is present on node, don't process this node object
 	if _, annotationPresent := node.ObjectMeta.Annotations[machineutils.NotManagedByMCM]; annotationPresent {
 		return
 	}
@@ -255,9 +255,9 @@ func (c *controller) getMachineFromNode(nodeName string) (*v1alpha1.Machine, err
 	machines, _ := c.machineLister.List(selector)
 
 	if len(machines) > 1 {
-		return nil, multipleMachineMatchError
+		return nil, errMultipleMachineMatch
 	} else if len(machines) < 1 {
-		return nil, noMachineMatchError
+		return nil, errNoMachineMatch
 	}
 	return machines[0], nil
 }

--- a/pkg/util/provider/machinecontroller/machine_safety.go
+++ b/pkg/util/provider/machinecontroller/machine_safety.go
@@ -179,9 +179,9 @@ func (c *controller) AnnotateNodesUnmanagedByMCM() (machineutils.RetryPeriod, er
 	for _, node := range nodes {
 		_, err := c.getMachineFromNode(node.Name)
 		if err != nil {
-			if err == multipleMachineMatchError {
+			if err == errMultipleMachineMatch {
 				klog.Errorf("Couldn't fetch machine, Error: %s", err)
-			} else if err == noMachineMatchError {
+			} else if err == errNoMachineMatch {
 				//if no backing machine for a node,means annotate it
 				if _, annotationPresent := node.ObjectMeta.Annotations[machineutils.NotManagedByMCM]; annotationPresent {
 					continue


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces an integration test with a unit test that tests the functionality of adding a freeze label on the MachineSet when there is overshooting

**Which issue(s) this PR fixes**:
Fixes #619 

**Special notes for your reviewer**:
I have only commented out the unwanted integration test in this PR. Once, it is merged and we know for sure that this works fine, in the subsequent PRs of K8s vendoring I will have it removed from the code.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Replace integration test with unit test to test the functionality to freeze MachineSet
```
