### PR TITLE
Restore integration test along with UTs 

### DIFF
--- a/.ci/integration-tests
+++ b/.ci/integration-tests
@@ -148,7 +148,7 @@ function run_controller() {
         --machine-safety-apiserver-statuscheck-timeout=30s \
         --machine-safety-apiserver-statuscheck-period=1m \
         --machine-safety-orphan-vms-period=30m \
-        --machine-safety-overshooting-period=300ms \
+        --machine-safety-overshooting-period=100ms \
         --leader-elect-lease-duration=1m \
         --leader-elect-renew-deadline=30s \
         --leader-elect-retry-period=15s \
@@ -367,9 +367,9 @@ function tc_machine_deployment() {
     hf_wait_on "hf_num_of_ready_nodes" nodes 3 1800
 
     # # Scale up the number of nodes to 6 and rapidly scale back to 2
-    # hf_object_configure $provider/md-scale-up.yaml
-    # printf "\n\tScale up the number of nodes to 6 and rapidly scale back to 2 leading to a freezing and unfreezing"
-    # sleep 20
+    hf_object_configure $provider/md-scale-up.yaml
+    printf "\n\tScale up the number of nodes to 6 and rapidly scale back to 2 leading to a freezing and unfreezing"
+    sleep 20
 
     # Scale down the number of nodes to 2
     hf_object_configure $provider/md-scale-down.yaml
@@ -387,9 +387,9 @@ function tc_machine_deployment() {
     hf_wait_on "hf_num_of_objects" machdeploy 0 1800
 
     # # Scaling from 6 to 2 should lead to freezing and unfreezing of machine-set
-    # printf "\n\tCheck for freezing and unfreezing of machine-set due to rapid scaleUp and scaleDown"
-    # hf_check_ms_freeze
-    # printf "\n\tFreezing and unfreezing of machineSet was observed"
+    printf "\n\tCheck for freezing and unfreezing of machine-set due to rapid scaleUp and scaleDown"
+    hf_check_ms_freeze
+    printf "\n\tFreezing and unfreezing of machineSet was observed"
 
     printf "\nCompleted TestCase\n"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is experimental to test if the race condition really occurs during rapid scale up and scale down. The overshooting period has been modified to 2s to checkout the scenario. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
If this integration tests pass then we are good with replacing the integration tests with UT. Otherwise, we may have to check and fix the possible occurrence of the race condition between MachineSet Controller and MachineSafetyController.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
