### PR TITLE
Clarify when to apply the force deletion label

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -109,7 +109,7 @@ Each `machine` object has an annotation `machinepriority.machine.sapcloud.io` se
 
 ### How to force delete a machine?
 
-A machine can be force deleted by adding the label `force-deletion: "True"` on the `machine` object if it's already being deleted. During force deletion, MCM skips the drain function and simply triggers the deletion of the machine. This label should be used with caution as it can violate the PDBs for pods running on the machine.
+A machine can be force deleted by adding the label `force-deletion: "True"` on the `machine` object before executing the actual delete command. During force deletion, MCM skips the drain function and simply triggers the deletion of the machine. This label should be used with caution as it can violate the PDBs for pods running on the machine.
 
 ### How to pause the ongoing rolling-update of the machinedeployment?
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The existing doc said that the label `force-deletion: "True"` should be applied when the machine object was already in deletion.
However it only works if the label is present when invoking `kubectl delete machine xxx`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
