### PR TITLE
Increasing concurrent object syncs to 50

### DIFF
--- a/pkg/util/provider/app/options/options.go
+++ b/pkg/util/provider/app/options/options.go
@@ -54,7 +54,7 @@ func NewMCServer() *MCServer {
 			Port:                    10259,
 			Namespace:               "default",
 			Address:                 "0.0.0.0",
-			ConcurrentNodeSyncs:     10,
+			ConcurrentNodeSyncs:     50,
 			ContentType:             "application/vnd.kubernetes.protobuf",
 			NodeConditions:          "KernelDeadlock,ReadonlyFilesystem,DiskPressure,NetworkUnavailable",
 			MinResyncPeriod:         metav1.Duration{Duration: 12 * time.Hour},


### PR DESCRIPTION
**What this PR does / why we need it**:
Increase concurrent object syncs to 50 to allow concurrent object reconciles especially in cases such as machine drains to allow more parallel drains. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to https://github.com/gardener/machine-controller-manager/pull/491. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Increase default concurrent object syncs to 50 to allow more concurrent reconciles to occur.
```
/invite @amshuman-kr @AxiomSamarth 
