### PR TITLE
Fixes regressions from PR#593 and PR#612 

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -208,7 +208,12 @@ func (c *controller) addNodeToMachine(obj interface{}) {
 	}
 
 	machine, err := c.getMachineFromNode(key)
-	if err != nil {
+	if err != nil && err != errNoMachineMatch {
+		if err != errNoMachineMatch {
+			// errNoMachineMatch could mean that VM is still in creation hence ignoring it
+			return
+		}
+
 		klog.Errorf("Couldn't fetch machine %s, Error: %s", key, err)
 		return
 	}
@@ -259,6 +264,7 @@ func (c *controller) getMachineFromNode(nodeName string) (*v1alpha1.Machine, err
 	} else if len(machines) < 1 {
 		return nil, errNoMachineMatch
 	}
+
 	return machines[0], nil
 }
 

--- a/pkg/util/provider/machinecontroller/machine_safety_util.go
+++ b/pkg/util/provider/machinecontroller/machine_safety_util.go
@@ -18,11 +18,11 @@ func (c *controller) updateNodeWithAnnotation(node *v1.Node, annotations map[str
 	}
 
 	_, err := c.targetCoreClient.CoreV1().Nodes().Update(node)
-
 	if err != nil {
 		klog.Errorf("Couldn't patch the node %q , Error: %s", node.Name, err)
 		return err
 	}
+	klog.V(2).Infof("Annotated node %q was annotated with NotManagedByMCM successfully", node.Name)
 
 	return nil
 }

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -124,10 +124,13 @@ func (c *controller) ValidateMachineClass(classSpec *v1alpha1.ClassSpec) (*v1alp
 	}
 
 	if finalizers := sets.NewString(machineClass.Finalizers...); !finalizers.Has(MCMFinalizerName) {
-		klog.Errorf("The machine class %s has no finalizers set. So not reconciling the machine.", machineClass.Name)
 		c.machineClassQueue.Add(machineClass.Name)
-		err := errors.New("The machine class %s has no finalizers set. So not reconciling the machine." + machineClass.Name)
-		return nil, nil, retry, err
+
+		errMessage := fmt.Sprintf("The machine class %s has no finalizers set. So not reconciling the machine.", machineClass.Name)
+		err := errors.New(errMessage)
+		klog.Warning(errMessage)
+
+		return nil, nil, machineutils.ShortRetry, err
 	}
 
 	return machineClass, secretData, retry, nil

--- a/pkg/util/provider/machinecontroller/machineclass.go
+++ b/pkg/util/provider/machinecontroller/machineclass.go
@@ -146,24 +146,34 @@ func (c *controller) reconcileClusterMachineClass(class *v1alpha1.MachineClass) 
 		return err
 	}
 
-	// fetch all machines referring the machineClass
+	// Fetch all machines referring the machineClass
 	machines, err := c.findMachinesForClass(machineutils.MachineClassKind, class.Name)
 	if err != nil {
 		return err
 	}
 
-	// Add finalizer to avoid losing machineClass object
 	if class.DeletionTimestamp == nil && len(machines) > 0 {
-		err = c.addMachineClassFinalizers(class)
-		if err != nil {
-			return err
+		// If deletionTimestamp is not set and more than one machines are referring this machineClass
+
+		if finalizers := sets.NewString(class.Finalizers...); !finalizers.Has(MCMFinalizerName) {
+			// Add machineClassFinalizer as if doesn't exist
+			err = c.addMachineClassFinalizers(class)
+			if err != nil {
+				return err
+			}
+
+			// Enqueue all machines once finalizer is added to machineClass
+			// This is to allow processing of such machines
+			for _, machine := range machines {
+				c.enqueueMachine(machine)
+			}
 		}
 
 		return nil
 	}
 
 	if len(machines) > 0 {
-		// machines are still referring the machine class, please wait before deletion
+		// Machines are still referring the machine class, please wait before deletion
 		klog.V(3).Infof("Cannot remove finalizer on %s because still (%d) machines are referencing it", class.Name, len(machines))
 
 		for _, machine := range machines {
@@ -173,8 +183,12 @@ func (c *controller) reconcileClusterMachineClass(class *v1alpha1.MachineClass) 
 		return fmt.Errorf("Retry as machine objects are still referring the machineclass")
 	}
 
-	// delete machine class finalizer if exists
-	return c.deleteMachineClassFinalizers(class)
+	if finalizers := sets.NewString(class.Finalizers...); finalizers.Has(MCMFinalizerName) {
+		// Delete finalizer if exists on machineClass
+		return c.deleteMachineClassFinalizers(class)
+	}
+
+	return nil
 }
 
 /*
@@ -183,23 +197,15 @@ func (c *controller) reconcileClusterMachineClass(class *v1alpha1.MachineClass) 
 */
 
 func (c *controller) addMachineClassFinalizers(class *v1alpha1.MachineClass) error {
-	clone := class.DeepCopy()
-
-	if finalizers := sets.NewString(clone.Finalizers...); !finalizers.Has(MCMFinalizerName) {
-		finalizers.Insert(MCMFinalizerName)
-		return c.updateMachineClassFinalizers(clone, finalizers.List())
-	}
-	return nil
+	finalizers := sets.NewString(class.Finalizers...)
+	finalizers.Insert(MCMFinalizerName)
+	return c.updateMachineClassFinalizers(class, finalizers.List())
 }
 
 func (c *controller) deleteMachineClassFinalizers(class *v1alpha1.MachineClass) error {
-	clone := class.DeepCopy()
-
-	if finalizers := sets.NewString(clone.Finalizers...); finalizers.Has(MCMFinalizerName) {
-		finalizers.Delete(MCMFinalizerName)
-		return c.updateMachineClassFinalizers(clone, finalizers.List())
-	}
-	return nil
+	finalizers := sets.NewString(class.Finalizers...)
+	finalizers.Delete(MCMFinalizerName)
+	return c.updateMachineClassFinalizers(class, finalizers.List())
 }
 
 func (c *controller) updateMachineClassFinalizers(class *v1alpha1.MachineClass, finalizers []string) error {

--- a/pkg/util/provider/machinecontroller/machineclass.go
+++ b/pkg/util/provider/machinecontroller/machineclass.go
@@ -153,7 +153,7 @@ func (c *controller) reconcileClusterMachineClass(class *v1alpha1.MachineClass) 
 	}
 
 	if class.DeletionTimestamp == nil && len(machines) > 0 {
-		// If deletionTimestamp is not set and more than one machines are referring this machineClass
+		// If deletionTimestamp is not set and at least one machine is referring this machineClass
 
 		if finalizers := sets.NewString(class.Finalizers...); !finalizers.Has(MCMFinalizerName) {
 			// Add machineClassFinalizer as if doesn't exist


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes regressions from https://github.com/gardener/machine-controller-manager/pull/593 and https://github.com/gardener/machine-controller-manager/pull/612. 

**Which issue(s) this PR fixes**:
Fixes #625 

- MachineClass finalizer error to retry sooner 
- Enqueue machines on MC finalizer addition
- Annotate NotManagedByMCM only post creationTimeout

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
/invite @himanshu-kun @AxiomSamarth 