### PR TITLE
Allow controlled machine drain and rollout

### DIFF
--- a/pkg/controller/deployment_rolling.go
+++ b/pkg/controller/deployment_rolling.go
@@ -377,7 +377,7 @@ func (dc *controller) annotateNodesBackingMachineSets(MachineSets []*v1alpha1.Ma
 
 	for _, machineSet := range MachineSets {
 
-		klog.V(3).Infof("Trying to annotate nodes under the MachineSet object %q with %s", machineSet.Name, annotations)
+		klog.V(4).Infof("Trying to annotate nodes under the MachineSet object %q with %s", machineSet.Name, annotations)
 		selector, err := metav1.LabelSelectorAsSelector(machineSet.Spec.Selector)
 		if err != nil {
 			return err
@@ -409,7 +409,7 @@ func (dc *controller) annotateNodesBackingMachineSets(MachineSets []*v1alpha1.Ma
 				}
 			}
 		}
-		klog.V(2).Infof("Annotated the nodes backed by MachineSet %q with %s", machineSet.Name, annotations)
+		klog.V(4).Infof("Annotated the nodes backed by MachineSet %q with %s", machineSet.Name, annotations)
 	}
 
 	return nil
@@ -472,7 +472,7 @@ func (dc *controller) removeAutoscalerAnnotationsIfRequired(MachineSets []*v1alp
 						klog.Warningf("Removing annotation failed for node: %s, %s", machine.Status.Node, err)
 						return err
 					}
-					klog.V(3).Infof("De-annotated the node %q backed by MachineSet %q with %s", machine.Status.Node, machineSet.Name, annotations)
+					klog.V(4).Infof("De-annotated the node %q backed by MachineSet %q with %s", machine.Status.Node, machineSet.Name, annotations)
 				}
 			}
 		}

--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -1092,7 +1092,7 @@ func NewISNewReplicas(deployment *v1alpha1.MachineDeployment, allISs []*v1alpha1
 			return 0, err
 		}
 		// Find the total number of machines
-		currentMachineCount := GetReplicaCountForMachineSets(allISs)
+		currentMachineCount := GetActualReplicaCountForMachineSets(allISs)
 		maxTotalMachines := (deployment.Spec.Replicas) + int32(maxSurge)
 		if currentMachineCount >= maxTotalMachines {
 			// Cannot scale up.

--- a/pkg/util/nodeops/taints.go
+++ b/pkg/util/nodeops/taints.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	clientretry "k8s.io/client-go/util/retry"
+	"k8s.io/klog"
 )
 
 // Backoff is the backoff period used while updating nodes
@@ -76,6 +77,8 @@ func AddOrUpdateTaintOnNode(c clientset.Interface, nodeName string, taints ...*v
 		if !updated {
 			return nil
 		}
+
+		klog.V(4).Infof("Trying to taint node %q to avoid scheduling of pods", nodeName)
 		return UpdateNodeTaints(c, nodeName, oldNode, newNode)
 	})
 }

--- a/pkg/util/provider/drain/volume_attachment.go
+++ b/pkg/util/provider/drain/volume_attachment.go
@@ -52,13 +52,19 @@ func (v *VolumeAttachmentHandler) dispatch(obj interface{}) {
 	}
 
 	klog.V(4).Infof("Dispatching request for PV %s", *volumeAttachment.Spec.Source.PersistentVolumeName)
+	defer klog.V(4).Infof("Done dispatching request for PV %s", *volumeAttachment.Spec.Source.PersistentVolumeName)
 
 	v.Lock()
 	defer v.Unlock()
 
 	for i, worker := range v.workers {
-		klog.V(4).Infof("Dispatching request for PV %s to worker %d", *volumeAttachment.Spec.Source.PersistentVolumeName, i)
-		worker <- volumeAttachment
+		klog.V(4).Infof("Dispatching request for PV %s to worker %d/%v", *volumeAttachment.Spec.Source.PersistentVolumeName, i, worker)
+
+		select {
+		case worker <- volumeAttachment:
+		default:
+			klog.Warningf("Worker %d/%v is full. Discarding value.", i, worker)
+		}
 	}
 }
 
@@ -78,9 +84,10 @@ func (v *VolumeAttachmentHandler) UpdateVolumeAttachment(oldObj, newObj interfac
 func (v *VolumeAttachmentHandler) AddWorker() chan *storagev1.VolumeAttachment {
 	// chanSize is the channel buffer size to hold requests.
 	// This assumes that not more than 20 unprocessed objects would exist at a given time.
+	// On bufferring requests beyond this the channel will start dropping writes
 	const chanSize = 20
 
-	klog.V(4).Infof("Adding new worker. Current active workers %d", len(v.workers))
+	klog.V(4).Infof("Adding new worker. Current active workers %d - %v", len(v.workers), v.workers)
 
 	v.Lock()
 	defer v.Unlock()
@@ -88,13 +95,13 @@ func (v *VolumeAttachmentHandler) AddWorker() chan *storagev1.VolumeAttachment {
 	newWorker := make(chan *storagev1.VolumeAttachment, chanSize)
 	v.workers = append(v.workers, newWorker)
 
-	klog.V(4).Infof("Successfully added new worker %v. Current active workers %d", newWorker, len(v.workers))
+	klog.V(4).Infof("Successfully added new worker %v. Current active workers %d - %v", newWorker, len(v.workers), v.workers)
 	return newWorker
 }
 
 // DeleteWorker is the method used to delete an existing worker
 func (v *VolumeAttachmentHandler) DeleteWorker(desiredWorker chan *storagev1.VolumeAttachment) {
-	klog.V(4).Infof("Deleting an existing worker %v. Current active workers %d", desiredWorker, len(v.workers))
+	klog.V(4).Infof("Deleting an existing worker %v. Current active workers %d - %v", desiredWorker, len(v.workers), v.workers)
 
 	v.Lock()
 	defer v.Unlock()
@@ -111,5 +118,5 @@ func (v *VolumeAttachmentHandler) DeleteWorker(desiredWorker chan *storagev1.Vol
 	}
 
 	v.workers = finalWorkers
-	klog.V(4).Infof("Successfully removed worker. Current active workers %d", len(v.workers))
+	klog.V(4).Infof("Successfully removed worker. Current active workers %d - %v", len(v.workers), v.workers)
 }

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -208,8 +208,8 @@ func (c *controller) addNodeToMachine(obj interface{}) {
 	}
 
 	machine, err := c.getMachineFromNode(key)
-	if err != nil && err != errNoMachineMatch {
-		if err != errNoMachineMatch {
+	if err != nil {
+		if err == errNoMachineMatch {
 			// errNoMachineMatch could mean that VM is still in creation hence ignoring it
 			return
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Machine rollouts are now more as desired with the number of replicas always maintained to `desired + maxSurge`. Earlier machines in termination were left out of this calculation but now is considered.
- Avoids blocking of drain call when the buffer is full for the `volumeAttachmentHandlers`. 
- `volumeAttachmentHandlers` are always closed now even on failure cases. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Machine rollouts are now more as desired with the number of replicas always maintained to `desired + maxSurge`. Earlier machines in termination were left out of this calculation but now is considered with this change.
```
```bugfix operator
Avoids blocking of drain call when the buffer is full for the volumeAttachmentHandlers. 
```

