### PR TITLE
using controller-gen latest version for crd generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/kubernetes/crds/machine.sapcloud.io_alicloudmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_alicloudmachineclasses.yaml
@@ -4,24 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: alicloudmachineclasses.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.instanceType
-    name: Instance Type
-    type: string
-  - JSONPath: .spec.region
-    name: Region
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: AlicloudMachineClass
@@ -29,131 +15,144 @@ spec:
     plural: alicloudmachineclasses
     singular: alicloudmachineclass
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: AlicloudMachineClass TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AlicloudMachineClassSpec is the specification of a AlicloudMachineClass.
-          properties:
-            IoOptimized:
-              type: string
-            credentialsSecretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            dataDisks:
-              items:
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.instanceType
+      name: Instance Type
+      type: string
+    - jsonPath: .spec.region
+      name: Region
+      priority: 1
+      type: string
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AlicloudMachineClass TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AlicloudMachineClassSpec is the specification of a AlicloudMachineClass.
+            properties:
+              IoOptimized:
+                type: string
+              credentialsSecretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              dataDisks:
+                items:
+                  properties:
+                    category:
+                      type: string
+                    deleteWithInstance:
+                      type: boolean
+                    description:
+                      type: string
+                    encrypted:
+                      type: boolean
+                    name:
+                      type: string
+                    size:
+                      type: integer
+                  required:
+                  - category
+                  - deleteWithInstance
+                  - encrypted
+                  - name
+                  - size
+                  type: object
+                type: array
+              imageID:
+                type: string
+              instanceChargeType:
+                type: string
+              instanceType:
+                type: string
+              internetChargeType:
+                type: string
+              internetMaxBandwidthIn:
+                type: integer
+              internetMaxBandwidthOut:
+                type: integer
+              keyPairName:
+                type: string
+              privateIPAddress:
+                type: string
+              region:
+                type: string
+              secretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              securityGroupID:
+                type: string
+              spotStrategy:
+                type: string
+              systemDisk:
+                description: AlicloudSystemDisk describes SystemDisk for Alicloud.
                 properties:
                   category:
-                    type: string
-                  deleteWithInstance:
-                    type: boolean
-                  description:
-                    type: string
-                  encrypted:
-                    type: boolean
-                  name:
                     type: string
                   size:
                     type: integer
                 required:
                 - category
-                - deleteWithInstance
-                - encrypted
-                - name
                 - size
                 type: object
-              type: array
-            imageID:
-              type: string
-            instanceChargeType:
-              type: string
-            instanceType:
-              type: string
-            internetChargeType:
-              type: string
-            internetMaxBandwidthIn:
-              type: integer
-            internetMaxBandwidthOut:
-              type: integer
-            keyPairName:
-              type: string
-            privateIPAddress:
-              type: string
-            region:
-              type: string
-            secretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
+              tags:
+                additionalProperties:
                   type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            securityGroupID:
-              type: string
-            spotStrategy:
-              type: string
-            systemDisk:
-              description: AlicloudSystemDisk describes SystemDisk for Alicloud.
-              properties:
-                category:
-                  type: string
-                size:
-                  type: integer
-              required:
-              - category
-              - size
-              type: object
-            tags:
-              additionalProperties:
+                type: object
+              vSwitchID:
                 type: string
-              type: object
-            vSwitchID:
-              type: string
-            zoneID:
-              type: string
-          required:
-          - imageID
-          - instanceType
-          - keyPairName
-          - region
-          - vSwitchID
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              zoneID:
+                type: string
+            required:
+            - imageID
+            - instanceType
+            - keyPairName
+            - region
+            - vSwitchID
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
@@ -4,27 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: awsmachineclasses.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.machineType
-    name: Machine Type
-    type: string
-  - JSONPath: .spec.ami
-    name: AMI
-    type: string
-  - JSONPath: .spec.region
-    name: Region
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: AWSMachineClass
@@ -32,203 +15,222 @@ spec:
     plural: awsmachineclasses
     singular: awsmachineclass
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: AWSMachineClass TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AWSMachineClassSpec is the specification of a AWSMachineClass.
-          properties:
-            ami:
-              type: string
-            blockDevices:
-              items:
-                properties:
-                  deviceName:
-                    description: The device name exposed to the machine (for example,
-                      /dev/sdh or xvdh).
-                    type: string
-                  ebs:
-                    description: Parameters used to automatically set up EBS volumes
-                      when the machine is launched.
-                    properties:
-                      deleteOnTermination:
-                        description: Indicates whether the EBS volume is deleted on
-                          machine termination.
-                        type: boolean
-                      encrypted:
-                        description: Indicates whether the EBS volume is encrypted.
-                          Encrypted Amazon EBS volumes may only be attached to machines
-                          that support Amazon EBS encryption.
-                        type: boolean
-                      iops:
-                        description: "The number of I/O operations per second (IOPS)
-                          that the volume supports. For io1, this represents the number
-                          of IOPS that are provisioned for the volume. For gp2, this
-                          represents the baseline performance of the volume and the
-                          rate at which the volume accumulates I/O credits for bursting.
-                          For more information about General Purpose SSD baseline
-                          performance, I/O credits, and bursting, see Amazon EBS Volume
-                          Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
-                          in the Amazon Elastic Compute Cloud User Guide. \n Constraint:
-                          Range is 100-20000 IOPS for io1 volumes and 100-10000 IOPS
-                          for gp2 volumes. \n Condition: This parameter is required
-                          for requests to create io1 volumes; it is not used in requests
-                          to create gp2, st1, sc1, or standard volumes."
-                        format: int64
-                        type: integer
-                      kmsKeyID:
-                        description: "Identifier (key ID, key alias, ID ARN, or alias
-                          ARN) for a customer managed CMK under which the EBS volume
-                          is encrypted. \n This parameter is only supported on BlockDeviceMapping
-                          objects called by RunInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html),
-                          RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html),
-                          and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html)."
-                        type: string
-                      snapshotID:
-                        description: The ID of the snapshot.
-                        type: string
-                      volumeSize:
-                        description: "The size of the volume, in GiB. \n Constraints:
-                          1-16384 for General Purpose SSD (gp2), 4-16384 for Provisioned
-                          IOPS SSD (io1), 500-16384 for Throughput Optimized HDD (st1),
-                          500-16384 for Cold HDD (sc1), and 1-1024 for Magnetic (standard)
-                          volumes. If you specify a snapshot, the volume size must
-                          be equal to or larger than the snapshot size. \n Default:
-                          If you're creating the volume from a snapshot and don't
-                          specify a volume size, the default is the snapshot size."
-                        format: int64
-                        type: integer
-                      volumeType:
-                        description: "The volume type: gp2, io1, st1, sc1, or standard.
-                          \n Default: standard"
-                        type: string
-                    type: object
-                  noDevice:
-                    description: Suppresses the specified device included in the block
-                      device mapping of the AMI.
-                    type: string
-                  virtualName:
-                    description: "The virtual device name (ephemeralN). Machine store
-                      volumes are numbered starting from 0. An machine type with 2
-                      available machine store volumes can specify mappings for ephemeral0
-                      and ephemeral1.The number of available machine store volumes
-                      depends on the machine type. After you connect to the machine,
-                      you must mount the volume. \n Constraints: For M3 machines,
-                      you must specify machine store volumes in the block device mapping
-                      for the machine. When you launch an M3 machine, we ignore any
-                      machine store volumes specified in the block device mapping
-                      for the AMI."
-                    type: string
-                type: object
-              type: array
-            credentialsSecretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            ebsOptimized:
-              type: boolean
-            iam:
-              description: Describes an IAM machine profile.
-              properties:
-                arn:
-                  description: The Amazon Resource Name (ARN) of the machine profile.
-                  type: string
-                name:
-                  description: The name of the machine profile.
-                  type: string
-              type: object
-            keyName:
-              type: string
-            machineType:
-              type: string
-            monitoring:
-              type: boolean
-            networkInterfaces:
-              items:
-                description: Describes a network interface. Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/MachineAWSNetworkInterfaceSpecification
-                properties:
-                  associatePublicIPAddress:
-                    description: Indicates whether to assign a public IPv4 address
-                      to an machine you launch in a VPC. The public IP address can
-                      only be assigned to a network interface for eth0, and can only
-                      be assigned to a new network interface, not an existing one.
-                      You cannot specify more than one network interface in the request.
-                      If launching into a default subnet, the default value is true.
-                    type: boolean
-                  deleteOnTermination:
-                    description: If set to true, the interface is deleted when the
-                      machine is terminated. You can specify true only if creating
-                      a new network interface when launching an machine.
-                    type: boolean
-                  description:
-                    description: The description of the network interface. Applies
-                      only if creating a network interface when launching an machine.
-                    type: string
-                  securityGroupIDs:
-                    description: The IDs of the security groups for the network interface.
-                      Applies only if creating a network interface when launching
-                      an machine.
-                    items:
-                      type: string
-                    type: array
-                  subnetID:
-                    description: The ID of the subnet associated with the network
-                      string. Applies only if creating a network interface when launching
-                      an machine.
-                    type: string
-                type: object
-              type: array
-            region:
-              type: string
-            secretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            spotPrice:
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              type: object
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.machineType
+      name: Machine Type
+      type: string
+    - jsonPath: .spec.ami
+      name: AMI
+      type: string
+    - jsonPath: .spec.region
+      name: Region
+      priority: 1
+      type: string
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AWSMachineClass TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSMachineClassSpec is the specification of a AWSMachineClass.
+            properties:
+              ami:
+                type: string
+              blockDevices:
+                items:
+                  properties:
+                    deviceName:
+                      description: The device name exposed to the machine (for example,
+                        /dev/sdh or xvdh).
+                      type: string
+                    ebs:
+                      description: Parameters used to automatically set up EBS volumes
+                        when the machine is launched.
+                      properties:
+                        deleteOnTermination:
+                          description: Indicates whether the EBS volume is deleted
+                            on machine termination.
+                          type: boolean
+                        encrypted:
+                          description: Indicates whether the EBS volume is encrypted.
+                            Encrypted Amazon EBS volumes may only be attached to machines
+                            that support Amazon EBS encryption.
+                          type: boolean
+                        iops:
+                          description: "The number of I/O operations per second (IOPS)
+                            that the volume supports. For io1, this represents the
+                            number of IOPS that are provisioned for the volume. For
+                            gp2, this represents the baseline performance of the volume
+                            and the rate at which the volume accumulates I/O credits
+                            for bursting. For more information about General Purpose
+                            SSD baseline performance, I/O credits, and bursting, see
+                            Amazon EBS Volume Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html)
+                            in the Amazon Elastic Compute Cloud User Guide. \n Constraint:
+                            Range is 100-20000 IOPS for io1 volumes and 100-10000
+                            IOPS for gp2 volumes. \n Condition: This parameter is
+                            required for requests to create io1 volumes; it is not
+                            used in requests to create gp2, st1, sc1, or standard
+                            volumes."
+                          format: int64
+                          type: integer
+                        kmsKeyID:
+                          description: "Identifier (key ID, key alias, ID ARN, or
+                            alias ARN) for a customer managed CMK under which the
+                            EBS volume is encrypted. \n This parameter is only supported
+                            on BlockDeviceMapping objects called by RunInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html),
+                            RequestSpotFleet (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotFleet.html),
+                            and RequestSpotInstances (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RequestSpotInstances.html)."
+                          type: string
+                        snapshotID:
+                          description: The ID of the snapshot.
+                          type: string
+                        volumeSize:
+                          description: "The size of the volume, in GiB. \n Constraints:
+                            1-16384 for General Purpose SSD (gp2), 4-16384 for Provisioned
+                            IOPS SSD (io1), 500-16384 for Throughput Optimized HDD
+                            (st1), 500-16384 for Cold HDD (sc1), and 1-1024 for Magnetic
+                            (standard) volumes. If you specify a snapshot, the volume
+                            size must be equal to or larger than the snapshot size.
+                            \n Default: If you're creating the volume from a snapshot
+                            and don't specify a volume size, the default is the snapshot
+                            size."
+                          format: int64
+                          type: integer
+                        volumeType:
+                          description: "The volume type: gp2, io1, st1, sc1, or standard.
+                            \n Default: standard"
+                          type: string
+                      type: object
+                    noDevice:
+                      description: Suppresses the specified device included in the
+                        block device mapping of the AMI.
+                      type: string
+                    virtualName:
+                      description: "The virtual device name (ephemeralN). Machine
+                        store volumes are numbered starting from 0. An machine type
+                        with 2 available machine store volumes can specify mappings
+                        for ephemeral0 and ephemeral1.The number of available machine
+                        store volumes depends on the machine type. After you connect
+                        to the machine, you must mount the volume. \n Constraints:
+                        For M3 machines, you must specify machine store volumes in
+                        the block device mapping for the machine. When you launch
+                        an M3 machine, we ignore any machine store volumes specified
+                        in the block device mapping for the AMI."
+                      type: string
+                  type: object
+                type: array
+              credentialsSecretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              ebsOptimized:
+                type: boolean
+              iam:
+                description: Describes an IAM machine profile.
+                properties:
+                  arn:
+                    description: The Amazon Resource Name (ARN) of the machine profile.
+                    type: string
+                  name:
+                    description: The name of the machine profile.
+                    type: string
+                type: object
+              keyName:
+                type: string
+              machineType:
+                type: string
+              monitoring:
+                type: boolean
+              networkInterfaces:
+                items:
+                  description: Describes a network interface. Please also see https://docs.aws.amazon.com/goto/WebAPI/ec2-2016-11-15/MachineAWSNetworkInterfaceSpecification
+                  properties:
+                    associatePublicIPAddress:
+                      description: Indicates whether to assign a public IPv4 address
+                        to an machine you launch in a VPC. The public IP address can
+                        only be assigned to a network interface for eth0, and can
+                        only be assigned to a new network interface, not an existing
+                        one. You cannot specify more than one network interface in
+                        the request. If launching into a default subnet, the default
+                        value is true.
+                      type: boolean
+                    deleteOnTermination:
+                      description: If set to true, the interface is deleted when the
+                        machine is terminated. You can specify true only if creating
+                        a new network interface when launching an machine.
+                      type: boolean
+                    description:
+                      description: The description of the network interface. Applies
+                        only if creating a network interface when launching an machine.
+                      type: string
+                    securityGroupIDs:
+                      description: The IDs of the security groups for the network
+                        interface. Applies only if creating a network interface when
+                        launching an machine.
+                      items:
+                        type: string
+                      type: array
+                    subnetID:
+                      description: The ID of the subnet associated with the network
+                        string. Applies only if creating a network interface when
+                        launching an machine.
+                      type: string
+                  type: object
+                type: array
+              region:
+                type: string
+              secretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              spotPrice:
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_azuremachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_azuremachineclasses.yaml
@@ -4,24 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: azuremachineclasses.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.properties.hardwareProfile.vmSize
-    name: VM Size
-    type: string
-  - JSONPath: .spec.location
-    name: Location
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: AzureMachineClass
@@ -29,235 +15,248 @@ spec:
     plural: azuremachineclasses
     singular: azuremachineclass
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: AzureMachineClass TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AzureMachineClassSpec is the specification of a AzureMachineClass.
-          properties:
-            credentialsSecretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            location:
-              type: string
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.properties.hardwareProfile.vmSize
+      name: VM Size
+      type: string
+    - jsonPath: .spec.location
+      name: Location
+      priority: 1
+      type: string
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AzureMachineClass TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AzureMachineClassSpec is the specification of a AzureMachineClass.
             properties:
-              description: AzureVirtualMachineProperties is describes the properties
-                of a Virtual Machine.
+              credentialsSecretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              location:
+                type: string
               properties:
-                availabilitySet:
-                  description: AzureSubResource is the Sub Resource definition.
-                  properties:
-                    id:
-                      type: string
-                  type: object
-                hardwareProfile:
-                  description: AzureHardwareProfile is specifies the hardware settings
-                    for the virtual machine. Refer github.com/Azure/azure-sdk-for-go/arm/compute/models.go
-                    for VMSizes
-                  properties:
-                    vmSize:
-                      type: string
-                  type: object
-                identityID:
-                  type: string
-                machineSet:
-                  description: AzureMachineSetConfig contains the information about
-                    the machine set
-                  properties:
-                    id:
-                      type: string
-                    kind:
-                      type: string
-                  required:
-                  - id
-                  - kind
-                  type: object
-                networkProfile:
-                  description: AzureNetworkProfile is specifies the network interfaces
-                    of the virtual machine.
-                  properties:
-                    acceleratedNetworking:
-                      type: boolean
-                    networkInterfaces:
-                      description: AzureNetworkInterfaceReference is describes a network
-                        interface reference.
-                      properties:
-                        id:
-                          type: string
+                description: AzureVirtualMachineProperties is describes the properties
+                  of a Virtual Machine.
+                properties:
+                  availabilitySet:
+                    description: AzureSubResource is the Sub Resource definition.
+                    properties:
+                      id:
+                        type: string
+                    type: object
+                  hardwareProfile:
+                    description: AzureHardwareProfile is specifies the hardware settings
+                      for the virtual machine. Refer github.com/Azure/azure-sdk-for-go/arm/compute/models.go
+                      for VMSizes
+                    properties:
+                      vmSize:
+                        type: string
+                    type: object
+                  identityID:
+                    type: string
+                  machineSet:
+                    description: AzureMachineSetConfig contains the information about
+                      the machine set
+                    properties:
+                      id:
+                        type: string
+                      kind:
+                        type: string
+                    required:
+                    - id
+                    - kind
+                    type: object
+                  networkProfile:
+                    description: AzureNetworkProfile is specifies the network interfaces
+                      of the virtual machine.
+                    properties:
+                      acceleratedNetworking:
+                        type: boolean
+                      networkInterfaces:
+                        description: AzureNetworkInterfaceReference is describes a
+                          network interface reference.
                         properties:
-                          description: AzureNetworkInterfaceReferenceProperties is
-                            describes a network interface reference properties.
+                          id:
+                            type: string
                           properties:
-                            primary:
-                              type: boolean
-                          type: object
-                      type: object
-                  type: object
-                osProfile:
-                  description: AzureOSProfile is specifies the operating system settings
-                    for the virtual machine.
-                  properties:
-                    adminPassword:
-                      type: string
-                    adminUsername:
-                      type: string
-                    computerName:
-                      type: string
-                    customData:
-                      type: string
-                    linuxConfiguration:
-                      description: AzureLinuxConfiguration is specifies the Linux
-                        operating system settings on the virtual machine. <br><br>For
-                        a list of supported Linux distributions, see [Linux on Azure-Endorsed
-                        Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-endorsed-distros?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json)
-                        <br><br> For running non-endorsed distributions, see [Information
-                        for Non-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
-                      properties:
-                        disablePasswordAuthentication:
-                          type: boolean
-                        ssh:
-                          description: AzureSSHConfiguration is SSH configuration
-                            for Linux based VMs running on Azure
-                          properties:
-                            publicKeys:
-                              description: AzureSSHPublicKey is contains information
-                                about SSH certificate public key and the path on the
-                                Linux VM where the public key is placed.
-                              properties:
-                                keyData:
-                                  type: string
-                                path:
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                  type: object
-                storageProfile:
-                  description: AzureStorageProfile is specifies the storage settings
-                    for the virtual machine disks.
-                  properties:
-                    dataDisks:
-                      items:
-                        properties:
-                          caching:
-                            type: string
-                          diskSizeGB:
-                            format: int32
-                            type: integer
-                          lun:
-                            format: int32
-                            type: integer
-                          name:
-                            type: string
-                          storageAccountType:
-                            type: string
+                            description: AzureNetworkInterfaceReferenceProperties
+                              is describes a network interface reference properties.
+                            properties:
+                              primary:
+                                type: boolean
+                            type: object
                         type: object
-                      type: array
-                    imageReference:
-                      description: AzureImageReference is specifies information about
-                        the image to use. You can specify information about platform
-                        images, marketplace images, or virtual machine images. This
-                        element is required when you want to use a platform image,
-                        marketplace image, or virtual machine image, but is not used
-                        in other creation operations.
-                      properties:
-                        id:
-                          type: string
-                        urn:
-                          description: Uniform Resource Name of the OS image to be
-                            used , it has the format 'publisher:offer:sku:version'
-                          type: string
-                      type: object
-                    osDisk:
-                      description: AzureOSDisk is specifies information about the
-                        operating system disk used by the virtual machine. <br><br>
-                        For more information about disks, see [About disks and VHDs
-                        for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).
-                      properties:
-                        caching:
-                          type: string
-                        createOption:
-                          type: string
-                        diskSizeGB:
-                          format: int32
-                          type: integer
-                        managedDisk:
-                          description: AzureManagedDiskParameters is the parameters
-                            of a managed disk.
+                    type: object
+                  osProfile:
+                    description: AzureOSProfile is specifies the operating system
+                      settings for the virtual machine.
+                    properties:
+                      adminPassword:
+                        type: string
+                      adminUsername:
+                        type: string
+                      computerName:
+                        type: string
+                      customData:
+                        type: string
+                      linuxConfiguration:
+                        description: AzureLinuxConfiguration is specifies the Linux
+                          operating system settings on the virtual machine. <br><br>For
+                          a list of supported Linux distributions, see [Linux on Azure-Endorsed
+                          Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-endorsed-distros?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json)
+                          <br><br> For running non-endorsed distributions, see [Information
+                          for Non-Endorsed Distributions](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json).
+                        properties:
+                          disablePasswordAuthentication:
+                            type: boolean
+                          ssh:
+                            description: AzureSSHConfiguration is SSH configuration
+                              for Linux based VMs running on Azure
+                            properties:
+                              publicKeys:
+                                description: AzureSSHPublicKey is contains information
+                                  about SSH certificate public key and the path on
+                                  the Linux VM where the public key is placed.
+                                properties:
+                                  keyData:
+                                    type: string
+                                  path:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  storageProfile:
+                    description: AzureStorageProfile is specifies the storage settings
+                      for the virtual machine disks.
+                    properties:
+                      dataDisks:
+                        items:
                           properties:
-                            id:
+                            caching:
+                              type: string
+                            diskSizeGB:
+                              format: int32
+                              type: integer
+                            lun:
+                              format: int32
+                              type: integer
+                            name:
                               type: string
                             storageAccountType:
                               type: string
                           type: object
-                        name:
-                          type: string
-                      type: object
-                  type: object
-                zone:
-                  type: integer
-              type: object
-            resourceGroup:
-              type: string
-            secretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            subnetInfo:
-              description: AzureSubnetInfo is the information containing the subnet
-                details
-              properties:
-                subnetName:
-                  type: string
-                vnetName:
-                  type: string
-                vnetResourceGroup:
-                  type: string
-              type: object
-            tags:
-              additionalProperties:
+                        type: array
+                      imageReference:
+                        description: AzureImageReference is specifies information
+                          about the image to use. You can specify information about
+                          platform images, marketplace images, or virtual machine
+                          images. This element is required when you want to use a
+                          platform image, marketplace image, or virtual machine image,
+                          but is not used in other creation operations.
+                        properties:
+                          id:
+                            type: string
+                          urn:
+                            description: Uniform Resource Name of the OS image to
+                              be used , it has the format 'publisher:offer:sku:version'
+                            type: string
+                        type: object
+                      osDisk:
+                        description: AzureOSDisk is specifies information about the
+                          operating system disk used by the virtual machine. <br><br>
+                          For more information about disks, see [About disks and VHDs
+                          for Azure virtual machines](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json).
+                        properties:
+                          caching:
+                            type: string
+                          createOption:
+                            type: string
+                          diskSizeGB:
+                            format: int32
+                            type: integer
+                          managedDisk:
+                            description: AzureManagedDiskParameters is the parameters
+                              of a managed disk.
+                            properties:
+                              id:
+                                type: string
+                              storageAccountType:
+                                type: string
+                            type: object
+                          name:
+                            type: string
+                        type: object
+                    type: object
+                  zone:
+                    type: integer
+                type: object
+              resourceGroup:
                 type: string
-              type: object
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              secretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              subnetInfo:
+                description: AzureSubnetInfo is the information containing the subnet
+                  details
+                properties:
+                  subnetName:
+                    type: string
+                  vnetName:
+                    type: string
+                  vnetResourceGroup:
+                    type: string
+                type: object
+              tags:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_gcpmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_gcpmachineclasses.yaml
@@ -4,24 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: gcpmachineclasses.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.machineType
-    name: Machine Type
-    type: string
-  - JSONPath: .spec.region
-    name: Region
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: GCPMachineClass
@@ -29,173 +15,187 @@ spec:
     plural: gcpmachineclasses
     singular: gcpmachineclass
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: GCPMachineClass TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GCPMachineClassSpec is the specification of a GCPMachineClass.
-          properties:
-            canIpForward:
-              type: boolean
-            credentialsSecretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            deletionProtection:
-              type: boolean
-            description:
-              type: string
-            disks:
-              items:
-                description: GCPDisk describes disks for GCP.
-                properties:
-                  autoDelete:
-                    type: boolean
-                  boot:
-                    type: boolean
-                  image:
-                    type: string
-                  interface:
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  sizeGb:
-                    format: int64
-                    type: integer
-                  type:
-                    type: string
-                required:
-                - autoDelete
-                - boot
-                - image
-                - interface
-                - labels
-                - sizeGb
-                - type
-                type: object
-              type: array
-            labels:
-              additionalProperties:
-                type: string
-              type: object
-            machineType:
-              type: string
-            metadata:
-              items:
-                description: GCPMetadata describes metadata for GCP.
-                properties:
-                  key:
-                    type: string
-                  value:
-                    type: string
-                required:
-                - key
-                - value
-                type: object
-              type: array
-            networkInterfaces:
-              items:
-                description: GCPNetworkInterface describes network interfaces for
-                  GCP
-                properties:
-                  disableExternalIP:
-                    type: boolean
-                  network:
-                    type: string
-                  subnetwork:
-                    type: string
-                type: object
-              type: array
-            region:
-              type: string
-            scheduling:
-              description: GCPScheduling describes scheduling configuration for GCP.
-              properties:
-                automaticRestart:
-                  type: boolean
-                onHostMaintenance:
-                  type: string
-                preemptible:
-                  type: boolean
-              required:
-              - automaticRestart
-              - onHostMaintenance
-              - preemptible
-              type: object
-            secretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            serviceAccounts:
-              items:
-                description: GCPServiceAccount describes service accounts for GCP.
-                properties:
-                  email:
-                    type: string
-                  scopes:
-                    items:
-                      type: string
-                    type: array
-                required:
-                - email
-                - scopes
-                type: object
-              type: array
-            tags:
-              items:
-                type: string
-              type: array
-            zone:
-              type: string
-          required:
-          - canIpForward
-          - deletionProtection
-          - machineType
-          - region
-          - scheduling
-          - serviceAccounts
-          - zone
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.machineType
+      name: Machine Type
+      type: string
+    - jsonPath: .spec.region
+      name: Region
+      priority: 1
+      type: string
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GCPMachineClass TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GCPMachineClassSpec is the specification of a GCPMachineClass.
+            properties:
+              canIpForward:
+                type: boolean
+              credentialsSecretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              deletionProtection:
+                type: boolean
+              description:
+                type: string
+              disks:
+                items:
+                  description: GCPDisk describes disks for GCP.
+                  properties:
+                    autoDelete:
+                      type: boolean
+                    boot:
+                      type: boolean
+                    image:
+                      type: string
+                    interface:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    sizeGb:
+                      format: int64
+                      type: integer
+                    type:
+                      type: string
+                  required:
+                  - autoDelete
+                  - boot
+                  - image
+                  - interface
+                  - labels
+                  - sizeGb
+                  - type
+                  type: object
+                type: array
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              machineType:
+                type: string
+              metadata:
+                items:
+                  description: GCPMetadata describes metadata for GCP.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              networkInterfaces:
+                items:
+                  description: GCPNetworkInterface describes network interfaces for
+                    GCP
+                  properties:
+                    disableExternalIP:
+                      type: boolean
+                    network:
+                      type: string
+                    subnetwork:
+                      type: string
+                  type: object
+                type: array
+              region:
+                type: string
+              scheduling:
+                description: GCPScheduling describes scheduling configuration for
+                  GCP.
+                properties:
+                  automaticRestart:
+                    type: boolean
+                  onHostMaintenance:
+                    type: string
+                  preemptible:
+                    type: boolean
+                required:
+                - automaticRestart
+                - onHostMaintenance
+                - preemptible
+                type: object
+              secretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              serviceAccounts:
+                items:
+                  description: GCPServiceAccount describes service accounts for GCP.
+                  properties:
+                    email:
+                      type: string
+                    scopes:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - email
+                  - scopes
+                  type: object
+                type: array
+              tags:
+                items:
+                  type: string
+                type: array
+              zone:
+                type: string
+            required:
+            - canIpForward
+            - deletionProtection
+            - machineType
+            - region
+            - scheduling
+            - serviceAccounts
+            - zone
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: machineclasses.machine.sapcloud.io
 spec:
@@ -15,64 +15,63 @@ spec:
     plural: machineclasses
     singular: machineclass
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: MachineClass can be used to templatize and re-use provider configuration
-        across multiple Machines / MachineSets / MachineDeployments.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        credentialsSecretRef:
-          description: CredentialsSecretRef can optionally store the credentials (in
-            this case the SecretRef does not need to store them). This might be useful
-            if multiple machine classes with the same credentials but different user-datas
-            are used.
-          properties:
-            name:
-              description: Name is unique within a namespace to reference a secret
-                resource.
-              type: string
-            namespace:
-              description: Namespace defines the space within which the secret name
-                must be unique.
-              type: string
-          type: object
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        provider:
-          description: Provider is the combination of name and location of cloud-specific
-            drivers.
-          type: string
-        providerSpec:
-          description: Provider-specific configuration to use during node creation.
-          type: object
-        secretRef:
-          description: SecretRef stores the necessary secrets such as credentials
-            or userdata.
-          properties:
-            name:
-              description: Name is unique within a namespace to reference a secret
-                resource.
-              type: string
-            namespace:
-              description: Namespace defines the space within which the secret name
-                must be unique.
-              type: string
-          type: object
-      required:
-      - providerSpec
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MachineClass can be used to templatize and re-use provider configuration
+          across multiple Machines / MachineSets / MachineDeployments.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          credentialsSecretRef:
+            description: CredentialsSecretRef can optionally store the credentials
+              (in this case the SecretRef does not need to store them). This might
+              be useful if multiple machine classes with the same credentials but
+              different user-datas are used.
+            properties:
+              name:
+                description: Name is unique within a namespace to reference a secret
+                  resource.
+                type: string
+              namespace:
+                description: Namespace defines the space within which the secret name
+                  must be unique.
+                type: string
+            type: object
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          provider:
+            description: Provider is the combination of name and location of cloud-specific
+              drivers.
+            type: string
+          providerSpec:
+            description: Provider-specific configuration to use during node creation.
+            type: object
+          secretRef:
+            description: SecretRef stores the necessary secrets such as credentials
+              or userdata.
+            properties:
+              name:
+                description: Name is unique within a namespace to reference a secret
+                  resource.
+                type: string
+              namespace:
+                description: Namespace defines the space within which the secret name
+                  must be unique.
+                type: string
+            type: object
+        required:
+        - providerSpec
+        type: object
     served: true
     storage: true
 status:

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -4,35 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: machinedeployments.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.readyReplicas
-    description: Total number of ready machines targeted by this machine deployment.
-    name: Ready
-    type: integer
-  - JSONPath: .spec.replicas
-    description: Number of desired machines.
-    name: Desired
-    type: integer
-  - JSONPath: .status.updatedReplicas
-    description: Total number of non-terminated machines targeted by this machine
-      deployment that have the desired template spec.
-    name: Up-to-date
-    type: integer
-  - JSONPath: .status.availableReplicas
-    description: Total number of available machines (ready for at least minReadySeconds)
-      targeted by this machine deployment.
-    name: Available
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: MachineDeployment
@@ -40,444 +15,476 @@ spec:
     plural: machinedeployments
     singular: machinedeployment
   scope: Namespaced
-  subresources:
-    scale:
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Deployment enables declarative updates for machines and MachineSets.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        spec:
-          description: Specification of the desired behavior of the MachineDeployment.
-          properties:
-            minReadySeconds:
-              description: Minimum number of seconds for which a newly created machine
-                should be ready without any of its container crashing, for it to be
-                considered available. Defaults to 0 (machine will be considered available
-                as soon as it is ready)
-              format: int32
-              type: integer
-            paused:
-              description: Indicates that the MachineDeployment is paused and will
-                not be processed by the MachineDeployment controller.
-              type: boolean
-            progressDeadlineSeconds:
-              description: The maximum time in seconds for a MachineDeployment to
-                make progress before it is considered to be failed. The MachineDeployment
-                controller will continue to process failed MachineDeployments and
-                a condition with a ProgressDeadlineExceeded reason will be surfaced
-                in the MachineDeployment status. Note that progress will not be estimated
-                during the time a MachineDeployment is paused. This is not set by
-                default.
-              format: int32
-              type: integer
-            replicas:
-              description: Number of desired machines. This is a pointer to distinguish
-                between explicit zero and not specified. Defaults to 0.
-              format: int32
-              type: integer
-            revisionHistoryLimit:
-              description: The number of old MachineSets to retain to allow rollback.
-                This is a pointer to distinguish between explicit zero and not specified.
-              format: int32
-              type: integer
-            rollbackTo:
-              description: DEPRECATED. The config this MachineDeployment is rolling
-                back to. Will be cleared after rollback is done.
-              properties:
-                revision:
-                  description: The revision to rollback to. If set to 0, rollback
-                    to the last revision.
-                  format: int64
-                  type: integer
-              type: object
-            selector:
-              description: Label selector for machines. Existing MachineSets whose
-                machines are selected by this will be the ones affected by this MachineDeployment.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies
-                          to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
-                    type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
-                  type: object
-              type: object
-            strategy:
-              description: The MachineDeployment strategy to use to replace existing
-                machines with new ones.
-              properties:
-                rollingUpdate:
-                  description: 'Rolling update config params. Present only if MachineDeploymentStrategyType
-                    = RollingUpdate. --- TODO: Update this to follow our convention
-                    for oneOf, whatever we decide it to be.'
-                  properties:
-                    maxSurge:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: 'The maximum number of machines that can be scheduled
-                        above the desired number of machines. Value can be an absolute
-                        number (ex: 5) or a percentage of desired machines (ex: 10%).
-                        This can not be 0 if MaxUnavailable is 0. Absolute number
-                        is calculated from percentage by rounding up. By default,
-                        a value of 1 is used. Example: when this is set to 30%, the
-                        new MC can be scaled up immediately when the rolling update
-                        starts, such that the total number of old and new machines
-                        do not exceed 130% of desired machines. Once old machines
-                        have been killed, new MC can be scaled up further, ensuring
-                        that total number of machines running at any time during the
-                        update is atmost 130% of desired machines.'
-                      x-kubernetes-int-or-string: true
-                    maxUnavailable:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: 'The maximum number of machines that can be unavailable
-                        during the update. Value can be an absolute number (ex: 5)
-                        or a percentage of desired machines (ex: 10%). Absolute number
-                        is calculated from percentage by rounding down. This can not
-                        be 0 if MaxSurge is 0. By default, a fixed value of 1 is used.
-                        Example: when this is set to 30%, the old MC can be scaled
-                        down to 70% of desired machines immediately when the rolling
-                        update starts. Once new machines are ready, old MC can be
-                        scaled down further, followed by scaling up the new MC, ensuring
-                        that the total number of machines available at all times during
-                        the update is at least 70% of desired machines.'
-                      x-kubernetes-int-or-string: true
-                  type: object
-                type:
-                  description: Type of MachineDeployment. Can be "Recreate" or "RollingUpdate".
-                    Default is RollingUpdate.
-                  type: string
-              type: object
-            template:
-              description: Template describes the machines that will be created.
-              properties:
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
-                  properties:
-                    class:
-                      description: Class contains the machineclass attributes of a
-                        machine
+  versions:
+  - additionalPrinterColumns:
+    - description: Total number of ready machines targeted by this machine deployment.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Number of desired machines.
+      jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - description: Total number of non-terminated machines targeted by this machine
+        deployment that have the desired template spec.
+      jsonPath: .status.updatedReplicas
+      name: Up-to-date
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+        targeted by this machine deployment.
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Deployment enables declarative updates for machines and MachineSets.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the MachineDeployment.
+            properties:
+              minReadySeconds:
+                description: Minimum number of seconds for which a newly created machine
+                  should be ready without any of its container crashing, for it to
+                  be considered available. Defaults to 0 (machine will be considered
+                  available as soon as it is ready)
+                format: int32
+                type: integer
+              paused:
+                description: Indicates that the MachineDeployment is paused and will
+                  not be processed by the MachineDeployment controller.
+                type: boolean
+              progressDeadlineSeconds:
+                description: The maximum time in seconds for a MachineDeployment to
+                  make progress before it is considered to be failed. The MachineDeployment
+                  controller will continue to process failed MachineDeployments and
+                  a condition with a ProgressDeadlineExceeded reason will be surfaced
+                  in the MachineDeployment status. Note that progress will not be
+                  estimated during the time a MachineDeployment is paused. This is
+                  not set by default.
+                format: int32
+                type: integer
+              replicas:
+                description: Number of desired machines. This is a pointer to distinguish
+                  between explicit zero and not specified. Defaults to 0.
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: The number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rollbackTo:
+                description: DEPRECATED. The config this MachineDeployment is rolling
+                  back to. Will be cleared after rollback is done.
+                properties:
+                  revision:
+                    description: The revision to rollback to. If set to 0, rollback
+                      to the last revision.
+                    format: int64
+                    type: integer
+                type: object
+              selector:
+                description: Label selector for machines. Existing MachineSets whose
+                  machines are selected by this will be the ones affected by this
+                  MachineDeployment.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
-                        apiGroup:
-                          description: API group to which it belongs
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
-                        kind:
-                          description: Kind for machine class
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
-                        name:
-                          description: Name of machine class
-                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
                       type: object
-                    creationTimeout:
-                      description: MachineCreationTimeout is the timeout after which
-                        machinie creation is declared failed.
+                    type: array
+                  matchLabels:
+                    additionalProperties:
                       type: string
-                    drainTimeout:
-                      description: MachineDraintimeout is the timeout after which
-                        machine is forcefully deleted.
-                      type: string
-                    healthTimeout:
-                      description: MachineHealthTimeout is the timeout after which
-                        machine is declared unhealhty/failed.
-                      type: string
-                    maxEvictRetries:
-                      description: MaxEvictRetries is the number of retries that will
-                        be attempted while draining the node.
-                      format: int32
-                      type: integer
-                    nodeConditions:
-                      description: NodeConditions are the set of conditions if set
-                        to true for MachineHealthTimeOut, machine will be declared
-                        failed.
-                      type: string
-                    nodeTemplate:
-                      description: NodeTemplateSpec describes the data a node should
-                        have when created from a template
-                      properties:
-                        metadata:
-                          type: object
-                        spec:
-                          description: NodeSpec describes the attributes that a node
-                            is created with.
-                          properties:
-                            configSource:
-                              description: If specified, the source to get node configuration
-                                from The DynamicKubeletConfig feature gate must be
-                                enabled for the Kubelet to use this field
-                              properties:
-                                configMap:
-                                  description: ConfigMap is a reference to a Node's
-                                    ConfigMap
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              strategy:
+                description: The MachineDeployment strategy to use to replace existing
+                  machines with new ones.
+                properties:
+                  rollingUpdate:
+                    description: 'Rolling update config params. Present only if MachineDeploymentStrategyType
+                      = RollingUpdate. --- TODO: Update this to follow our convention
+                      for oneOf, whatever we decide it to be.'
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be scheduled
+                          above the desired number of machines. Value can be an absolute
+                          number (ex: 5) or a percentage of desired machines (ex:
+                          10%). This can not be 0 if MaxUnavailable is 0. Absolute
+                          number is calculated from percentage by rounding up. By
+                          default, a value of 1 is used. Example: when this is set
+                          to 30%, the new MC can be scaled up immediately when the
+                          rolling update starts, such that the total number of old
+                          and new machines do not exceed 130% of desired machines.
+                          Once old machines have been killed, new MC can be scaled
+                          up further, ensuring that total number of machines running
+                          at any time during the update is atmost 130% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'The maximum number of machines that can be unavailable
+                          during the update. Value can be an absolute number (ex:
+                          5) or a percentage of desired machines (ex: 10%). Absolute
+                          number is calculated from percentage by rounding down. This
+                          can not be 0 if MaxSurge is 0. By default, a fixed value
+                          of 1 is used. Example: when this is set to 30%, the old
+                          MC can be scaled down to 70% of desired machines immediately
+                          when the rolling update starts. Once new machines are ready,
+                          old MC can be scaled down further, followed by scaling up
+                          the new MC, ensuring that the total number of machines available
+                          at all times during the update is at least 70% of desired
+                          machines.'
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of MachineDeployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              template:
+                description: Template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                    properties:
+                      class:
+                        description: Class contains the machineclass attributes of
+                          a machine
+                        properties:
+                          apiGroup:
+                            description: API group to which it belongs
+                            type: string
+                          kind:
+                            description: Kind for machine class
+                            type: string
+                          name:
+                            description: Name of machine class
+                            type: string
+                        type: object
+                      creationTimeout:
+                        description: MachineCreationTimeout is the timeout after which
+                          machinie creation is declared failed.
+                        type: string
+                      drainTimeout:
+                        description: MachineDraintimeout is the timeout after which
+                          machine is forcefully deleted.
+                        type: string
+                      healthTimeout:
+                        description: MachineHealthTimeout is the timeout after which
+                          machine is declared unhealhty/failed.
+                        type: string
+                      maxEvictRetries:
+                        description: MaxEvictRetries is the number of retries that
+                          will be attempted while draining the node.
+                        format: int32
+                        type: integer
+                      nodeConditions:
+                        description: NodeConditions are the set of conditions if set
+                          to true for MachineHealthTimeOut, machine will be declared
+                          failed.
+                        type: string
+                      nodeTemplate:
+                        description: NodeTemplateSpec describes the data a node should
+                          have when created from a template
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            description: NodeSpec describes the attributes that a
+                              node is created with.
+                            properties:
+                              configSource:
+                                description: If specified, the source to get node
+                                  configuration from The DynamicKubeletConfig feature
+                                  gate must be enabled for the Kubelet to use this
+                                  field
+                                properties:
+                                  configMap:
+                                    description: ConfigMap is a reference to a Node's
+                                      ConfigMap
+                                    properties:
+                                      kubeletConfigKey:
+                                        description: KubeletConfigKey declares which
+                                          key of the referenced ConfigMap corresponds
+                                          to the KubeletConfiguration structure This
+                                          field is required in all cases.
+                                        type: string
+                                      name:
+                                        description: Name is the metadata.name of
+                                          the referenced ConfigMap. This field is
+                                          required in all cases.
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the metadata.namespace
+                                          of the referenced ConfigMap. This field
+                                          is required in all cases.
+                                        type: string
+                                      resourceVersion:
+                                        description: ResourceVersion is the metadata.ResourceVersion
+                                          of the referenced ConfigMap. This field
+                                          is forbidden in Node.Spec, and required
+                                          in Node.Status.
+                                        type: string
+                                      uid:
+                                        description: UID is the metadata.UID of the
+                                          referenced ConfigMap. This field is forbidden
+                                          in Node.Spec, and required in Node.Status.
+                                        type: string
+                                    required:
+                                    - kubeletConfigKey
+                                    - name
+                                    - namespace
+                                    type: object
+                                type: object
+                              externalID:
+                                description: 'Deprecated. Not all kubelets will set
+                                  this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
+                                type: string
+                              podCIDR:
+                                description: PodCIDR represents the pod IP range assigned
+                                  to the node.
+                                type: string
+                              podCIDRs:
+                                description: podCIDRs represents the IP ranges assigned
+                                  to the node for usage by Pods on that node. If this
+                                  field is specified, the 0th entry must match the
+                                  podCIDR field. It may contain at most 1 value for
+                                  each of IPv4 and IPv6.
+                                items:
+                                  type: string
+                                type: array
+                              providerID:
+                                description: 'ID of the node assigned by the cloud
+                                  provider in the format: <ProviderName>://<ProviderSpecificNodeID>'
+                                type: string
+                              taints:
+                                description: If specified, the node's taints.
+                                items:
+                                  description: The node this Taint is attached to
+                                    has the "effect" on any pod that does not tolerate
+                                    the Taint.
                                   properties:
-                                    kubeletConfigKey:
-                                      description: KubeletConfigKey declares which
-                                        key of the referenced ConfigMap corresponds
-                                        to the KubeletConfiguration structure This
-                                        field is required in all cases.
+                                    effect:
+                                      description: Required. The effect of the taint
+                                        on pods that do not tolerate the taint. Valid
+                                        effects are NoSchedule, PreferNoSchedule and
+                                        NoExecute.
                                       type: string
-                                    name:
-                                      description: Name is the metadata.name of the
-                                        referenced ConfigMap. This field is required
-                                        in all cases.
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
                                       type: string
-                                    namespace:
-                                      description: Namespace is the metadata.namespace
-                                        of the referenced ConfigMap. This field is
-                                        required in all cases.
+                                    timeAdded:
+                                      description: TimeAdded represents the time at
+                                        which the taint was added. It is only written
+                                        for NoExecute taints.
+                                      format: date-time
                                       type: string
-                                    resourceVersion:
-                                      description: ResourceVersion is the metadata.ResourceVersion
-                                        of the referenced ConfigMap. This field is
-                                        forbidden in Node.Spec, and required in Node.Status.
-                                      type: string
-                                    uid:
-                                      description: UID is the metadata.UID of the
-                                        referenced ConfigMap. This field is forbidden
-                                        in Node.Spec, and required in Node.Status.
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
                                       type: string
                                   required:
-                                  - kubeletConfigKey
-                                  - name
-                                  - namespace
+                                  - effect
+                                  - key
                                   type: object
-                              type: object
-                            externalID:
-                              description: 'Deprecated. Not all kubelets will set
-                                this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
-                              type: string
-                            podCIDR:
-                              description: PodCIDR represents the pod IP range assigned
-                                to the node.
-                              type: string
-                            podCIDRs:
-                              description: podCIDRs represents the IP ranges assigned
-                                to the node for usage by Pods on that node. If this
-                                field is specified, the 0th entry must match the podCIDR
-                                field. It may contain at most 1 value for each of
-                                IPv4 and IPv6.
-                              items:
-                                type: string
-                              type: array
-                            providerID:
-                              description: 'ID of the node assigned by the cloud provider
-                                in the format: <ProviderName>://<ProviderSpecificNodeID>'
-                              type: string
-                            taints:
-                              description: If specified, the node's taints.
-                              items:
-                                description: The node this Taint is attached to has
-                                  the "effect" on any pod that does not tolerate the
-                                  Taint.
-                                properties:
-                                  effect:
-                                    description: Required. The effect of the taint
-                                      on pods that do not tolerate the taint. Valid
-                                      effects are NoSchedule, PreferNoSchedule and
-                                      NoExecute.
-                                    type: string
-                                  key:
-                                    description: Required. The taint key to be applied
-                                      to a node.
-                                    type: string
-                                  timeAdded:
-                                    description: TimeAdded represents the time at
-                                      which the taint was added. It is only written
-                                      for NoExecute taints.
-                                    format: date-time
-                                    type: string
-                                  value:
-                                    description: Required. The taint value corresponding
-                                      to the taint key.
-                                    type: string
-                                required:
-                                - effect
-                                - key
-                                type: object
-                              type: array
-                            unschedulable:
-                              description: 'Unschedulable controls node schedulability
-                                of new pods. By default, node is schedulable. More
-                                info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
-                              type: boolean
-                          type: object
+                                type: array
+                              unschedulable:
+                                description: 'Unschedulable controls node schedulability
+                                  of new pods. By default, node is schedulable. More
+                                  info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
+                                type: boolean
+                            type: object
+                        type: object
+                      providerID:
+                        description: ProviderID represents the provider's unique ID
+                          given to a machine
+                        type: string
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: Most recently observed status of the MachineDeployment.
+            properties:
+              availableReplicas:
+                description: Total number of available machines (ready for at least
+                  minReadySeconds) targeted by this MachineDeployment.
+                format: int32
+                type: integer
+              collisionCount:
+                description: Count of hash collisions for the MachineDeployment. The
+                  MachineDeployment controller uses this field as a collision avoidance
+                  mechanism when it needs to create the name for the newest MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: Represents the latest available observations of a MachineDeployment's
+                  current state.
+                items:
+                  description: MachineDeploymentCondition describes the state of a
+                    MachineDeployment at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of MachineDeployment condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failedMachines:
+                description: FailedMachines has summary of machines on which lastOperation
+                  Failed
+                items:
+                  description: MachineSummary store the summary of machine.
+                  properties:
+                    lastOperation:
+                      description: Last operation refers to the status of the last
+                        operation performed
+                      properties:
+                        description:
+                          description: Description of the current operation
+                          type: string
+                        lastUpdateTime:
+                          description: Last update time of current operation
+                          format: date-time
+                          type: string
+                        state:
+                          description: State of operation
+                          type: string
+                        type:
+                          description: Type of operation
+                          type: string
                       type: object
+                    name:
+                      description: Name of the machine object
+                      type: string
+                    ownerRef:
+                      description: OwnerRef
+                      type: string
                     providerID:
                       description: ProviderID represents the provider's unique ID
                         given to a machine
                       type: string
                   type: object
-              type: object
-          required:
-          - template
-          type: object
-        status:
-          description: Most recently observed status of the MachineDeployment.
-          properties:
-            availableReplicas:
-              description: Total number of available machines (ready for at least
-                minReadySeconds) targeted by this MachineDeployment.
-              format: int32
-              type: integer
-            collisionCount:
-              description: Count of hash collisions for the MachineDeployment. The
-                MachineDeployment controller uses this field as a collision avoidance
-                mechanism when it needs to create the name for the newest MachineSet.
-              format: int32
-              type: integer
-            conditions:
-              description: Represents the latest available observations of a MachineDeployment's
-                current state.
-              items:
-                description: MachineDeploymentCondition describes the state of a MachineDeployment
-                  at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  lastUpdateTime:
-                    description: The last time this condition was updated.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of MachineDeployment condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            failedMachines:
-              description: FailedMachines has summary of machines on which lastOperation
-                Failed
-              items:
-                description: MachineSummary store the summary of machine.
-                properties:
-                  lastOperation:
-                    description: Last operation refers to the status of the last operation
-                      performed
-                    properties:
-                      description:
-                        description: Description of the current operation
-                        type: string
-                      lastUpdateTime:
-                        description: Last update time of current operation
-                        format: date-time
-                        type: string
-                      state:
-                        description: State of operation
-                        type: string
-                      type:
-                        description: Type of operation
-                        type: string
-                    type: object
-                  name:
-                    description: Name of the machine object
-                    type: string
-                  ownerRef:
-                    description: OwnerRef
-                    type: string
-                  providerID:
-                    description: ProviderID represents the provider's unique ID given
-                      to a machine
-                    type: string
-                type: object
-              type: array
-            observedGeneration:
-              description: The generation observed by the MachineDeployment controller.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: Total number of ready machines targeted by this MachineDeployment.
-              format: int32
-              type: integer
-            replicas:
-              description: Total number of non-terminated machines targeted by this
-                MachineDeployment (their labels match the selector).
-              format: int32
-              type: integer
-            unavailableReplicas:
-              description: Total number of unavailable machines targeted by this MachineDeployment.
-                This is the total number of machines that are still required for the
-                MachineDeployment to have 100% available capacity. They may either
-                be machines that are running but not yet available or machines that
-                still have not been created.
-              format: int32
-              type: integer
-            updatedReplicas:
-              description: Total number of non-terminated machines targeted by this
-                MachineDeployment that have the desired template spec.
-              format: int32
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+                type: array
+              observedGeneration:
+                description: The generation observed by the MachineDeployment controller.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: Total number of ready machines targeted by this MachineDeployment.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated machines targeted by this
+                  MachineDeployment (their labels match the selector).
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable machines targeted by this
+                  MachineDeployment. This is the total number of machines that are
+                  still required for the MachineDeployment to have 100% available
+                  capacity. They may either be machines that are running but not yet
+                  available or machines that still have not been created.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated machines targeted by this
+                  MachineDeployment that have the desired template spec.
+                format: int32
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: machines.machine.sapcloud.io
 spec:
@@ -15,252 +15,252 @@ spec:
     plural: machines
     singular: machine
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Machine TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          description: ObjectMeta for machine object
-          type: object
-        spec:
-          description: Spec contains the specification of the machine
-          properties:
-            class:
-              description: Class contains the machineclass attributes of a machine
-              properties:
-                apiGroup:
-                  description: API group to which it belongs
-                  type: string
-                kind:
-                  description: Kind for machine class
-                  type: string
-                name:
-                  description: Name of machine class
-                  type: string
-              type: object
-            creationTimeout:
-              description: MachineCreationTimeout is the timeout after which machinie
-                creation is declared failed.
-              type: string
-            drainTimeout:
-              description: MachineDraintimeout is the timeout after which machine
-                is forcefully deleted.
-              type: string
-            healthTimeout:
-              description: MachineHealthTimeout is the timeout after which machine
-                is declared unhealhty/failed.
-              type: string
-            maxEvictRetries:
-              description: MaxEvictRetries is the number of retries that will be attempted
-                while draining the node.
-              format: int32
-              type: integer
-            nodeConditions:
-              description: NodeConditions are the set of conditions if set to true
-                for MachineHealthTimeOut, machine will be declared failed.
-              type: string
-            nodeTemplate:
-              description: NodeTemplateSpec describes the data a node should have
-                when created from a template
-              properties:
-                metadata:
-                  type: object
-                spec:
-                  description: NodeSpec describes the attributes that a node is created
-                    with.
-                  properties:
-                    configSource:
-                      description: If specified, the source to get node configuration
-                        from The DynamicKubeletConfig feature gate must be enabled
-                        for the Kubelet to use this field
-                      properties:
-                        configMap:
-                          description: ConfigMap is a reference to a Node's ConfigMap
-                          properties:
-                            kubeletConfigKey:
-                              description: KubeletConfigKey declares which key of
-                                the referenced ConfigMap corresponds to the KubeletConfiguration
-                                structure This field is required in all cases.
-                              type: string
-                            name:
-                              description: Name is the metadata.name of the referenced
-                                ConfigMap. This field is required in all cases.
-                              type: string
-                            namespace:
-                              description: Namespace is the metadata.namespace of
-                                the referenced ConfigMap. This field is required in
-                                all cases.
-                              type: string
-                            resourceVersion:
-                              description: ResourceVersion is the metadata.ResourceVersion
-                                of the referenced ConfigMap. This field is forbidden
-                                in Node.Spec, and required in Node.Status.
-                              type: string
-                            uid:
-                              description: UID is the metadata.UID of the referenced
-                                ConfigMap. This field is forbidden in Node.Spec, and
-                                required in Node.Status.
-                              type: string
-                          required:
-                          - kubeletConfigKey
-                          - name
-                          - namespace
-                          type: object
-                      type: object
-                    externalID:
-                      description: 'Deprecated. Not all kubelets will set this field.
-                        Remove field after 1.13. see: https://issues.k8s.io/61966'
-                      type: string
-                    podCIDR:
-                      description: PodCIDR represents the pod IP range assigned to
-                        the node.
-                      type: string
-                    podCIDRs:
-                      description: podCIDRs represents the IP ranges assigned to the
-                        node for usage by Pods on that node. If this field is specified,
-                        the 0th entry must match the podCIDR field. It may contain
-                        at most 1 value for each of IPv4 and IPv6.
-                      items:
-                        type: string
-                      type: array
-                    providerID:
-                      description: 'ID of the node assigned by the cloud provider
-                        in the format: <ProviderName>://<ProviderSpecificNodeID>'
-                      type: string
-                    taints:
-                      description: If specified, the node's taints.
-                      items:
-                        description: The node this Taint is attached to has the "effect"
-                          on any pod that does not tolerate the Taint.
-                        properties:
-                          effect:
-                            description: Required. The effect of the taint on pods
-                              that do not tolerate the taint. Valid effects are NoSchedule,
-                              PreferNoSchedule and NoExecute.
-                            type: string
-                          key:
-                            description: Required. The taint key to be applied to
-                              a node.
-                            type: string
-                          timeAdded:
-                            description: TimeAdded represents the time at which the
-                              taint was added. It is only written for NoExecute taints.
-                            format: date-time
-                            type: string
-                          value:
-                            description: Required. The taint value corresponding to
-                              the taint key.
-                            type: string
-                        required:
-                        - effect
-                        - key
-                        type: object
-                      type: array
-                    unschedulable:
-                      description: 'Unschedulable controls node schedulability of
-                        new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
-                      type: boolean
-                  type: object
-              type: object
-            providerID:
-              description: ProviderID represents the provider's unique ID given to
-                a machine
-              type: string
-          type: object
-        status:
-          description: Status contains fields depicting the status
-          properties:
-            conditions:
-              description: Conditions of this machine, same as node
-              items:
-                description: NodeCondition contains condition information for a node.
-                properties:
-                  lastHeartbeatTime:
-                    description: Last time we got an update on a given condition.
-                    format: date-time
-                    type: string
-                  lastTransitionTime:
-                    description: Last time the condition transit from one status to
-                      another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human readable message indicating details about last
-                      transition.
-                    type: string
-                  reason:
-                    description: (brief) reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type of node condition.
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            currentStatus:
-              description: Current status of the machine object
-              properties:
-                lastUpdateTime:
-                  description: Last update time of current status
-                  format: date-time
-                  type: string
-                phase:
-                  description: MachinePhase is a label for the condition of a machines
-                    at the current time.
-                  type: string
-                timeoutActive:
-                  type: boolean
-              type: object
-            lastKnownState:
-              description: LastKnownState can store details of the last known state
-                of the VM by the plugins. It can be used by future operation calls
-                to determine current infrastucture state
-              type: string
-            lastOperation:
-              description: Last operation refers to the status of the last operation
-                performed
-              properties:
-                description:
-                  description: Description of the current operation
-                  type: string
-                lastUpdateTime:
-                  description: Last update time of current operation
-                  format: date-time
-                  type: string
-                state:
-                  description: State of operation
-                  type: string
-                type:
-                  description: Type of operation
-                  type: string
-              type: object
-            node:
-              description: Node string
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Machine TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec contains the specification of the machine
+            properties:
+              class:
+                description: Class contains the machineclass attributes of a machine
+                properties:
+                  apiGroup:
+                    description: API group to which it belongs
+                    type: string
+                  kind:
+                    description: Kind for machine class
+                    type: string
+                  name:
+                    description: Name of machine class
+                    type: string
+                type: object
+              creationTimeout:
+                description: MachineCreationTimeout is the timeout after which machinie
+                  creation is declared failed.
+                type: string
+              drainTimeout:
+                description: MachineDraintimeout is the timeout after which machine
+                  is forcefully deleted.
+                type: string
+              healthTimeout:
+                description: MachineHealthTimeout is the timeout after which machine
+                  is declared unhealhty/failed.
+                type: string
+              maxEvictRetries:
+                description: MaxEvictRetries is the number of retries that will be
+                  attempted while draining the node.
+                format: int32
+                type: integer
+              nodeConditions:
+                description: NodeConditions are the set of conditions if set to true
+                  for MachineHealthTimeOut, machine will be declared failed.
+                type: string
+              nodeTemplate:
+                description: NodeTemplateSpec describes the data a node should have
+                  when created from a template
+                properties:
+                  metadata:
+                    type: object
+                  spec:
+                    description: NodeSpec describes the attributes that a node is
+                      created with.
+                    properties:
+                      configSource:
+                        description: If specified, the source to get node configuration
+                          from The DynamicKubeletConfig feature gate must be enabled
+                          for the Kubelet to use this field
+                        properties:
+                          configMap:
+                            description: ConfigMap is a reference to a Node's ConfigMap
+                            properties:
+                              kubeletConfigKey:
+                                description: KubeletConfigKey declares which key of
+                                  the referenced ConfigMap corresponds to the KubeletConfiguration
+                                  structure This field is required in all cases.
+                                type: string
+                              name:
+                                description: Name is the metadata.name of the referenced
+                                  ConfigMap. This field is required in all cases.
+                                type: string
+                              namespace:
+                                description: Namespace is the metadata.namespace of
+                                  the referenced ConfigMap. This field is required
+                                  in all cases.
+                                type: string
+                              resourceVersion:
+                                description: ResourceVersion is the metadata.ResourceVersion
+                                  of the referenced ConfigMap. This field is forbidden
+                                  in Node.Spec, and required in Node.Status.
+                                type: string
+                              uid:
+                                description: UID is the metadata.UID of the referenced
+                                  ConfigMap. This field is forbidden in Node.Spec,
+                                  and required in Node.Status.
+                                type: string
+                            required:
+                            - kubeletConfigKey
+                            - name
+                            - namespace
+                            type: object
+                        type: object
+                      externalID:
+                        description: 'Deprecated. Not all kubelets will set this field.
+                          Remove field after 1.13. see: https://issues.k8s.io/61966'
+                        type: string
+                      podCIDR:
+                        description: PodCIDR represents the pod IP range assigned
+                          to the node.
+                        type: string
+                      podCIDRs:
+                        description: podCIDRs represents the IP ranges assigned to
+                          the node for usage by Pods on that node. If this field is
+                          specified, the 0th entry must match the podCIDR field. It
+                          may contain at most 1 value for each of IPv4 and IPv6.
+                        items:
+                          type: string
+                        type: array
+                      providerID:
+                        description: 'ID of the node assigned by the cloud provider
+                          in the format: <ProviderName>://<ProviderSpecificNodeID>'
+                        type: string
+                      taints:
+                        description: If specified, the node's taints.
+                        items:
+                          description: The node this Taint is attached to has the
+                            "effect" on any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: Required. The effect of the taint on pods
+                                that do not tolerate the taint. Valid effects are
+                                NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: TimeAdded represents the time at which
+                                the taint was added. It is only written for NoExecute
+                                taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                      unschedulable:
+                        description: 'Unschedulable controls node schedulability of
+                          new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
+                        type: boolean
+                    type: object
+                type: object
+              providerID:
+                description: ProviderID represents the provider's unique ID given
+                  to a machine
+                type: string
+            type: object
+          status:
+            description: Status contains fields depicting the status
+            properties:
+              conditions:
+                description: Conditions of this machine, same as node
+                items:
+                  description: NodeCondition contains condition information for a
+                    node.
+                  properties:
+                    lastHeartbeatTime:
+                      description: Last time we got an update on a given condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human readable message indicating details about
+                        last transition.
+                      type: string
+                    reason:
+                      description: (brief) reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of node condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentStatus:
+                description: Current status of the machine object
+                properties:
+                  lastUpdateTime:
+                    description: Last update time of current status
+                    format: date-time
+                    type: string
+                  phase:
+                    description: MachinePhase is a label for the condition of a machines
+                      at the current time.
+                    type: string
+                  timeoutActive:
+                    type: boolean
+                type: object
+              lastKnownState:
+                description: LastKnownState can store details of the last known state
+                  of the VM by the plugins. It can be used by future operation calls
+                  to determine current infrastucture state
+                type: string
+              lastOperation:
+                description: Last operation refers to the status of the last operation
+                  performed
+                properties:
+                  description:
+                    description: Description of the current operation
+                    type: string
+                  lastUpdateTime:
+                    description: Last update time of current operation
+                    format: date-time
+                    type: string
+                  state:
+                    description: State of operation
+                    type: string
+                  type:
+                    description: Type of operation
+                    type: string
+                type: object
+              node:
+                description: Node string
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
@@ -4,29 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: machinesets.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.replicas
-    description: Number of desired replicas.
-    name: Desired
-    type: integer
-  - JSONPath: .status.replicas
-    description: Number of actual replicas.
-    name: Current
-    type: integer
-  - JSONPath: .status.readyReplicas
-    description: Number of ready replicas for this machine set.
-    name: Ready
-    type: integer
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: MachineSet
@@ -34,377 +15,398 @@ spec:
     plural: machinesets
     singular: machineset
   scope: Namespaced
-  subresources:
-    scale:
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: MachineSet TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: MachineSetSpec is the specification of a MachineSet.
-          properties:
-            machineClass:
-              description: ClassSpec is the class specification of machine
-              properties:
-                apiGroup:
-                  description: API group to which it belongs
-                  type: string
-                kind:
-                  description: Kind for machine class
-                  type: string
-                name:
-                  description: Name of machine class
-                  type: string
-              type: object
-            minReadySeconds:
-              format: int32
-              type: integer
-            replicas:
-              format: int32
-              type: integer
-            selector:
-              description: A label selector is a label query over a set of resources.
-                The result of matchLabels and matchExpressions are ANDed. An empty
-                label selector matches all objects. A null label selector matches
-                no objects.
-              properties:
-                matchExpressions:
-                  description: matchExpressions is a list of label selector requirements.
-                    The requirements are ANDed.
-                  items:
-                    description: A label selector requirement is a selector that contains
-                      values, a key, and an operator that relates the key and values.
-                    properties:
-                      key:
-                        description: key is the label key that the selector applies
-                          to.
-                        type: string
-                      operator:
-                        description: operator represents a key's relationship to a
-                          set of values. Valid operators are In, NotIn, Exists and
-                          DoesNotExist.
-                        type: string
-                      values:
-                        description: values is an array of string values. If the operator
-                          is In or NotIn, the values array must be non-empty. If the
-                          operator is Exists or DoesNotExist, the values array must
-                          be empty. This array is replaced during a strategic merge
-                          patch.
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - key
-                    - operator
-                    type: object
-                  type: array
-                matchLabels:
-                  additionalProperties:
+  versions:
+  - additionalPrinterColumns:
+    - description: Number of desired replicas.
+      jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - description: Number of actual replicas.
+      jsonPath: .status.replicas
+      name: Current
+      type: integer
+    - description: Number of ready replicas for this machine set.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MachineSet TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineSetSpec is the specification of a MachineSet.
+            properties:
+              machineClass:
+                description: ClassSpec is the class specification of machine
+                properties:
+                  apiGroup:
+                    description: API group to which it belongs
                     type: string
-                  description: matchLabels is a map of {key,value} pairs. A single
-                    {key,value} in the matchLabels map is equivalent to an element
-                    of matchExpressions, whose key field is "key", the operator is
-                    "In", and the values array contains only "value". The requirements
-                    are ANDed.
-                  type: object
-              type: object
-            template:
-              description: MachineTemplateSpec describes the data a machine should
-                have when created from a template
-              properties:
-                metadata:
-                  description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                  type: object
-                spec:
-                  description: 'Specification of the desired behavior of the machine.
-                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
-                  properties:
-                    class:
-                      description: Class contains the machineclass attributes of a
-                        machine
+                  kind:
+                    description: Kind for machine class
+                    type: string
+                  name:
+                    description: Name of machine class
+                    type: string
+                type: object
+              minReadySeconds:
+                format: int32
+                type: integer
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                description: A label selector is a label query over a set of resources.
+                  The result of matchLabels and matchExpressions are ANDed. An empty
+                  label selector matches all objects. A null label selector matches
+                  no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
                       properties:
-                        apiGroup:
-                          description: API group to which it belongs
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
                           type: string
-                        kind:
-                          description: Kind for machine class
+                        operator:
+                          description: operator represents a key's relationship to
+                            a set of values. Valid operators are In, NotIn, Exists
+                            and DoesNotExist.
                           type: string
-                        name:
-                          description: Name of machine class
-                          type: string
+                        values:
+                          description: values is an array of string values. If the
+                            operator is In or NotIn, the values array must be non-empty.
+                            If the operator is Exists or DoesNotExist, the values
+                            array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
                       type: object
-                    creationTimeout:
-                      description: MachineCreationTimeout is the timeout after which
-                        machinie creation is declared failed.
+                    type: array
+                  matchLabels:
+                    additionalProperties:
                       type: string
-                    drainTimeout:
-                      description: MachineDraintimeout is the timeout after which
-                        machine is forcefully deleted.
-                      type: string
-                    healthTimeout:
-                      description: MachineHealthTimeout is the timeout after which
-                        machine is declared unhealhty/failed.
-                      type: string
-                    maxEvictRetries:
-                      description: MaxEvictRetries is the number of retries that will
-                        be attempted while draining the node.
-                      format: int32
-                      type: integer
-                    nodeConditions:
-                      description: NodeConditions are the set of conditions if set
-                        to true for MachineHealthTimeOut, machine will be declared
-                        failed.
-                      type: string
-                    nodeTemplate:
-                      description: NodeTemplateSpec describes the data a node should
-                        have when created from a template
-                      properties:
-                        metadata:
-                          type: object
-                        spec:
-                          description: NodeSpec describes the attributes that a node
-                            is created with.
-                          properties:
-                            configSource:
-                              description: If specified, the source to get node configuration
-                                from The DynamicKubeletConfig feature gate must be
-                                enabled for the Kubelet to use this field
-                              properties:
-                                configMap:
-                                  description: ConfigMap is a reference to a Node's
-                                    ConfigMap
+                    description: matchLabels is a map of {key,value} pairs. A single
+                      {key,value} in the matchLabels map is equivalent to an element
+                      of matchExpressions, whose key field is "key", the operator
+                      is "In", and the values array contains only "value". The requirements
+                      are ANDed.
+                    type: object
+                type: object
+              template:
+                description: MachineTemplateSpec describes the data a machine should
+                  have when created from a template
+                properties:
+                  metadata:
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                    type: object
+                  spec:
+                    description: 'Specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                    properties:
+                      class:
+                        description: Class contains the machineclass attributes of
+                          a machine
+                        properties:
+                          apiGroup:
+                            description: API group to which it belongs
+                            type: string
+                          kind:
+                            description: Kind for machine class
+                            type: string
+                          name:
+                            description: Name of machine class
+                            type: string
+                        type: object
+                      creationTimeout:
+                        description: MachineCreationTimeout is the timeout after which
+                          machinie creation is declared failed.
+                        type: string
+                      drainTimeout:
+                        description: MachineDraintimeout is the timeout after which
+                          machine is forcefully deleted.
+                        type: string
+                      healthTimeout:
+                        description: MachineHealthTimeout is the timeout after which
+                          machine is declared unhealhty/failed.
+                        type: string
+                      maxEvictRetries:
+                        description: MaxEvictRetries is the number of retries that
+                          will be attempted while draining the node.
+                        format: int32
+                        type: integer
+                      nodeConditions:
+                        description: NodeConditions are the set of conditions if set
+                          to true for MachineHealthTimeOut, machine will be declared
+                          failed.
+                        type: string
+                      nodeTemplate:
+                        description: NodeTemplateSpec describes the data a node should
+                          have when created from a template
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            description: NodeSpec describes the attributes that a
+                              node is created with.
+                            properties:
+                              configSource:
+                                description: If specified, the source to get node
+                                  configuration from The DynamicKubeletConfig feature
+                                  gate must be enabled for the Kubelet to use this
+                                  field
+                                properties:
+                                  configMap:
+                                    description: ConfigMap is a reference to a Node's
+                                      ConfigMap
+                                    properties:
+                                      kubeletConfigKey:
+                                        description: KubeletConfigKey declares which
+                                          key of the referenced ConfigMap corresponds
+                                          to the KubeletConfiguration structure This
+                                          field is required in all cases.
+                                        type: string
+                                      name:
+                                        description: Name is the metadata.name of
+                                          the referenced ConfigMap. This field is
+                                          required in all cases.
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the metadata.namespace
+                                          of the referenced ConfigMap. This field
+                                          is required in all cases.
+                                        type: string
+                                      resourceVersion:
+                                        description: ResourceVersion is the metadata.ResourceVersion
+                                          of the referenced ConfigMap. This field
+                                          is forbidden in Node.Spec, and required
+                                          in Node.Status.
+                                        type: string
+                                      uid:
+                                        description: UID is the metadata.UID of the
+                                          referenced ConfigMap. This field is forbidden
+                                          in Node.Spec, and required in Node.Status.
+                                        type: string
+                                    required:
+                                    - kubeletConfigKey
+                                    - name
+                                    - namespace
+                                    type: object
+                                type: object
+                              externalID:
+                                description: 'Deprecated. Not all kubelets will set
+                                  this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
+                                type: string
+                              podCIDR:
+                                description: PodCIDR represents the pod IP range assigned
+                                  to the node.
+                                type: string
+                              podCIDRs:
+                                description: podCIDRs represents the IP ranges assigned
+                                  to the node for usage by Pods on that node. If this
+                                  field is specified, the 0th entry must match the
+                                  podCIDR field. It may contain at most 1 value for
+                                  each of IPv4 and IPv6.
+                                items:
+                                  type: string
+                                type: array
+                              providerID:
+                                description: 'ID of the node assigned by the cloud
+                                  provider in the format: <ProviderName>://<ProviderSpecificNodeID>'
+                                type: string
+                              taints:
+                                description: If specified, the node's taints.
+                                items:
+                                  description: The node this Taint is attached to
+                                    has the "effect" on any pod that does not tolerate
+                                    the Taint.
                                   properties:
-                                    kubeletConfigKey:
-                                      description: KubeletConfigKey declares which
-                                        key of the referenced ConfigMap corresponds
-                                        to the KubeletConfiguration structure This
-                                        field is required in all cases.
+                                    effect:
+                                      description: Required. The effect of the taint
+                                        on pods that do not tolerate the taint. Valid
+                                        effects are NoSchedule, PreferNoSchedule and
+                                        NoExecute.
                                       type: string
-                                    name:
-                                      description: Name is the metadata.name of the
-                                        referenced ConfigMap. This field is required
-                                        in all cases.
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
                                       type: string
-                                    namespace:
-                                      description: Namespace is the metadata.namespace
-                                        of the referenced ConfigMap. This field is
-                                        required in all cases.
+                                    timeAdded:
+                                      description: TimeAdded represents the time at
+                                        which the taint was added. It is only written
+                                        for NoExecute taints.
+                                      format: date-time
                                       type: string
-                                    resourceVersion:
-                                      description: ResourceVersion is the metadata.ResourceVersion
-                                        of the referenced ConfigMap. This field is
-                                        forbidden in Node.Spec, and required in Node.Status.
-                                      type: string
-                                    uid:
-                                      description: UID is the metadata.UID of the
-                                        referenced ConfigMap. This field is forbidden
-                                        in Node.Spec, and required in Node.Status.
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
                                       type: string
                                   required:
-                                  - kubeletConfigKey
-                                  - name
-                                  - namespace
+                                  - effect
+                                  - key
                                   type: object
-                              type: object
-                            externalID:
-                              description: 'Deprecated. Not all kubelets will set
-                                this field. Remove field after 1.13. see: https://issues.k8s.io/61966'
-                              type: string
-                            podCIDR:
-                              description: PodCIDR represents the pod IP range assigned
-                                to the node.
-                              type: string
-                            podCIDRs:
-                              description: podCIDRs represents the IP ranges assigned
-                                to the node for usage by Pods on that node. If this
-                                field is specified, the 0th entry must match the podCIDR
-                                field. It may contain at most 1 value for each of
-                                IPv4 and IPv6.
-                              items:
-                                type: string
-                              type: array
-                            providerID:
-                              description: 'ID of the node assigned by the cloud provider
-                                in the format: <ProviderName>://<ProviderSpecificNodeID>'
-                              type: string
-                            taints:
-                              description: If specified, the node's taints.
-                              items:
-                                description: The node this Taint is attached to has
-                                  the "effect" on any pod that does not tolerate the
-                                  Taint.
-                                properties:
-                                  effect:
-                                    description: Required. The effect of the taint
-                                      on pods that do not tolerate the taint. Valid
-                                      effects are NoSchedule, PreferNoSchedule and
-                                      NoExecute.
-                                    type: string
-                                  key:
-                                    description: Required. The taint key to be applied
-                                      to a node.
-                                    type: string
-                                  timeAdded:
-                                    description: TimeAdded represents the time at
-                                      which the taint was added. It is only written
-                                      for NoExecute taints.
-                                    format: date-time
-                                    type: string
-                                  value:
-                                    description: Required. The taint value corresponding
-                                      to the taint key.
-                                    type: string
-                                required:
-                                - effect
-                                - key
-                                type: object
-                              type: array
-                            unschedulable:
-                              description: 'Unschedulable controls node schedulability
-                                of new pods. By default, node is schedulable. More
-                                info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
-                              type: boolean
-                          type: object
+                                type: array
+                              unschedulable:
+                                description: 'Unschedulable controls node schedulability
+                                  of new pods. By default, node is schedulable. More
+                                  info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration'
+                                type: boolean
+                            type: object
+                        type: object
+                      providerID:
+                        description: ProviderID represents the provider's unique ID
+                          given to a machine
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: MachineSetStatus holds the most recently observed status
+              of MachineSet.
+            properties:
+              availableReplicas:
+                description: The number of available replicas (ready for at least
+                  minReadySeconds) for this replica set.
+                format: int32
+                type: integer
+              failedMachines:
+                description: FailedMachines has summary of machines on which lastOperation
+                  Failed
+                items:
+                  description: MachineSummary store the summary of machine.
+                  properties:
+                    lastOperation:
+                      description: Last operation refers to the status of the last
+                        operation performed
+                      properties:
+                        description:
+                          description: Description of the current operation
+                          type: string
+                        lastUpdateTime:
+                          description: Last update time of current operation
+                          format: date-time
+                          type: string
+                        state:
+                          description: State of operation
+                          type: string
+                        type:
+                          description: Type of operation
+                          type: string
                       type: object
+                    name:
+                      description: Name of the machine object
+                      type: string
+                    ownerRef:
+                      description: OwnerRef
+                      type: string
                     providerID:
                       description: ProviderID represents the provider's unique ID
                         given to a machine
                       type: string
                   type: object
-              type: object
-          type: object
-        status:
-          description: MachineSetStatus holds the most recently observed status of
-            MachineSet.
-          properties:
-            availableReplicas:
-              description: The number of available replicas (ready for at least minReadySeconds)
-                for this replica set.
-              format: int32
-              type: integer
-            failedMachines:
-              description: FailedMachines has summary of machines on which lastOperation
-                Failed
-              items:
-                description: MachineSummary store the summary of machine.
+                type: array
+              fullyLabeledReplicas:
+                description: The number of pods that have labels matching the labels
+                  of the pod template of the replicaset.
+                format: int32
+                type: integer
+              lastOperation:
+                description: LastOperation performed
                 properties:
-                  lastOperation:
-                    description: Last operation refers to the status of the last operation
-                      performed
-                    properties:
-                      description:
-                        description: Description of the current operation
-                        type: string
-                      lastUpdateTime:
-                        description: Last update time of current operation
-                        format: date-time
-                        type: string
-                      state:
-                        description: State of operation
-                        type: string
-                      type:
-                        description: Type of operation
-                        type: string
-                    type: object
-                  name:
-                    description: Name of the machine object
+                  description:
+                    description: Description of the current operation
                     type: string
-                  ownerRef:
-                    description: OwnerRef
-                    type: string
-                  providerID:
-                    description: ProviderID represents the provider's unique ID given
-                      to a machine
-                    type: string
-                type: object
-              type: array
-            fullyLabeledReplicas:
-              description: The number of pods that have labels matching the labels
-                of the pod template of the replicaset.
-              format: int32
-              type: integer
-            lastOperation:
-              description: LastOperation performed
-              properties:
-                description:
-                  description: Description of the current operation
-                  type: string
-                lastUpdateTime:
-                  description: Last update time of current operation
-                  format: date-time
-                  type: string
-                state:
-                  description: State of operation
-                  type: string
-                type:
-                  description: Type of operation
-                  type: string
-              type: object
-            machineSetCondition:
-              description: Represents the latest available observations of a replica
-                set's current state.
-              items:
-                description: MachineSetCondition describes the state of a machine
-                  set at a certain point.
-                properties:
-                  lastTransitionTime:
-                    description: The last time the condition transitioned from one
-                      status to another.
+                  lastUpdateTime:
+                    description: Last update time of current operation
                     format: date-time
                     type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
+                  state:
+                    description: State of operation
                     type: string
                   type:
-                    description: Type of machine set condition.
+                    description: Type of operation
                     type: string
-                required:
-                - status
-                - type
                 type: object
-              type: array
-            observedGeneration:
-              description: ObservedGeneration is the most recent generation observed
-                by the controller.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: The number of ready replicas for this replica set.
-              format: int32
-              type: integer
-            replicas:
-              description: Replicas is the number of actual replicas.
-              format: int32
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              machineSetCondition:
+                description: Represents the latest available observations of a replica
+                  set's current state.
+                items:
+                  description: MachineSetCondition describes the state of a machine
+                    set at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: The last time the condition transitioned from one
+                        status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of machine set condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: The number of ready replicas for this replica set.
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of actual replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
@@ -4,27 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: openstackmachineclasses.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.flavorName
-    name: Flavor
-    type: string
-  - JSONPath: .spec.imageName
-    name: Image
-    type: string
-  - JSONPath: .spec.region
-    name: Region
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: OpenStackMachineClass
@@ -32,112 +15,128 @@ spec:
     plural: openstackmachineclasses
     singular: openstackmachineclass
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: OpenStackMachineClass TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OpenStackMachineClassSpec is the specification of a OpenStackMachineClass.
-          properties:
-            availabilityZone:
-              type: string
-            credentialsSecretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            flavorName:
-              type: string
-            imageID:
-              type: string
-            imageName:
-              type: string
-            keyName:
-              type: string
-            networkID:
-              type: string
-            networks:
-              items:
-                properties:
-                  id:
-                    type: string
-                  name:
-                    type: string
-                  podNetwork:
-                    type: boolean
-                type: object
-              type: array
-            podNetworkCidr:
-              type: string
-            region:
-              type: string
-            rootDiskSize:
-              type: integer
-            secretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            securityGroups:
-              items:
-                type: string
-              type: array
-            serverGroupID:
-              type: string
-            subnetID:
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              type: object
-            useConfigDrive:
-              type: boolean
-          required:
-          - availabilityZone
-          - flavorName
-          - imageID
-          - imageName
-          - keyName
-          - networkID
-          - podNetworkCidr
-          - region
-          - securityGroups
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.flavorName
+      name: Flavor
+      type: string
+    - jsonPath: .spec.imageName
+      name: Image
+      type: string
+    - jsonPath: .spec.region
+      name: Region
+      priority: 1
+      type: string
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenStackMachineClass TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenStackMachineClassSpec is the specification of a OpenStackMachineClass.
+            properties:
+              availabilityZone:
+                type: string
+              credentialsSecretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              flavorName:
+                type: string
+              imageID:
+                type: string
+              imageName:
+                type: string
+              keyName:
+                type: string
+              networkID:
+                type: string
+              networks:
+                items:
+                  properties:
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    podNetwork:
+                      type: boolean
+                  type: object
+                type: array
+              podNetworkCidr:
+                type: string
+              region:
+                type: string
+              rootDiskSize:
+                type: integer
+              secretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              securityGroups:
+                items:
+                  type: string
+                type: array
+              serverGroupID:
+                type: string
+              subnetID:
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                type: object
+              useConfigDrive:
+                type: boolean
+            required:
+            - availabilityZone
+            - flavorName
+            - imageID
+            - imageName
+            - keyName
+            - networkID
+            - podNetworkCidr
+            - region
+            - securityGroups
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/kubernetes/crds/machine.sapcloud.io_packetmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_packetmachineclasses.yaml
@@ -4,17 +4,10 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.0
+    controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
   name: packetmachineclasses.machine.sapcloud.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-    name: Age
-    type: date
   group: machine.sapcloud.io
   names:
     kind: PacketMachineClass
@@ -22,87 +15,93 @@ spec:
     plural: packetmachineclasses
     singular: packetmachineclass
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: PacketMachineClass TODO
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PacketMachineClassSpec is the specification of a PacketMachineClass.
-          properties:
-            OS:
-              type: string
-            billingCycle:
-              type: string
-            credentialsSecretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            facility:
-              items:
-                type: string
-              type: array
-            machineType:
-              type: string
-            projectID:
-              type: string
-            secretRef:
-              description: SecretReference represents a Secret Reference. It has enough
-                information to retrieve secret in any namespace
-              properties:
-                name:
-                  description: Name is unique within a namespace to reference a secret
-                    resource.
-                  type: string
-                namespace:
-                  description: Namespace defines the space within which the secret
-                    name must be unique.
-                  type: string
-              type: object
-            sshKeys:
-              items:
-                type: string
-              type: array
-            tags:
-              items:
-                type: string
-              type: array
-            userdata:
-              type: string
-          required:
-          - OS
-          - billingCycle
-          - facility
-          - machineType
-          - projectID
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PacketMachineClass TODO
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PacketMachineClassSpec is the specification of a PacketMachineClass.
+            properties:
+              OS:
+                type: string
+              billingCycle:
+                type: string
+              credentialsSecretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              facility:
+                items:
+                  type: string
+                type: array
+              machineType:
+                type: string
+              projectID:
+                type: string
+              secretRef:
+                description: SecretReference represents a Secret Reference. It has
+                  enough information to retrieve secret in any namespace
+                properties:
+                  name:
+                    description: Name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: Namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+              sshKeys:
+                items:
+                  type: string
+                type: array
+              tags:
+                items:
+                  type: string
+                type: array
+              userdata:
+                type: string
+            required:
+            - OS
+            - billingCycle
+            - facility
+            - machineType
+            - projectID
+            type: object
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -384,6 +384,7 @@ func schema_pkg_apis_machine_v1alpha1_AWSBlockDeviceMappingSpec(ref common.Refer
 					"ebs": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parameters used to automatically set up EBS volumes when the machine is launched.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSEbsBlockDeviceSpec"),
 						},
 					},
@@ -507,7 +508,8 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClass(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"kind": {
@@ -526,7 +528,8 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClass(ref common.ReferenceCallba
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSMachineClassSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSMachineClassSpec"),
 						},
 					},
 				},
@@ -560,7 +563,8 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClassList(ref common.ReferenceCa
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -569,7 +573,8 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClassList(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSMachineClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSMachineClass"),
 									},
 								},
 							},
@@ -608,7 +613,8 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClassSpec(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSBlockDeviceMappingSpec"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSBlockDeviceMappingSpec"),
 									},
 								},
 							},
@@ -622,7 +628,8 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClassSpec(ref common.ReferenceCa
 					},
 					"iam": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSIAMProfileSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSIAMProfileSpec"),
 						},
 					},
 					"machineType": {
@@ -649,7 +656,8 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClassSpec(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSNetworkInterfaceSpec"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AWSNetworkInterfaceSpec"),
 									},
 								},
 							},
@@ -662,8 +670,9 @@ func schema_pkg_apis_machine_v1alpha1_AWSMachineClassSpec(ref common.ReferenceCa
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -728,8 +737,9 @@ func schema_pkg_apis_machine_v1alpha1_AWSNetworkInterfaceSpec(ref common.Referen
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -756,26 +766,30 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudDataDisk(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"category": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"description": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"encrypted": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"deleteWithInstance": {
@@ -786,8 +800,9 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudDataDisk(ref common.ReferenceCallb
 					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 				},
@@ -806,7 +821,8 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClass(ref common.ReferenceC
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"kind": {
@@ -825,7 +841,8 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClass(ref common.ReferenceC
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AlicloudMachineClassSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AlicloudMachineClassSpec"),
 						},
 					},
 				},
@@ -859,7 +876,8 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassList(ref common.Refere
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -868,7 +886,8 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassList(ref common.Refere
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AlicloudMachineClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AlicloudMachineClass"),
 									},
 								},
 							},
@@ -891,20 +910,23 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassSpec(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"imageID": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"instanceType": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"zoneID": {
@@ -921,8 +943,9 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassSpec(ref common.Refere
 					},
 					"vSwitchID": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"privateIPAddress": {
@@ -942,7 +965,8 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassSpec(ref common.Refere
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AlicloudDataDisk"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AlicloudDataDisk"),
 									},
 								},
 							},
@@ -991,8 +1015,9 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassSpec(ref common.Refere
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -1000,8 +1025,9 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudMachineClassSpec(ref common.Refere
 					},
 					"keyPairName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"secretRef": {
@@ -1032,14 +1058,16 @@ func schema_pkg_apis_machine_v1alpha1_AlicloudSystemDisk(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"category": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 				},
@@ -1151,7 +1179,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureLinuxConfiguration(ref common.Referen
 					},
 					"ssh": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureSSHConfiguration"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureSSHConfiguration"),
 						},
 					},
 				},
@@ -1171,7 +1200,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClass(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"kind": {
@@ -1190,7 +1220,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClass(ref common.ReferenceCall
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureMachineClassSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureMachineClassSpec"),
 						},
 					},
 				},
@@ -1224,7 +1255,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClassList(ref common.Reference
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1233,7 +1265,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClassList(ref common.Reference
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureMachineClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureMachineClass"),
 									},
 								},
 							},
@@ -1267,8 +1300,9 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClassSpec(ref common.Reference
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -1276,7 +1310,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClassSpec(ref common.Reference
 					},
 					"properties": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureVirtualMachineProperties"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureVirtualMachineProperties"),
 						},
 					},
 					"resourceGroup": {
@@ -1287,7 +1322,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineClassSpec(ref common.Reference
 					},
 					"subnetInfo": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureSubnetInfo"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureSubnetInfo"),
 						},
 					},
 					"secretRef": {
@@ -1317,14 +1353,16 @@ func schema_pkg_apis_machine_v1alpha1_AzureMachineSetConfig(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"id": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -1413,7 +1451,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureNetworkProfile(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"networkInterfaces": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureNetworkInterfaceReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureNetworkInterfaceReference"),
 						},
 					},
 					"acceleratedNetworking": {
@@ -1451,7 +1490,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureOSDisk(ref common.ReferenceCallback) 
 					},
 					"managedDisk": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureManagedDiskParameters"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureManagedDiskParameters"),
 						},
 					},
 					"diskSizeGB": {
@@ -1507,7 +1547,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureOSProfile(ref common.ReferenceCallbac
 					},
 					"linuxConfiguration": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureLinuxConfiguration"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureLinuxConfiguration"),
 						},
 					},
 				},
@@ -1527,7 +1568,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureSSHConfiguration(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"publicKeys": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureSSHPublicKey"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureSSHPublicKey"),
 						},
 					},
 				},
@@ -1572,12 +1614,14 @@ func schema_pkg_apis_machine_v1alpha1_AzureStorageProfile(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"imageReference": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureImageReference"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureImageReference"),
 						},
 					},
 					"osDisk": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureOSDisk"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureOSDisk"),
 						},
 					},
 					"dataDisks": {
@@ -1586,7 +1630,8 @@ func schema_pkg_apis_machine_v1alpha1_AzureStorageProfile(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureDataDisk"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureDataDisk"),
 									},
 								},
 							},
@@ -1659,22 +1704,26 @@ func schema_pkg_apis_machine_v1alpha1_AzureVirtualMachineProperties(ref common.R
 				Properties: map[string]spec.Schema{
 					"hardwareProfile": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureHardwareProfile"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureHardwareProfile"),
 						},
 					},
 					"storageProfile": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureStorageProfile"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureStorageProfile"),
 						},
 					},
 					"osProfile": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureOSProfile"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureOSProfile"),
 						},
 					},
 					"networkProfile": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureNetworkProfile"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.AzureNetworkProfile"),
 						},
 					},
 					"availabilitySet": {
@@ -1763,6 +1812,7 @@ func schema_pkg_apis_machine_v1alpha1_CurrentStatus(ref common.ReferenceCallback
 					"lastUpdateTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last update time of current status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -1789,32 +1839,37 @@ func schema_pkg_apis_machine_v1alpha1_GCPDisk(ref common.ReferenceCallback) comm
 					},
 					"boot": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"sizeGb": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int64",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int64",
 						},
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"interface": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"image": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"labels": {
@@ -1824,8 +1879,9 @@ func schema_pkg_apis_machine_v1alpha1_GCPDisk(ref common.ReferenceCallback) comm
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -1847,7 +1903,8 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClass(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"kind": {
@@ -1866,7 +1923,8 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClass(ref common.ReferenceCallba
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPMachineClassSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPMachineClassSpec"),
 						},
 					},
 				},
@@ -1900,7 +1958,8 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassList(ref common.ReferenceCa
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1909,7 +1968,8 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassList(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPMachineClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPMachineClass"),
 									},
 								},
 							},
@@ -1932,14 +1992,16 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 				Properties: map[string]spec.Schema{
 					"canIpForward": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"deletionProtection": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"description": {
@@ -1967,8 +2029,9 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -1976,8 +2039,9 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 					},
 					"machineType": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"metadata": {
@@ -2006,7 +2070,8 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 					},
 					"scheduling": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPScheduling"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPScheduling"),
 						},
 					},
 					"secretRef": {
@@ -2025,7 +2090,8 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPServiceAccount"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.GCPServiceAccount"),
 									},
 								},
 							},
@@ -2037,8 +2103,9 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -2046,14 +2113,16 @@ func schema_pkg_apis_machine_v1alpha1_GCPMachineClassSpec(ref common.ReferenceCa
 					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"zone": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -2074,8 +2143,9 @@ func schema_pkg_apis_machine_v1alpha1_GCPMetadata(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"key": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"value": {
@@ -2131,20 +2201,23 @@ func schema_pkg_apis_machine_v1alpha1_GCPScheduling(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"automaticRestart": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 					"onHostMaintenance": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"preemptible": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
+							Default: false,
+							Type:    []string{"boolean"},
+							Format:  "",
 						},
 					},
 				},
@@ -2163,8 +2236,9 @@ func schema_pkg_apis_machine_v1alpha1_GCPServiceAccount(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"email": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"scopes": {
@@ -2173,8 +2247,9 @@ func schema_pkg_apis_machine_v1alpha1_GCPServiceAccount(ref common.ReferenceCall
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -2204,6 +2279,7 @@ func schema_pkg_apis_machine_v1alpha1_LastOperation(ref common.ReferenceCallback
 					"lastUpdateTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last update time of current operation",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -2239,6 +2315,7 @@ func schema_pkg_apis_machine_v1alpha1_Machine(ref common.ReferenceCallback) comm
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ObjectMeta for machine object",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -2259,12 +2336,14 @@ func schema_pkg_apis_machine_v1alpha1_Machine(ref common.ReferenceCallback) comm
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec contains the specification of the machine",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status contains fields depicting the status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineStatus"),
 						},
 					},
@@ -2299,12 +2378,14 @@ func schema_pkg_apis_machine_v1alpha1_MachineClass(ref common.ReferenceCallback)
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"providerSpec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Provider-specific configuration to use during node creation.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
@@ -2359,7 +2440,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineClassList(ref common.ReferenceCallb
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2368,7 +2450,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineClassList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineClass"),
 									},
 								},
 							},
@@ -2454,18 +2537,21 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeployment(ref common.ReferenceCall
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object metadata.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the MachineDeployment.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineDeploymentSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the MachineDeployment.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineDeploymentStatus"),
 						},
 					},
@@ -2487,6 +2573,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentCondition(ref common.Refe
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of MachineDeployment condition.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2494,6 +2581,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentCondition(ref common.Refe
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2501,12 +2589,14 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentCondition(ref common.Refe
 					"lastUpdateTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The last time this condition was updated.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transitioned from one status to another.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -2557,6 +2647,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentList(ref common.Reference
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -2567,7 +2658,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentList(ref common.Reference
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineDeployment"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineDeployment"),
 									},
 								},
 							},
@@ -2605,6 +2697,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentSpec(ref common.Reference
 					"template": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Template describes the machines that will be created.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineTemplateSpec"),
 						},
 					},
@@ -2616,6 +2709,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentSpec(ref common.Reference
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "The MachineDeployment strategy to use to replace existing machines with new ones.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineDeploymentStrategy"),
 						},
 					},
@@ -2724,7 +2818,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeploymentStatus(ref common.Referen
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineDeploymentCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineDeploymentCondition"),
 									},
 								},
 							},
@@ -2810,6 +2905,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineList(ref common.ReferenceCallback) 
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TypeMeta for MachineList object",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -2820,7 +2916,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineList(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.Machine"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.Machine"),
 									},
 								},
 							},
@@ -2844,7 +2941,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineSet(ref common.ReferenceCallback) c
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"kind": {
@@ -2863,12 +2961,14 @@ func schema_pkg_apis_machine_v1alpha1_MachineSet(ref common.ReferenceCallback) c
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSetSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSetStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSetStatus"),
 						},
 					},
 				},
@@ -2889,6 +2989,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetCondition(ref common.ReferenceCa
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of machine set condition.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2896,6 +2997,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetCondition(ref common.ReferenceCa
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2903,6 +3005,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetCondition(ref common.ReferenceCa
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The last time the condition transitioned from one status to another.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -2952,7 +3055,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetList(ref common.ReferenceCallbac
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2961,7 +3065,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetList(ref common.ReferenceCallbac
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSet"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSet"),
 									},
 								},
 							},
@@ -2995,12 +3100,14 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetSpec(ref common.ReferenceCallbac
 					},
 					"machineClass": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.ClassSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.ClassSpec"),
 						},
 					},
 					"template": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineTemplateSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineTemplateSpec"),
 						},
 					},
 					"minReadySeconds": {
@@ -3066,7 +3173,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSetCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSetCondition"),
 									},
 								},
 							},
@@ -3075,6 +3183,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetStatus(ref common.ReferenceCallb
 					"lastOperation": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LastOperation performed",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.LastOperation"),
 						},
 					},
@@ -3085,7 +3194,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineSetStatus(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSummary"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSummary"),
 									},
 								},
 							},
@@ -3109,6 +3219,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineSpec(ref common.ReferenceCallback) 
 					"class": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Class contains the machineclass attributes of a machine",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.ClassSpec"),
 						},
 					},
@@ -3122,6 +3233,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineSpec(ref common.ReferenceCallback) 
 					"nodeTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeTemplateSpec describes the data a node should have when created from a template",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.NodeTemplateSpec"),
 						},
 					},
@@ -3186,7 +3298,8 @@ func schema_pkg_apis_machine_v1alpha1_MachineStatus(ref common.ReferenceCallback
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.NodeCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.NodeCondition"),
 									},
 								},
 							},
@@ -3195,12 +3308,14 @@ func schema_pkg_apis_machine_v1alpha1_MachineStatus(ref common.ReferenceCallback
 					"lastOperation": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last operation refers to the status of the last operation performed",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.LastOperation"),
 						},
 					},
 					"currentStatus": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Current status of the machine object",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.CurrentStatus"),
 						},
 					},
@@ -3243,6 +3358,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineSummary(ref common.ReferenceCallbac
 					"lastOperation": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last operation refers to the status of the last operation performed",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.LastOperation"),
 						},
 					},
@@ -3271,12 +3387,14 @@ func schema_pkg_apis_machine_v1alpha1_MachineTemplateSpec(ref common.ReferenceCa
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the machine. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.MachineSpec"),
 						},
 					},
@@ -3297,12 +3415,14 @@ func schema_pkg_apis_machine_v1alpha1_NodeTemplateSpec(ref common.ReferenceCallb
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NodeSpec describes the attributes that a node is created with.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NodeSpec"),
 						},
 					},
@@ -3323,7 +3443,8 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClass(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"kind": {
@@ -3342,7 +3463,8 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClass(ref common.Reference
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.OpenStackMachineClassSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.OpenStackMachineClassSpec"),
 						},
 					},
 				},
@@ -3376,7 +3498,8 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassList(ref common.Refer
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3385,7 +3508,8 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassList(ref common.Refer
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.OpenStackMachineClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.OpenStackMachineClass"),
 									},
 								},
 							},
@@ -3408,38 +3532,44 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 				Properties: map[string]spec.Schema{
 					"imageID": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"imageName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"availabilityZone": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"flavorName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"keyName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"securityGroups": {
@@ -3448,8 +3578,9 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -3462,8 +3593,9 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -3471,8 +3603,9 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 					},
 					"networkID": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"networks": {
@@ -3481,7 +3614,8 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.OpenStackNetwork"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.OpenStackNetwork"),
 									},
 								},
 							},
@@ -3505,8 +3639,9 @@ func schema_pkg_apis_machine_v1alpha1_OpenStackMachineClassSpec(ref common.Refer
 					},
 					"podNetworkCidr": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"rootDiskSize": {
@@ -3577,7 +3712,8 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClass(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"kind": {
@@ -3596,7 +3732,8 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClass(ref common.ReferenceCal
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.PacketMachineClassSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.PacketMachineClassSpec"),
 						},
 					},
 				},
@@ -3630,7 +3767,8 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClassList(ref common.Referenc
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3639,7 +3777,8 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClassList(ref common.Referenc
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.PacketMachineClass"),
+										Default: map[string]interface{}{},
+										Ref:     ref("github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1.PacketMachineClass"),
 									},
 								},
 							},
@@ -3666,8 +3805,9 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClassSpec(ref common.Referenc
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -3675,26 +3815,30 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClassSpec(ref common.Referenc
 					},
 					"machineType": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"billingCycle": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"OS": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"projectID": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"tags": {
@@ -3703,8 +3847,9 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClassSpec(ref common.Referenc
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -3716,8 +3861,9 @@ func schema_pkg_apis_machine_v1alpha1_PacketMachineClassSpec(ref common.Referenc
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -3804,6 +3950,7 @@ func schema_k8sio_api_core_v1_AWSElasticBlockStoreVolumeSource(ref common.Refere
 					"volumeID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3879,6 +4026,7 @@ func schema_k8sio_api_core_v1_AttachedVolume(ref common.ReferenceCallback) commo
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the attached volume",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3886,6 +4034,7 @@ func schema_k8sio_api_core_v1_AttachedVolume(ref common.ReferenceCallback) commo
 					"devicePath": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DevicePath represents the device path where the volume should be available",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3911,7 +4060,8 @@ func schema_k8sio_api_core_v1_AvoidPods(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PreferAvoidPodsEntry"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PreferAvoidPodsEntry"),
 									},
 								},
 							},
@@ -3935,6 +4085,7 @@ func schema_k8sio_api_core_v1_AzureDiskVolumeSource(ref common.ReferenceCallback
 					"diskName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Name of the data disk in the blob storage",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3942,6 +4093,7 @@ func schema_k8sio_api_core_v1_AzureDiskVolumeSource(ref common.ReferenceCallback
 					"diskURI": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The URI the data disk in the blob storage",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3991,6 +4143,7 @@ func schema_k8sio_api_core_v1_AzureFilePersistentVolumeSource(ref common.Referen
 					"secretName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "the name of secret that contains Azure Storage Account Name and Key",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3998,6 +4151,7 @@ func schema_k8sio_api_core_v1_AzureFilePersistentVolumeSource(ref common.Referen
 					"shareName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Share Name",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4033,6 +4187,7 @@ func schema_k8sio_api_core_v1_AzureFileVolumeSource(ref common.ReferenceCallback
 					"secretName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "the name of secret that contains Azure Storage Account Name and Key",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4040,6 +4195,7 @@ func schema_k8sio_api_core_v1_AzureFileVolumeSource(ref common.ReferenceCallback
 					"shareName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Share Name",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4082,12 +4238,14 @@ func schema_k8sio_api_core_v1_Binding(ref common.ReferenceCallback) common.OpenA
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"target": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The target object that you want to bind to the standard object.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
@@ -4110,6 +4268,7 @@ func schema_k8sio_api_core_v1_CSIPersistentVolumeSource(ref common.ReferenceCall
 					"driver": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Driver is the name of the driver to use for this volume. Required.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4117,6 +4276,7 @@ func schema_k8sio_api_core_v1_CSIPersistentVolumeSource(ref common.ReferenceCall
 					"volumeHandle": {
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4143,8 +4303,9 @@ func schema_k8sio_api_core_v1_CSIPersistentVolumeSource(ref common.ReferenceCall
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -4193,6 +4354,7 @@ func schema_k8sio_api_core_v1_CSIVolumeSource(ref common.ReferenceCallback) comm
 					"driver": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4219,8 +4381,9 @@ func schema_k8sio_api_core_v1_CSIVolumeSource(ref common.ReferenceCallback) comm
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -4255,8 +4418,9 @@ func schema_k8sio_api_core_v1_Capabilities(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -4269,8 +4433,9 @@ func schema_k8sio_api_core_v1_Capabilities(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -4296,8 +4461,9 @@ func schema_k8sio_api_core_v1_CephFSPersistentVolumeSource(ref common.ReferenceC
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -4360,8 +4526,9 @@ func schema_k8sio_api_core_v1_CephFSVolumeSource(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -4420,6 +4587,7 @@ func schema_k8sio_api_core_v1_CinderPersistentVolumeSource(ref common.ReferenceC
 					"volumeID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4463,6 +4631,7 @@ func schema_k8sio_api_core_v1_CinderVolumeSource(ref common.ReferenceCallback) c
 					"volumeID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4526,6 +4695,7 @@ func schema_k8sio_api_core_v1_ComponentCondition(ref common.ReferenceCallback) c
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of condition for a component. Valid value: \"Healthy\"",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4533,6 +4703,7 @@ func schema_k8sio_api_core_v1_ComponentCondition(ref common.ReferenceCallback) c
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition for a component. Valid values for \"Healthy\": \"True\", \"False\", or \"Unknown\".",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4582,6 +4753,7 @@ func schema_k8sio_api_core_v1_ComponentStatus(ref common.ReferenceCallback) comm
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -4598,7 +4770,8 @@ func schema_k8sio_api_core_v1_ComponentStatus(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ComponentCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ComponentCondition"),
 									},
 								},
 							},
@@ -4636,6 +4809,7 @@ func schema_k8sio_api_core_v1_ComponentStatusList(ref common.ReferenceCallback) 
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -4646,7 +4820,8 @@ func schema_k8sio_api_core_v1_ComponentStatusList(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ComponentStatus"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ComponentStatus"),
 									},
 								},
 							},
@@ -4685,6 +4860,7 @@ func schema_k8sio_api_core_v1_ConfigMap(ref common.ReferenceCallback) common.Ope
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -4703,8 +4879,9 @@ func schema_k8sio_api_core_v1_ConfigMap(ref common.ReferenceCallback) common.Ope
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -4777,6 +4954,7 @@ func schema_k8sio_api_core_v1_ConfigMapKeySelector(ref common.ReferenceCallback)
 					"key": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The key to select.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4819,6 +4997,7 @@ func schema_k8sio_api_core_v1_ConfigMapList(ref common.ReferenceCallback) common
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -4829,7 +5008,8 @@ func schema_k8sio_api_core_v1_ConfigMapList(ref common.ReferenceCallback) common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ConfigMap"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ConfigMap"),
 									},
 								},
 							},
@@ -4854,6 +5034,7 @@ func schema_k8sio_api_core_v1_ConfigMapNodeConfigSource(ref common.ReferenceCall
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Namespace is the metadata.namespace of the referenced ConfigMap. This field is required in all cases.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4861,6 +5042,7 @@ func schema_k8sio_api_core_v1_ConfigMapNodeConfigSource(ref common.ReferenceCall
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name is the metadata.name of the referenced ConfigMap. This field is required in all cases.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4882,6 +5064,7 @@ func schema_k8sio_api_core_v1_ConfigMapNodeConfigSource(ref common.ReferenceCall
 					"kubeletConfigKey": {
 						SchemaProps: spec.SchemaProps{
 							Description: "KubeletConfigKey declares which key of the referenced ConfigMap corresponds to the KubeletConfiguration structure This field is required in all cases.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4914,7 +5097,8 @@ func schema_k8sio_api_core_v1_ConfigMapProjection(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.KeyToPath"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.KeyToPath"),
 									},
 								},
 							},
@@ -4956,7 +5140,8 @@ func schema_k8sio_api_core_v1_ConfigMapVolumeSource(ref common.ReferenceCallback
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.KeyToPath"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.KeyToPath"),
 									},
 								},
 							},
@@ -4994,6 +5179,7 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5012,8 +5198,9 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -5026,8 +5213,9 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -5058,7 +5246,8 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerPort"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerPort"),
 									},
 								},
 							},
@@ -5071,7 +5260,8 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvFromSource"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvFromSource"),
 									},
 								},
 							},
@@ -5090,7 +5280,8 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -5099,6 +5290,7 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
@@ -5115,7 +5307,8 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.VolumeMount"),
 									},
 								},
 							},
@@ -5134,7 +5327,8 @@ func schema_k8sio_api_core_v1_Container(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.VolumeDevice"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.VolumeDevice"),
 									},
 								},
 							},
@@ -5235,8 +5429,9 @@ func schema_k8sio_api_core_v1_ContainerImage(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -5280,6 +5475,7 @@ func schema_k8sio_api_core_v1_ContainerPort(ref common.ReferenceCallback) common
 					"containerPort": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -5287,6 +5483,7 @@ func schema_k8sio_api_core_v1_ContainerPort(ref common.ReferenceCallback) common
 					"protocol": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Protocol for port. Must be UDP, TCP, or SCTP. Defaults to \"TCP\".",
+							Default:     "TCP",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5348,6 +5545,7 @@ func schema_k8sio_api_core_v1_ContainerStateRunning(ref common.ReferenceCallback
 					"startedAt": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which the container was last (re-)started",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -5369,6 +5567,7 @@ func schema_k8sio_api_core_v1_ContainerStateTerminated(ref common.ReferenceCallb
 					"exitCode": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Exit status from the last termination of the container",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -5397,12 +5596,14 @@ func schema_k8sio_api_core_v1_ContainerStateTerminated(ref common.ReferenceCallb
 					"startedAt": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which previous execution of the container started",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"finishedAt": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which the container last terminated",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -5459,6 +5660,7 @@ func schema_k8sio_api_core_v1_ContainerStatus(ref common.ReferenceCallback) comm
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "This must be a DNS_LABEL. Each container in a pod must have a unique name. Cannot be updated.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5466,18 +5668,21 @@ func schema_k8sio_api_core_v1_ContainerStatus(ref common.ReferenceCallback) comm
 					"state": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Details about the container's current condition.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ContainerState"),
 						},
 					},
 					"lastState": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Details about the container's last termination condition.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ContainerState"),
 						},
 					},
 					"ready": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies whether the container has passed its readiness probe.",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -5485,6 +5690,7 @@ func schema_k8sio_api_core_v1_ContainerStatus(ref common.ReferenceCallback) comm
 					"restartCount": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The number of times the container has been restarted, currently based on the number of dead containers that have not yet been removed. Note that this is calculated from dead containers. But those containers are subject to garbage collection. This value will get capped at 5 by GC.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -5492,6 +5698,7 @@ func schema_k8sio_api_core_v1_ContainerStatus(ref common.ReferenceCallback) comm
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The image the container is running. More info: https://kubernetes.io/docs/concepts/containers/images",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5499,6 +5706,7 @@ func schema_k8sio_api_core_v1_ContainerStatus(ref common.ReferenceCallback) comm
 					"imageID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ImageID of the container's image.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5536,6 +5744,7 @@ func schema_k8sio_api_core_v1_DaemonEndpoint(ref common.ReferenceCallback) commo
 					"Port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Port number of the given endpoint.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -5561,7 +5770,8 @@ func schema_k8sio_api_core_v1_DownwardAPIProjection(ref common.ReferenceCallback
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.DownwardAPIVolumeFile"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.DownwardAPIVolumeFile"),
 									},
 								},
 							},
@@ -5585,6 +5795,7 @@ func schema_k8sio_api_core_v1_DownwardAPIVolumeFile(ref common.ReferenceCallback
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5631,7 +5842,8 @@ func schema_k8sio_api_core_v1_DownwardAPIVolumeSource(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.DownwardAPIVolumeFile"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.DownwardAPIVolumeFile"),
 									},
 								},
 							},
@@ -5690,6 +5902,7 @@ func schema_k8sio_api_core_v1_EndpointAddress(ref common.ReferenceCallback) comm
 					"ip": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5740,6 +5953,7 @@ func schema_k8sio_api_core_v1_EndpointPort(ref common.ReferenceCallback) common.
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The port number of the endpoint.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -5779,7 +5993,8 @@ func schema_k8sio_api_core_v1_EndpointSubset(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EndpointAddress"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EndpointAddress"),
 									},
 								},
 							},
@@ -5792,7 +6007,8 @@ func schema_k8sio_api_core_v1_EndpointSubset(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EndpointAddress"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EndpointAddress"),
 									},
 								},
 							},
@@ -5805,7 +6021,8 @@ func schema_k8sio_api_core_v1_EndpointSubset(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EndpointPort"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EndpointPort"),
 									},
 								},
 							},
@@ -5843,6 +6060,7 @@ func schema_k8sio_api_core_v1_Endpoints(ref common.ReferenceCallback) common.Ope
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -5853,7 +6071,8 @@ func schema_k8sio_api_core_v1_Endpoints(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EndpointSubset"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EndpointSubset"),
 									},
 								},
 							},
@@ -5891,6 +6110,7 @@ func schema_k8sio_api_core_v1_EndpointsList(ref common.ReferenceCallback) common
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -5901,7 +6121,8 @@ func schema_k8sio_api_core_v1_EndpointsList(ref common.ReferenceCallback) common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Endpoints"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Endpoints"),
 									},
 								},
 							},
@@ -5960,6 +6181,7 @@ func schema_k8sio_api_core_v1_EnvVar(ref common.ReferenceCallback) common.OpenAP
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the environment variable. Must be a C_IDENTIFIER.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6035,6 +6257,7 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6053,8 +6276,9 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6067,8 +6291,9 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6088,7 +6313,8 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerPort"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerPort"),
 									},
 								},
 							},
@@ -6101,7 +6327,8 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvFromSource"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvFromSource"),
 									},
 								},
 							},
@@ -6120,7 +6347,8 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -6129,6 +6357,7 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
@@ -6145,7 +6374,8 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.VolumeMount"),
 									},
 								},
 							},
@@ -6164,7 +6394,8 @@ func schema_k8sio_api_core_v1_EphemeralContainer(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.VolumeDevice"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.VolumeDevice"),
 									},
 								},
 							},
@@ -6268,6 +6499,7 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6286,8 +6518,9 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6300,8 +6533,9 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6321,7 +6555,8 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerPort"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerPort"),
 									},
 								},
 							},
@@ -6334,7 +6569,8 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvFromSource"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvFromSource"),
 									},
 								},
 							},
@@ -6353,7 +6589,8 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -6362,6 +6599,7 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
@@ -6378,7 +6616,8 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.VolumeMount"),
 									},
 								},
 							},
@@ -6397,7 +6636,8 @@ func schema_k8sio_api_core_v1_EphemeralContainerCommon(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.VolumeDevice"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.VolumeDevice"),
 									},
 								},
 							},
@@ -6507,7 +6747,8 @@ func schema_k8sio_api_core_v1_EphemeralContainers(ref common.ReferenceCallback) 
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"ephemeralContainers": {
@@ -6523,7 +6764,8 @@ func schema_k8sio_api_core_v1_EphemeralContainers(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EphemeralContainer"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EphemeralContainer"),
 									},
 								},
 							},
@@ -6590,12 +6832,14 @@ func schema_k8sio_api_core_v1_Event(ref common.ReferenceCallback) common.OpenAPI
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"involvedObject": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The object that this event is about.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
@@ -6616,18 +6860,21 @@ func schema_k8sio_api_core_v1_Event(ref common.ReferenceCallback) common.OpenAPI
 					"source": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The component reporting this event. Should be a short machine understandable string.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.EventSource"),
 						},
 					},
 					"firstTimestamp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"lastTimestamp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The time at which the most recent occurrence of this event was recorded.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -6648,6 +6895,7 @@ func schema_k8sio_api_core_v1_Event(ref common.ReferenceCallback) common.OpenAPI
 					"eventTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time when this Event was first observed.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
@@ -6673,6 +6921,7 @@ func schema_k8sio_api_core_v1_Event(ref common.ReferenceCallback) common.OpenAPI
 					"reportingComponent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the controller that emitted this Event, e.g. `kubernetes.io/kubelet`.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6680,6 +6929,7 @@ func schema_k8sio_api_core_v1_Event(ref common.ReferenceCallback) common.OpenAPI
 					"reportingInstance": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ID of the controller instance, e.g. `kubelet-xyzf`.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6717,6 +6967,7 @@ func schema_k8sio_api_core_v1_EventList(ref common.ReferenceCallback) common.Ope
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -6727,7 +6978,8 @@ func schema_k8sio_api_core_v1_EventList(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Event"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Event"),
 									},
 								},
 							},
@@ -6759,6 +7011,7 @@ func schema_k8sio_api_core_v1_EventSeries(ref common.ReferenceCallback) common.O
 					"lastObservedTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time of the last occurrence observed",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.MicroTime"),
 						},
 					},
@@ -6811,8 +7064,9 @@ func schema_k8sio_api_core_v1_ExecAction(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6838,8 +7092,9 @@ func schema_k8sio_api_core_v1_FCVolumeSource(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6873,8 +7128,9 @@ func schema_k8sio_api_core_v1_FCVolumeSource(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6896,6 +7152,7 @@ func schema_k8sio_api_core_v1_FlexPersistentVolumeSource(ref common.ReferenceCal
 					"driver": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Driver is the name of the driver to use for this volume.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6928,8 +7185,9 @@ func schema_k8sio_api_core_v1_FlexPersistentVolumeSource(ref common.ReferenceCal
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -6954,6 +7212,7 @@ func schema_k8sio_api_core_v1_FlexVolumeSource(ref common.ReferenceCallback) com
 					"driver": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Driver is the name of the driver to use for this volume.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6986,8 +7245,9 @@ func schema_k8sio_api_core_v1_FlexVolumeSource(ref common.ReferenceCallback) com
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -7039,6 +7299,7 @@ func schema_k8sio_api_core_v1_GCEPersistentDiskVolumeSource(ref common.Reference
 					"pdName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7081,6 +7342,7 @@ func schema_k8sio_api_core_v1_GitRepoVolumeSource(ref common.ReferenceCallback) 
 					"repository": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Repository URL",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7116,6 +7378,7 @@ func schema_k8sio_api_core_v1_GlusterfsPersistentVolumeSource(ref common.Referen
 					"endpoints": {
 						SchemaProps: spec.SchemaProps{
 							Description: "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7123,6 +7386,7 @@ func schema_k8sio_api_core_v1_GlusterfsPersistentVolumeSource(ref common.Referen
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7158,6 +7422,7 @@ func schema_k8sio_api_core_v1_GlusterfsVolumeSource(ref common.ReferenceCallback
 					"endpoints": {
 						SchemaProps: spec.SchemaProps{
 							Description: "EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7165,6 +7430,7 @@ func schema_k8sio_api_core_v1_GlusterfsVolumeSource(ref common.ReferenceCallback
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7200,6 +7466,7 @@ func schema_k8sio_api_core_v1_HTTPGetAction(ref common.ReferenceCallback) common
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -7224,7 +7491,8 @@ func schema_k8sio_api_core_v1_HTTPGetAction(ref common.ReferenceCallback) common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.HTTPHeader"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.HTTPHeader"),
 									},
 								},
 							},
@@ -7249,6 +7517,7 @@ func schema_k8sio_api_core_v1_HTTPHeader(ref common.ReferenceCallback) common.Op
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The header field name",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7256,6 +7525,7 @@ func schema_k8sio_api_core_v1_HTTPHeader(ref common.ReferenceCallback) common.Op
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The header field value",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7321,8 +7591,9 @@ func schema_k8sio_api_core_v1_HostAlias(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -7344,6 +7615,7 @@ func schema_k8sio_api_core_v1_HostPathVolumeSource(ref common.ReferenceCallback)
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7372,6 +7644,7 @@ func schema_k8sio_api_core_v1_ISCSIPersistentVolumeSource(ref common.ReferenceCa
 					"targetPortal": {
 						SchemaProps: spec.SchemaProps{
 							Description: "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7379,6 +7652,7 @@ func schema_k8sio_api_core_v1_ISCSIPersistentVolumeSource(ref common.ReferenceCa
 					"iqn": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Target iSCSI Qualified Name.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7386,6 +7660,7 @@ func schema_k8sio_api_core_v1_ISCSIPersistentVolumeSource(ref common.ReferenceCa
 					"lun": {
 						SchemaProps: spec.SchemaProps{
 							Description: "iSCSI Target Lun number.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -7418,8 +7693,9 @@ func schema_k8sio_api_core_v1_ISCSIPersistentVolumeSource(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -7471,6 +7747,7 @@ func schema_k8sio_api_core_v1_ISCSIVolumeSource(ref common.ReferenceCallback) co
 					"targetPortal": {
 						SchemaProps: spec.SchemaProps{
 							Description: "iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7478,6 +7755,7 @@ func schema_k8sio_api_core_v1_ISCSIVolumeSource(ref common.ReferenceCallback) co
 					"iqn": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Target iSCSI Qualified Name.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7485,6 +7763,7 @@ func schema_k8sio_api_core_v1_ISCSIVolumeSource(ref common.ReferenceCallback) co
 					"lun": {
 						SchemaProps: spec.SchemaProps{
 							Description: "iSCSI Target Lun number.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -7517,8 +7796,9 @@ func schema_k8sio_api_core_v1_ISCSIVolumeSource(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -7570,6 +7850,7 @@ func schema_k8sio_api_core_v1_KeyToPath(ref common.ReferenceCallback) common.Ope
 					"key": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The key to project.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7577,6 +7858,7 @@ func schema_k8sio_api_core_v1_KeyToPath(ref common.ReferenceCallback) common.Ope
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7646,12 +7928,14 @@ func schema_k8sio_api_core_v1_LimitRange(ref common.ReferenceCallback) common.Op
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the limits enforced. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.LimitRangeSpec"),
 						},
 					},
@@ -7673,6 +7957,7 @@ func schema_k8sio_api_core_v1_LimitRangeItem(ref common.ReferenceCallback) commo
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of resource that this limit applies to.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7685,7 +7970,8 @@ func schema_k8sio_api_core_v1_LimitRangeItem(ref common.ReferenceCallback) commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -7699,7 +7985,8 @@ func schema_k8sio_api_core_v1_LimitRangeItem(ref common.ReferenceCallback) commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -7713,7 +8000,8 @@ func schema_k8sio_api_core_v1_LimitRangeItem(ref common.ReferenceCallback) commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -7727,7 +8015,8 @@ func schema_k8sio_api_core_v1_LimitRangeItem(ref common.ReferenceCallback) commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -7741,7 +8030,8 @@ func schema_k8sio_api_core_v1_LimitRangeItem(ref common.ReferenceCallback) commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -7780,6 +8070,7 @@ func schema_k8sio_api_core_v1_LimitRangeList(ref common.ReferenceCallback) commo
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -7790,7 +8081,8 @@ func schema_k8sio_api_core_v1_LimitRangeList(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LimitRange"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LimitRange"),
 									},
 								},
 							},
@@ -7819,7 +8111,8 @@ func schema_k8sio_api_core_v1_LimitRangeSpec(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LimitRangeItem"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LimitRangeItem"),
 									},
 								},
 							},
@@ -7858,6 +8151,7 @@ func schema_k8sio_api_core_v1_List(ref common.ReferenceCallback) common.OpenAPID
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -7868,7 +8162,8 @@ func schema_k8sio_api_core_v1_List(ref common.ReferenceCallback) common.OpenAPID
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 									},
 								},
 							},
@@ -7916,7 +8211,8 @@ func schema_k8sio_api_core_v1_LoadBalancerIngress(ref common.ReferenceCallback) 
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PortStatus"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PortStatus"),
 									},
 								},
 							},
@@ -7944,7 +8240,8 @@ func schema_k8sio_api_core_v1_LoadBalancerStatus(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LoadBalancerIngress"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LoadBalancerIngress"),
 									},
 								},
 							},
@@ -7988,6 +8285,7 @@ func schema_k8sio_api_core_v1_LocalVolumeSource(ref common.ReferenceCallback) co
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The full path to the volume on the node. It can be either a directory or block device (disk, partition, ...).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8016,6 +8314,7 @@ func schema_k8sio_api_core_v1_NFSVolumeSource(ref common.ReferenceCallback) comm
 					"server": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8023,6 +8322,7 @@ func schema_k8sio_api_core_v1_NFSVolumeSource(ref common.ReferenceCallback) comm
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8065,18 +8365,21 @@ func schema_k8sio_api_core_v1_Namespace(ref common.ReferenceCallback) common.Ope
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the behavior of the Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NamespaceSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status describes the current status of a Namespace. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NamespaceStatus"),
 						},
 					},
@@ -8098,6 +8401,7 @@ func schema_k8sio_api_core_v1_NamespaceCondition(ref common.ReferenceCallback) c
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of namespace controller condition.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8105,13 +8409,15 @@ func schema_k8sio_api_core_v1_NamespaceCondition(ref common.ReferenceCallback) c
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"reason": {
@@ -8159,6 +8465,7 @@ func schema_k8sio_api_core_v1_NamespaceList(ref common.ReferenceCallback) common
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -8169,7 +8476,8 @@ func schema_k8sio_api_core_v1_NamespaceList(ref common.ReferenceCallback) common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Namespace"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Namespace"),
 									},
 								},
 							},
@@ -8198,8 +8506,9 @@ func schema_k8sio_api_core_v1_NamespaceSpec(ref common.ReferenceCallback) common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -8238,7 +8547,8 @@ func schema_k8sio_api_core_v1_NamespaceStatus(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.NamespaceCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.NamespaceCondition"),
 									},
 								},
 							},
@@ -8276,18 +8586,21 @@ func schema_k8sio_api_core_v1_Node(ref common.ReferenceCallback) common.OpenAPID
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the behavior of a node. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NodeSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the node. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NodeStatus"),
 						},
 					},
@@ -8309,6 +8622,7 @@ func schema_k8sio_api_core_v1_NodeAddress(ref common.ReferenceCallback) common.O
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Node address type, one of Hostname, ExternalIP or InternalIP.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8316,6 +8630,7 @@ func schema_k8sio_api_core_v1_NodeAddress(ref common.ReferenceCallback) common.O
 					"address": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The node address.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8347,7 +8662,8 @@ func schema_k8sio_api_core_v1_NodeAffinity(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PreferredSchedulingTerm"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PreferredSchedulingTerm"),
 									},
 								},
 							},
@@ -8371,6 +8687,7 @@ func schema_k8sio_api_core_v1_NodeCondition(ref common.ReferenceCallback) common
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of node condition.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8378,6 +8695,7 @@ func schema_k8sio_api_core_v1_NodeCondition(ref common.ReferenceCallback) common
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8385,12 +8703,14 @@ func schema_k8sio_api_core_v1_NodeCondition(ref common.ReferenceCallback) common
 					"lastHeartbeatTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time we got an update on a given condition.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transit from one status to another.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -8488,6 +8808,7 @@ func schema_k8sio_api_core_v1_NodeDaemonEndpoints(ref common.ReferenceCallback) 
 					"kubeletEndpoint": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Endpoint on which Kubelet is listening.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.DaemonEndpoint"),
 						},
 					},
@@ -8523,6 +8844,7 @@ func schema_k8sio_api_core_v1_NodeList(ref common.ReferenceCallback) common.Open
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -8533,7 +8855,8 @@ func schema_k8sio_api_core_v1_NodeList(ref common.ReferenceCallback) common.Open
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Node"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Node"),
 									},
 								},
 							},
@@ -8597,7 +8920,8 @@ func schema_k8sio_api_core_v1_NodeResources(ref common.ReferenceCallback) common
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -8626,7 +8950,8 @@ func schema_k8sio_api_core_v1_NodeSelector(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.NodeSelectorTerm"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.NodeSelectorTerm"),
 									},
 								},
 							},
@@ -8651,6 +8976,7 @@ func schema_k8sio_api_core_v1_NodeSelectorRequirement(ref common.ReferenceCallba
 					"key": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The label key that the selector applies to.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8658,6 +8984,7 @@ func schema_k8sio_api_core_v1_NodeSelectorRequirement(ref common.ReferenceCallba
 					"operator": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8669,8 +8996,9 @@ func schema_k8sio_api_core_v1_NodeSelectorRequirement(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -8697,7 +9025,8 @@ func schema_k8sio_api_core_v1_NodeSelectorTerm(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.NodeSelectorRequirement"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.NodeSelectorRequirement"),
 									},
 								},
 							},
@@ -8710,7 +9039,8 @@ func schema_k8sio_api_core_v1_NodeSelectorTerm(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.NodeSelectorRequirement"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.NodeSelectorRequirement"),
 									},
 								},
 							},
@@ -8750,8 +9080,9 @@ func schema_k8sio_api_core_v1_NodeSpec(ref common.ReferenceCallback) common.Open
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -8778,7 +9109,8 @@ func schema_k8sio_api_core_v1_NodeSpec(ref common.ReferenceCallback) common.Open
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Taint"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Taint"),
 									},
 								},
 							},
@@ -8820,7 +9152,8 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -8834,7 +9167,8 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -8860,7 +9194,8 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.NodeCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.NodeCondition"),
 									},
 								},
 							},
@@ -8879,7 +9214,8 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.NodeAddress"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.NodeAddress"),
 									},
 								},
 							},
@@ -8888,12 +9224,14 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 					"daemonEndpoints": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Endpoints of daemons running on the Node.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NodeDaemonEndpoints"),
 						},
 					},
 					"nodeInfo": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Set of ids/uuids to uniquely identify the node. More info: https://kubernetes.io/docs/concepts/nodes/node/#info",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NodeSystemInfo"),
 						},
 					},
@@ -8904,7 +9242,8 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerImage"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerImage"),
 									},
 								},
 							},
@@ -8917,8 +9256,9 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -8931,7 +9271,8 @@ func schema_k8sio_api_core_v1_NodeStatus(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.AttachedVolume"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.AttachedVolume"),
 									},
 								},
 							},
@@ -8961,6 +9302,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"machineID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MachineID reported by the node. For unique machine identification in the cluster this field is preferred. Learn more from man(5) machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8968,6 +9310,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"systemUUID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SystemUUID reported by the node. For unique machine identification MachineID is preferred. This field is specific to Red Hat hosts https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8975,6 +9318,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"bootID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Boot ID reported by the node.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8982,6 +9326,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"kernelVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Kernel Version reported by the node from 'uname -r' (e.g. 3.16.0-0.bpo.4-amd64).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8989,6 +9334,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"osImage": {
 						SchemaProps: spec.SchemaProps{
 							Description: "OS Image reported by the node from /etc/os-release (e.g. Debian GNU/Linux 7 (wheezy)).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8996,6 +9342,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"containerRuntimeVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ContainerRuntime Version reported by the node through runtime remote API (e.g. docker://1.5.0).",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9003,6 +9350,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"kubeletVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Kubelet Version reported by the node.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9010,6 +9358,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"kubeProxyVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "KubeProxy Version reported by the node.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9017,6 +9366,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"operatingSystem": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Operating System reported by the node",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9024,6 +9374,7 @@ func schema_k8sio_api_core_v1_NodeSystemInfo(ref common.ReferenceCallback) commo
 					"architecture": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Architecture reported by the node",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9052,6 +9403,7 @@ func schema_k8sio_api_core_v1_ObjectFieldSelector(ref common.ReferenceCallback) 
 					"fieldPath": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path of the field to select in the specified API version.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9149,18 +9501,21 @@ func schema_k8sio_api_core_v1_PersistentVolume(ref common.ReferenceCallback) com
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines a specification of a persistent volume owned by the cluster. Provisioned by an administrator. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status represents the current information/status for the persistent volume. Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistent-volumes",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeStatus"),
 						},
 					},
@@ -9196,18 +9551,21 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaim(ref common.ReferenceCallback
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeClaimSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeClaimStatus"),
 						},
 					},
@@ -9228,25 +9586,29 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimCondition(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"lastProbeTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time we probed the condition.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transitioned from one status to another.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -9297,6 +9659,7 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimList(ref common.ReferenceCall
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -9307,7 +9670,8 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimList(ref common.ReferenceCall
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PersistentVolumeClaim"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PersistentVolumeClaim"),
 									},
 								},
 							},
@@ -9336,8 +9700,9 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimSpec(ref common.ReferenceCall
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -9352,6 +9717,7 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimSpec(ref common.ReferenceCall
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
@@ -9411,8 +9777,9 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimStatus(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -9426,7 +9793,8 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimStatus(ref common.ReferenceCa
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -9445,7 +9813,8 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimStatus(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PersistentVolumeClaimCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PersistentVolumeClaimCondition"),
 									},
 								},
 							},
@@ -9469,12 +9838,14 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimTemplate(ref common.Reference
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PersistentVolumeClaimSpec"),
 						},
 					},
@@ -9497,6 +9868,7 @@ func schema_k8sio_api_core_v1_PersistentVolumeClaimVolumeSource(ref common.Refer
 					"claimName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9539,6 +9911,7 @@ func schema_k8sio_api_core_v1_PersistentVolumeList(ref common.ReferenceCallback)
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -9549,7 +9922,8 @@ func schema_k8sio_api_core_v1_PersistentVolumeList(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PersistentVolume"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PersistentVolume"),
 									},
 								},
 							},
@@ -9726,7 +10100,8 @@ func schema_k8sio_api_core_v1_PersistentVolumeSpec(ref common.ReferenceCallback)
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -9871,8 +10246,9 @@ func schema_k8sio_api_core_v1_PersistentVolumeSpec(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -9905,8 +10281,9 @@ func schema_k8sio_api_core_v1_PersistentVolumeSpec(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -9977,6 +10354,7 @@ func schema_k8sio_api_core_v1_PhotonPersistentDiskVolumeSource(ref common.Refere
 					"pdID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ID that identifies Photon Controller persistent disk",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10019,18 +10397,21 @@ func schema_k8sio_api_core_v1_Pod(ref common.ReferenceCallback) common.OpenAPIDe
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PodSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PodStatus"),
 						},
 					},
@@ -10056,7 +10437,8 @@ func schema_k8sio_api_core_v1_PodAffinity(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PodAffinityTerm"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PodAffinityTerm"),
 									},
 								},
 							},
@@ -10069,7 +10451,8 @@ func schema_k8sio_api_core_v1_PodAffinity(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.WeightedPodAffinityTerm"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.WeightedPodAffinityTerm"),
 									},
 								},
 							},
@@ -10103,8 +10486,9 @@ func schema_k8sio_api_core_v1_PodAffinityTerm(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -10113,6 +10497,7 @@ func schema_k8sio_api_core_v1_PodAffinityTerm(ref common.ReferenceCallback) comm
 					"topologyKey": {
 						SchemaProps: spec.SchemaProps{
 							Description: "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10140,7 +10525,8 @@ func schema_k8sio_api_core_v1_PodAntiAffinity(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PodAffinityTerm"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PodAffinityTerm"),
 									},
 								},
 							},
@@ -10153,7 +10539,8 @@ func schema_k8sio_api_core_v1_PodAntiAffinity(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.WeightedPodAffinityTerm"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.WeightedPodAffinityTerm"),
 									},
 								},
 							},
@@ -10239,6 +10626,7 @@ func schema_k8sio_api_core_v1_PodCondition(ref common.ReferenceCallback) common.
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type is the type of the condition. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10246,6 +10634,7 @@ func schema_k8sio_api_core_v1_PodCondition(ref common.ReferenceCallback) common.
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the status of the condition. Can be True, False, Unknown. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10253,12 +10642,14 @@ func schema_k8sio_api_core_v1_PodCondition(ref common.ReferenceCallback) common.
 					"lastProbeTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time we probed the condition.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transitioned from one status to another.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -10299,8 +10690,9 @@ func schema_k8sio_api_core_v1_PodDNSConfig(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -10313,8 +10705,9 @@ func schema_k8sio_api_core_v1_PodDNSConfig(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -10327,7 +10720,8 @@ func schema_k8sio_api_core_v1_PodDNSConfig(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PodDNSConfigOption"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PodDNSConfigOption"),
 									},
 								},
 							},
@@ -10430,8 +10824,9 @@ func schema_k8sio_api_core_v1_PodExecOptions(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -10488,6 +10883,7 @@ func schema_k8sio_api_core_v1_PodList(ref common.ReferenceCallback) common.OpenA
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -10498,7 +10894,8 @@ func schema_k8sio_api_core_v1_PodList(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Pod"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Pod"),
 									},
 								},
 							},
@@ -10632,8 +11029,9 @@ func schema_k8sio_api_core_v1_PodPortForwardOptions(ref common.ReferenceCallback
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"integer"},
-										Format: "int32",
+										Default: 0,
+										Type:    []string{"integer"},
+										Format:  "int32",
 									},
 								},
 							},
@@ -10689,6 +11087,7 @@ func schema_k8sio_api_core_v1_PodReadinessGate(ref common.ReferenceCallback) com
 					"conditionType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ConditionType refers to a condition in the pod's condition list with matching type.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10747,8 +11146,9 @@ func schema_k8sio_api_core_v1_PodSecurityContext(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"integer"},
-										Format: "int64",
+										Default: 0,
+										Type:    []string{"integer"},
+										Format:  "int64",
 									},
 								},
 							},
@@ -10768,7 +11168,8 @@ func schema_k8sio_api_core_v1_PodSecurityContext(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Sysctl"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Sysctl"),
 									},
 								},
 							},
@@ -10836,7 +11237,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Volume"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Volume"),
 									},
 								},
 							},
@@ -10855,7 +11257,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Container"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Container"),
 									},
 								},
 							},
@@ -10874,7 +11277,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Container"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Container"),
 									},
 								},
 							},
@@ -10893,7 +11297,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EphemeralContainer"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EphemeralContainer"),
 									},
 								},
 							},
@@ -10935,8 +11340,9 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -11017,7 +11423,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -11057,7 +11464,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Toleration"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Toleration"),
 									},
 								},
 							},
@@ -11076,7 +11484,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.HostAlias"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.HostAlias"),
 									},
 								},
 							},
@@ -11109,7 +11518,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PodReadinessGate"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PodReadinessGate"),
 									},
 								},
 							},
@@ -11144,7 +11554,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -11168,7 +11579,8 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.TopologySpreadConstraint"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.TopologySpreadConstraint"),
 									},
 								},
 							},
@@ -11217,7 +11629,8 @@ func schema_k8sio_api_core_v1_PodStatus(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PodCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PodCondition"),
 									},
 								},
 							},
@@ -11271,7 +11684,8 @@ func schema_k8sio_api_core_v1_PodStatus(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PodIP"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PodIP"),
 									},
 								},
 							},
@@ -11290,7 +11704,8 @@ func schema_k8sio_api_core_v1_PodStatus(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerStatus"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerStatus"),
 									},
 								},
 							},
@@ -11303,7 +11718,8 @@ func schema_k8sio_api_core_v1_PodStatus(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerStatus"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerStatus"),
 									},
 								},
 							},
@@ -11323,7 +11739,8 @@ func schema_k8sio_api_core_v1_PodStatus(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ContainerStatus"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ContainerStatus"),
 									},
 								},
 							},
@@ -11361,12 +11778,14 @@ func schema_k8sio_api_core_v1_PodStatusResult(ref common.ReferenceCallback) comm
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the pod. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PodStatus"),
 						},
 					},
@@ -11402,12 +11821,14 @@ func schema_k8sio_api_core_v1_PodTemplate(ref common.ReferenceCallback) common.O
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"template": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Template defines the pods that will be created from this pod template. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PodTemplateSpec"),
 						},
 					},
@@ -11443,6 +11864,7 @@ func schema_k8sio_api_core_v1_PodTemplateList(ref common.ReferenceCallback) comm
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -11453,7 +11875,8 @@ func schema_k8sio_api_core_v1_PodTemplateList(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.PodTemplate"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.PodTemplate"),
 									},
 								},
 							},
@@ -11478,12 +11901,14 @@ func schema_k8sio_api_core_v1_PodTemplateSpec(ref common.ReferenceCallback) comm
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PodSpec"),
 						},
 					},
@@ -11504,6 +11929,7 @@ func schema_k8sio_api_core_v1_PortStatus(ref common.ReferenceCallback) common.Op
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Port is the port number of the service port of which status is recorded here",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -11511,6 +11937,7 @@ func schema_k8sio_api_core_v1_PortStatus(ref common.ReferenceCallback) common.Op
 					"protocol": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Protocol is the protocol of the service port of which status is recorded here The supported values are: \"TCP\", \"UDP\", \"SCTP\"",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11539,6 +11966,7 @@ func schema_k8sio_api_core_v1_PortworxVolumeSource(ref common.ReferenceCallback)
 					"volumeID": {
 						SchemaProps: spec.SchemaProps{
 							Description: "VolumeID uniquely identifies a Portworx volume",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11574,12 +12002,14 @@ func schema_k8sio_api_core_v1_PreferAvoidPodsEntry(ref common.ReferenceCallback)
 					"podSignature": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The class of pods.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PodSignature"),
 						},
 					},
 					"evictionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which this entry was added to the list.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -11616,6 +12046,7 @@ func schema_k8sio_api_core_v1_PreferredSchedulingTerm(ref common.ReferenceCallba
 					"weight": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -11623,6 +12054,7 @@ func schema_k8sio_api_core_v1_PreferredSchedulingTerm(ref common.ReferenceCallba
 					"preference": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A node selector term, associated with the corresponding weight.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.NodeSelectorTerm"),
 						},
 					},
@@ -11717,7 +12149,8 @@ func schema_k8sio_api_core_v1_ProjectedVolumeSource(ref common.ReferenceCallback
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.VolumeProjection"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.VolumeProjection"),
 									},
 								},
 							},
@@ -11748,6 +12181,7 @@ func schema_k8sio_api_core_v1_QuobyteVolumeSource(ref common.ReferenceCallback) 
 					"registry": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11755,6 +12189,7 @@ func schema_k8sio_api_core_v1_QuobyteVolumeSource(ref common.ReferenceCallback) 
 					"volume": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Volume is a string that references an already created Quobyte volume by name.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11808,8 +12243,9 @@ func schema_k8sio_api_core_v1_RBDPersistentVolumeSource(ref common.ReferenceCall
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -11818,6 +12254,7 @@ func schema_k8sio_api_core_v1_RBDPersistentVolumeSource(ref common.ReferenceCall
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11886,8 +12323,9 @@ func schema_k8sio_api_core_v1_RBDVolumeSource(ref common.ReferenceCallback) comm
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -11896,6 +12334,7 @@ func schema_k8sio_api_core_v1_RBDVolumeSource(ref common.ReferenceCallback) comm
 					"image": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11974,12 +12413,14 @@ func schema_k8sio_api_core_v1_RangeAllocation(ref common.ReferenceCallback) comm
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"range": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Range is string that identifies the range represented by 'data'.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12024,18 +12465,21 @@ func schema_k8sio_api_core_v1_ReplicationController(ref common.ReferenceCallback
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If the Labels of a ReplicationController are empty, they are defaulted to be the same as the Pod(s) that the replication controller manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the specification of the desired behavior of the replication controller. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ReplicationControllerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the most recently observed status of the replication controller. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ReplicationControllerStatus"),
 						},
 					},
@@ -12057,6 +12501,7 @@ func schema_k8sio_api_core_v1_ReplicationControllerCondition(ref common.Referenc
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of replication controller condition.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12064,6 +12509,7 @@ func schema_k8sio_api_core_v1_ReplicationControllerCondition(ref common.Referenc
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12071,6 +12517,7 @@ func schema_k8sio_api_core_v1_ReplicationControllerCondition(ref common.Referenc
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The last time the condition transitioned from one status to another.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -12121,6 +12568,7 @@ func schema_k8sio_api_core_v1_ReplicationControllerList(ref common.ReferenceCall
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -12131,7 +12579,8 @@ func schema_k8sio_api_core_v1_ReplicationControllerList(ref common.ReferenceCall
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ReplicationController"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ReplicationController"),
 									},
 								},
 							},
@@ -12175,8 +12624,9 @@ func schema_k8sio_api_core_v1_ReplicationControllerSpec(ref common.ReferenceCall
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -12206,6 +12656,7 @@ func schema_k8sio_api_core_v1_ReplicationControllerStatus(ref common.ReferenceCa
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#what-is-a-replicationcontroller",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -12251,7 +12702,8 @@ func schema_k8sio_api_core_v1_ReplicationControllerStatus(ref common.ReferenceCa
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ReplicationControllerCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ReplicationControllerCondition"),
 									},
 								},
 							},
@@ -12283,6 +12735,7 @@ func schema_k8sio_api_core_v1_ResourceFieldSelector(ref common.ReferenceCallback
 					"resource": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Required: resource to select",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12290,6 +12743,7 @@ func schema_k8sio_api_core_v1_ResourceFieldSelector(ref common.ReferenceCallback
 					"divisor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies the output format of the exposed resources, defaults to \"1\"",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 						},
 					},
@@ -12326,18 +12780,21 @@ func schema_k8sio_api_core_v1_ResourceQuota(ref common.ReferenceCallback) common
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the desired quota. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceQuotaSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status defines the actual enforced quota and its current usage. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceQuotaStatus"),
 						},
 					},
@@ -12373,6 +12830,7 @@ func schema_k8sio_api_core_v1_ResourceQuotaList(ref common.ReferenceCallback) co
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -12383,7 +12841,8 @@ func schema_k8sio_api_core_v1_ResourceQuotaList(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ResourceQuota"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ResourceQuota"),
 									},
 								},
 							},
@@ -12413,7 +12872,8 @@ func schema_k8sio_api_core_v1_ResourceQuotaSpec(ref common.ReferenceCallback) co
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -12426,8 +12886,9 @@ func schema_k8sio_api_core_v1_ResourceQuotaSpec(ref common.ReferenceCallback) co
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -12462,7 +12923,8 @@ func schema_k8sio_api_core_v1_ResourceQuotaStatus(ref common.ReferenceCallback) 
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -12476,7 +12938,8 @@ func schema_k8sio_api_core_v1_ResourceQuotaStatus(ref common.ReferenceCallback) 
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -12505,7 +12968,8 @@ func schema_k8sio_api_core_v1_ResourceRequirements(ref common.ReferenceCallback)
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -12519,7 +12983,8 @@ func schema_k8sio_api_core_v1_ResourceRequirements(ref common.ReferenceCallback)
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 									},
 								},
 							},
@@ -12584,6 +13049,7 @@ func schema_k8sio_api_core_v1_ScaleIOPersistentVolumeSource(ref common.Reference
 					"gateway": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The host address of the ScaleIO API Gateway.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12591,6 +13057,7 @@ func schema_k8sio_api_core_v1_ScaleIOPersistentVolumeSource(ref common.Reference
 					"system": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the storage system as configured in ScaleIO.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12669,6 +13136,7 @@ func schema_k8sio_api_core_v1_ScaleIOVolumeSource(ref common.ReferenceCallback) 
 					"gateway": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The host address of the ScaleIO API Gateway.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12676,6 +13144,7 @@ func schema_k8sio_api_core_v1_ScaleIOVolumeSource(ref common.ReferenceCallback) 
 					"system": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the storage system as configured in ScaleIO.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12758,7 +13227,8 @@ func schema_k8sio_api_core_v1_ScopeSelector(ref common.ReferenceCallback) common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ScopedResourceSelectorRequirement"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ScopedResourceSelectorRequirement"),
 									},
 								},
 							},
@@ -12782,6 +13252,7 @@ func schema_k8sio_api_core_v1_ScopedResourceSelectorRequirement(ref common.Refer
 					"scopeName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The name of the scope that the selector applies to.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12789,6 +13260,7 @@ func schema_k8sio_api_core_v1_ScopedResourceSelectorRequirement(ref common.Refer
 					"operator": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Represents a scope's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12800,8 +13272,9 @@ func schema_k8sio_api_core_v1_ScopedResourceSelectorRequirement(ref common.Refer
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -12824,6 +13297,7 @@ func schema_k8sio_api_core_v1_SeccompProfile(ref common.ReferenceCallback) commo
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "type indicates which kind of seccomp profile will be applied. Valid options are:\n\nLocalhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12878,6 +13352,7 @@ func schema_k8sio_api_core_v1_Secret(ref common.ReferenceCallback) common.OpenAP
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -12911,8 +13386,9 @@ func schema_k8sio_api_core_v1_Secret(ref common.ReferenceCallback) common.OpenAP
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -12977,6 +13453,7 @@ func schema_k8sio_api_core_v1_SecretKeySelector(ref common.ReferenceCallback) co
 					"key": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The key of the secret to select from.  Must be a valid secret key.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -13019,6 +13496,7 @@ func schema_k8sio_api_core_v1_SecretList(ref common.ReferenceCallback) common.Op
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -13029,7 +13507,8 @@ func schema_k8sio_api_core_v1_SecretList(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Secret"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Secret"),
 									},
 								},
 							},
@@ -13065,7 +13544,8 @@ func schema_k8sio_api_core_v1_SecretProjection(ref common.ReferenceCallback) com
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.KeyToPath"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.KeyToPath"),
 									},
 								},
 							},
@@ -13134,7 +13614,8 @@ func schema_k8sio_api_core_v1_SecretVolumeSource(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.KeyToPath"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.KeyToPath"),
 									},
 								},
 							},
@@ -13274,6 +13755,7 @@ func schema_k8sio_api_core_v1_SerializedReference(ref common.ReferenceCallback) 
 					"reference": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The reference to an object in the system.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
@@ -13309,18 +13791,21 @@ func schema_k8sio_api_core_v1_Service(ref common.ReferenceCallback) common.OpenA
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the behavior of a service. https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ServiceSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the service. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ServiceStatus"),
 						},
 					},
@@ -13356,6 +13841,7 @@ func schema_k8sio_api_core_v1_ServiceAccount(ref common.ReferenceCallback) commo
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -13372,7 +13858,8 @@ func schema_k8sio_api_core_v1_ServiceAccount(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ObjectReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ObjectReference"),
 									},
 								},
 							},
@@ -13385,7 +13872,8 @@ func schema_k8sio_api_core_v1_ServiceAccount(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -13430,6 +13918,7 @@ func schema_k8sio_api_core_v1_ServiceAccountList(ref common.ReferenceCallback) c
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -13440,7 +13929,8 @@ func schema_k8sio_api_core_v1_ServiceAccountList(ref common.ReferenceCallback) c
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ServiceAccount"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ServiceAccount"),
 									},
 								},
 							},
@@ -13479,6 +13969,7 @@ func schema_k8sio_api_core_v1_ServiceAccountTokenProjection(ref common.Reference
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path is the path relative to the mount point of the file to project the token into.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -13514,6 +14005,7 @@ func schema_k8sio_api_core_v1_ServiceList(ref common.ReferenceCallback) common.O
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -13524,7 +14016,8 @@ func schema_k8sio_api_core_v1_ServiceList(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.Service"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.Service"),
 									},
 								},
 							},
@@ -13556,6 +14049,7 @@ func schema_k8sio_api_core_v1_ServicePort(ref common.ReferenceCallback) common.O
 					"protocol": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The IP protocol for this port. Supports \"TCP\", \"UDP\", and \"SCTP\". Default is TCP.",
+							Default:     "TCP",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -13570,6 +14064,7 @@ func schema_k8sio_api_core_v1_ServicePort(ref common.ReferenceCallback) common.O
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The port that will be exposed by this service.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -13577,6 +14072,7 @@ func schema_k8sio_api_core_v1_ServicePort(ref common.ReferenceCallback) common.O
 					"targetPort": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -13655,7 +14151,8 @@ func schema_k8sio_api_core_v1_ServiceSpec(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.ServicePort"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.ServicePort"),
 									},
 								},
 							},
@@ -13669,8 +14166,9 @@ func schema_k8sio_api_core_v1_ServiceSpec(ref common.ReferenceCallback) common.O
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -13695,8 +14193,9 @@ func schema_k8sio_api_core_v1_ServiceSpec(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -13716,8 +14215,9 @@ func schema_k8sio_api_core_v1_ServiceSpec(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -13744,8 +14244,9 @@ func schema_k8sio_api_core_v1_ServiceSpec(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -13792,8 +14293,9 @@ func schema_k8sio_api_core_v1_ServiceSpec(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -13811,8 +14313,9 @@ func schema_k8sio_api_core_v1_ServiceSpec(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -13850,6 +14353,7 @@ func schema_k8sio_api_core_v1_ServiceStatus(ref common.ReferenceCallback) common
 					"loadBalancer": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LoadBalancer contains the current status of the load-balancer, if one is present.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.LoadBalancerStatus"),
 						},
 					},
@@ -13870,7 +14374,8 @@ func schema_k8sio_api_core_v1_ServiceStatus(ref common.ReferenceCallback) common
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.Condition"),
 									},
 								},
 							},
@@ -14013,6 +14518,7 @@ func schema_k8sio_api_core_v1_Sysctl(ref common.ReferenceCallback) common.OpenAP
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of a property to set",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14020,6 +14526,7 @@ func schema_k8sio_api_core_v1_Sysctl(ref common.ReferenceCallback) common.OpenAP
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Value of a property to set",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14041,6 +14548,7 @@ func schema_k8sio_api_core_v1_TCPSocketAction(ref common.ReferenceCallback) comm
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/util/intstr.IntOrString"),
 						},
 					},
@@ -14070,6 +14578,7 @@ func schema_k8sio_api_core_v1_Taint(ref common.ReferenceCallback) common.OpenAPI
 					"key": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Required. The taint key to be applied to a node.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14084,6 +14593,7 @@ func schema_k8sio_api_core_v1_Taint(ref common.ReferenceCallback) common.OpenAPI
 					"effect": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14161,6 +14671,7 @@ func schema_k8sio_api_core_v1_TopologySelectorLabelRequirement(ref common.Refere
 					"key": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The label key that the selector applies to.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14172,8 +14683,9 @@ func schema_k8sio_api_core_v1_TopologySelectorLabelRequirement(ref common.Refere
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -14200,7 +14712,8 @@ func schema_k8sio_api_core_v1_TopologySelectorTerm(ref common.ReferenceCallback)
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.TopologySelectorLabelRequirement"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.TopologySelectorLabelRequirement"),
 									},
 								},
 							},
@@ -14224,6 +14737,7 @@ func schema_k8sio_api_core_v1_TopologySpreadConstraint(ref common.ReferenceCallb
 					"maxSkew": {
 						SchemaProps: spec.SchemaProps{
 							Description: "MaxSkew describes the degree to which pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference between the number of matching pods in the target topology and the global minimum. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence to topologies that satisfy it. It's a required field. Default value is 1 and 0 is not allowed.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -14231,6 +14745,7 @@ func schema_k8sio_api_core_v1_TopologySpreadConstraint(ref common.ReferenceCallb
 					"topologyKey": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a \"bucket\", and try to put balanced number of pods into each bucket. It's a required field.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14238,6 +14753,7 @@ func schema_k8sio_api_core_v1_TopologySpreadConstraint(ref common.ReferenceCallb
 					"whenUnsatisfiable": {
 						SchemaProps: spec.SchemaProps{
 							Description: "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it. - ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod if and only if every possible node assigment for that pod would violate \"MaxSkew\" on some topology. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won't make it *more* imbalanced. It's a required field.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14274,6 +14790,7 @@ func schema_k8sio_api_core_v1_TypedLocalObjectReference(ref common.ReferenceCall
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Kind is the type of resource being referenced",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14281,6 +14798,7 @@ func schema_k8sio_api_core_v1_TypedLocalObjectReference(ref common.ReferenceCall
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name is the name of resource being referenced",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14302,6 +14820,7 @@ func schema_k8sio_api_core_v1_Volume(ref common.ReferenceCallback) common.OpenAP
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Volume's name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14499,6 +15018,7 @@ func schema_k8sio_api_core_v1_VolumeDevice(ref common.ReferenceCallback) common.
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name must match the name of a persistentVolumeClaim in the pod",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14506,6 +15026,7 @@ func schema_k8sio_api_core_v1_VolumeDevice(ref common.ReferenceCallback) common.
 					"devicePath": {
 						SchemaProps: spec.SchemaProps{
 							Description: "devicePath is the path inside of the container that the device will be mapped to.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14527,6 +15048,7 @@ func schema_k8sio_api_core_v1_VolumeMount(ref common.ReferenceCallback) common.O
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "This must match the Name of a Volume.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14541,6 +15063,7 @@ func schema_k8sio_api_core_v1_VolumeMount(ref common.ReferenceCallback) common.O
 					"mountPath": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path within the container at which the volume should be mounted.  Must not contain ':'.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14832,6 +15355,7 @@ func schema_k8sio_api_core_v1_VsphereVirtualDiskVolumeSource(ref common.Referenc
 					"volumePath": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Path that identifies vSphere volume vmdk",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14874,6 +15398,7 @@ func schema_k8sio_api_core_v1_WeightedPodAffinityTerm(ref common.ReferenceCallba
 					"weight": {
 						SchemaProps: spec.SchemaProps{
 							Description: "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -14881,6 +15406,7 @@ func schema_k8sio_api_core_v1_WeightedPodAffinityTerm(ref common.ReferenceCallba
 					"podAffinityTerm": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Required. A pod affinity term, associated with the corresponding weight.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.PodAffinityTerm"),
 						},
 					},
@@ -14948,14 +15474,16 @@ func schema_apimachinery_pkg_api_resource_int64Amount(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"value": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int64",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int64",
 						},
 					},
 					"scale": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Default: 0,
+							Type:    []string{"integer"},
+							Format:  "int32",
 						},
 					},
 				},
@@ -14989,6 +15517,7 @@ func schema_pkg_apis_meta_v1_APIGroup(ref common.ReferenceCallback) common.OpenA
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the name of the group.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15000,7 +15529,8 @@ func schema_pkg_apis_meta_v1_APIGroup(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.GroupVersionForDiscovery"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.GroupVersionForDiscovery"),
 									},
 								},
 							},
@@ -15009,6 +15539,7 @@ func schema_pkg_apis_meta_v1_APIGroup(ref common.ReferenceCallback) common.OpenA
 					"preferredVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "preferredVersion is the version preferred by the API server, which probably is the storage version.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.GroupVersionForDiscovery"),
 						},
 					},
@@ -15019,7 +15550,8 @@ func schema_pkg_apis_meta_v1_APIGroup(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ServerAddressByClientCIDR"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ServerAddressByClientCIDR"),
 									},
 								},
 							},
@@ -15062,7 +15594,8 @@ func schema_pkg_apis_meta_v1_APIGroupList(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.APIGroup"),
 									},
 								},
 							},
@@ -15087,6 +15620,7 @@ func schema_pkg_apis_meta_v1_APIResource(ref common.ReferenceCallback) common.Op
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is the plural name of the resource.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15094,6 +15628,7 @@ func schema_pkg_apis_meta_v1_APIResource(ref common.ReferenceCallback) common.Op
 					"singularName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15101,6 +15636,7 @@ func schema_pkg_apis_meta_v1_APIResource(ref common.ReferenceCallback) common.Op
 					"namespaced": {
 						SchemaProps: spec.SchemaProps{
 							Description: "namespaced indicates if a resource is namespaced or not.",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -15122,6 +15658,7 @@ func schema_pkg_apis_meta_v1_APIResource(ref common.ReferenceCallback) common.Op
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15133,8 +15670,9 @@ func schema_pkg_apis_meta_v1_APIResource(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15147,8 +15685,9 @@ func schema_pkg_apis_meta_v1_APIResource(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15161,8 +15700,9 @@ func schema_pkg_apis_meta_v1_APIResource(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15206,6 +15746,7 @@ func schema_pkg_apis_meta_v1_APIResourceList(ref common.ReferenceCallback) commo
 					"groupVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "groupVersion is the group and version this APIResourceList is for.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15217,7 +15758,8 @@ func schema_pkg_apis_meta_v1_APIResourceList(ref common.ReferenceCallback) commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.APIResource"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.APIResource"),
 									},
 								},
 							},
@@ -15260,8 +15802,9 @@ func schema_pkg_apis_meta_v1_APIVersions(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15274,7 +15817,8 @@ func schema_pkg_apis_meta_v1_APIVersions(ref common.ReferenceCallback) common.Op
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ServerAddressByClientCIDR"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ServerAddressByClientCIDR"),
 									},
 								},
 							},
@@ -15299,6 +15843,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "type of condition in CamelCase or in foo.example.com/CamelCase.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15306,6 +15851,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15320,12 +15866,14 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
 							Description: "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15333,6 +15881,7 @@ func schema_pkg_apis_meta_v1_Condition(ref common.ReferenceCallback) common.Open
 					"message": {
 						SchemaProps: spec.SchemaProps{
 							Description: "message is a human readable message indicating details about the transition. This may be an empty string.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15374,8 +15923,9 @@ func schema_pkg_apis_meta_v1_CreateOptions(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15449,8 +15999,9 @@ func schema_pkg_apis_meta_v1_DeleteOptions(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15500,6 +16051,7 @@ func schema_pkg_apis_meta_v1_ExportOptions(ref common.ReferenceCallback) common.
 					"export": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Should this value be exported.  Export strips fields that a user can not specify. Deprecated. Planned for removal in 1.18.",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -15507,6 +16059,7 @@ func schema_pkg_apis_meta_v1_ExportOptions(ref common.ReferenceCallback) common.
 					"exact": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'. Deprecated. Planned for removal in 1.18.",
+							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -15572,14 +16125,16 @@ func schema_pkg_apis_meta_v1_GroupKind(ref common.ReferenceCallback) common.Open
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -15598,14 +16153,16 @@ func schema_pkg_apis_meta_v1_GroupResource(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -15624,14 +16181,16 @@ func schema_pkg_apis_meta_v1_GroupVersion(ref common.ReferenceCallback) common.O
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -15651,6 +16210,7 @@ func schema_pkg_apis_meta_v1_GroupVersionForDiscovery(ref common.ReferenceCallba
 					"groupVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "groupVersion specifies the API group and version in the form \"group/version\"",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15658,6 +16218,7 @@ func schema_pkg_apis_meta_v1_GroupVersionForDiscovery(ref common.ReferenceCallba
 					"version": {
 						SchemaProps: spec.SchemaProps{
 							Description: "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15678,20 +16239,23 @@ func schema_pkg_apis_meta_v1_GroupVersionKind(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -15710,20 +16274,23 @@ func schema_pkg_apis_meta_v1_GroupVersionResource(ref common.ReferenceCallback) 
 				Properties: map[string]spec.Schema{
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"resource": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},
@@ -15742,8 +16309,9 @@ func schema_pkg_apis_meta_v1_InternalEvent(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"Type": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"Object": {
@@ -15776,8 +16344,9 @@ func schema_pkg_apis_meta_v1_LabelSelector(ref common.ReferenceCallback) common.
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15790,7 +16359,8 @@ func schema_pkg_apis_meta_v1_LabelSelector(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelectorRequirement"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelectorRequirement"),
 									},
 								},
 							},
@@ -15825,6 +16395,7 @@ func schema_pkg_apis_meta_v1_LabelSelectorRequirement(ref common.ReferenceCallba
 						},
 						SchemaProps: spec.SchemaProps{
 							Description: "key is the label key that the selector applies to.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15832,6 +16403,7 @@ func schema_pkg_apis_meta_v1_LabelSelectorRequirement(ref common.ReferenceCallba
 					"operator": {
 						SchemaProps: spec.SchemaProps{
 							Description: "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -15843,8 +16415,9 @@ func schema_pkg_apis_meta_v1_LabelSelectorRequirement(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -15881,6 +16454,7 @@ func schema_pkg_apis_meta_v1_List(ref common.ReferenceCallback) common.OpenAPIDe
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -15891,7 +16465,8 @@ func schema_pkg_apis_meta_v1_List(ref common.ReferenceCallback) common.OpenAPIDe
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 									},
 								},
 							},
@@ -16163,6 +16738,7 @@ func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.Ope
 					"creationTimestamp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
@@ -16187,8 +16763,9 @@ func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.Ope
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -16202,8 +16779,9 @@ func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.Ope
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -16222,7 +16800,8 @@ func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.OwnerReference"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.OwnerReference"),
 									},
 								},
 							},
@@ -16240,8 +16819,9 @@ func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -16261,7 +16841,8 @@ func schema_pkg_apis_meta_v1_ObjectMeta(ref common.ReferenceCallback) common.Ope
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ManagedFieldsEntry"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ManagedFieldsEntry"),
 									},
 								},
 							},
@@ -16285,6 +16866,7 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 					"apiVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "API version of the referent.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16292,6 +16874,7 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 					"kind": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16299,6 +16882,7 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16306,6 +16890,7 @@ func schema_pkg_apis_meta_v1_OwnerReference(ref common.ReferenceCallback) common
 					"uid": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16355,6 +16940,7 @@ func schema_pkg_apis_meta_v1_PartialObjectMetadata(ref common.ReferenceCallback)
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
@@ -16390,6 +16976,7 @@ func schema_pkg_apis_meta_v1_PartialObjectMetadataList(ref common.ReferenceCallb
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -16400,7 +16987,8 @@ func schema_pkg_apis_meta_v1_PartialObjectMetadataList(ref common.ReferenceCallb
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.PartialObjectMetadata"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.PartialObjectMetadata"),
 									},
 								},
 							},
@@ -16454,8 +17042,9 @@ func schema_pkg_apis_meta_v1_PatchOptions(ref common.ReferenceCallback) common.O
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -16522,8 +17111,9 @@ func schema_pkg_apis_meta_v1_RootPaths(ref common.ReferenceCallback) common.Open
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -16546,6 +17136,7 @@ func schema_pkg_apis_meta_v1_ServerAddressByClientCIDR(ref common.ReferenceCallb
 					"clientCIDR": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16553,6 +17144,7 @@ func schema_pkg_apis_meta_v1_ServerAddressByClientCIDR(ref common.ReferenceCallb
 					"serverAddress": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16588,6 +17180,7 @@ func schema_pkg_apis_meta_v1_Status(ref common.ReferenceCallback) common.OpenAPI
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -16709,7 +17302,8 @@ func schema_pkg_apis_meta_v1_StatusDetails(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.StatusCause"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.StatusCause"),
 									},
 								},
 							},
@@ -16754,6 +17348,7 @@ func schema_pkg_apis_meta_v1_Table(ref common.ReferenceCallback) common.OpenAPID
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta"),
 						},
 					},
@@ -16764,7 +17359,8 @@ func schema_pkg_apis_meta_v1_Table(ref common.ReferenceCallback) common.OpenAPID
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.TableColumnDefinition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.TableColumnDefinition"),
 									},
 								},
 							},
@@ -16777,7 +17373,8 @@ func schema_pkg_apis_meta_v1_Table(ref common.ReferenceCallback) common.OpenAPID
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.TableRow"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.TableRow"),
 									},
 								},
 							},
@@ -16802,6 +17399,7 @@ func schema_pkg_apis_meta_v1_TableColumnDefinition(ref common.ReferenceCallback)
 					"name": {
 						SchemaProps: spec.SchemaProps{
 							Description: "name is a human readable name for the column.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16809,6 +17407,7 @@ func schema_pkg_apis_meta_v1_TableColumnDefinition(ref common.ReferenceCallback)
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "type is an OpenAPI type definition for this column, such as number, integer, string, or array. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16816,6 +17415,7 @@ func schema_pkg_apis_meta_v1_TableColumnDefinition(ref common.ReferenceCallback)
 					"format": {
 						SchemaProps: spec.SchemaProps{
 							Description: "format is an optional OpenAPI type modifier for this column. A format modifies the type and imposes additional rules, like date or time formatting for a string. The 'name' format is applied to the primary identifier column which has type 'string' to assist in clients identifying column is the resource name. See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types for more.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16823,6 +17423,7 @@ func schema_pkg_apis_meta_v1_TableColumnDefinition(ref common.ReferenceCallback)
 					"description": {
 						SchemaProps: spec.SchemaProps{
 							Description: "description is a human readable description of this column.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16830,6 +17431,7 @@ func schema_pkg_apis_meta_v1_TableColumnDefinition(ref common.ReferenceCallback)
 					"priority": {
 						SchemaProps: spec.SchemaProps{
 							Description: "priority is an integer defining the relative importance of this column compared to others. Lower numbers are considered higher priority. Columns that may be omitted in limited space scenarios should be given a higher priority.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -16903,7 +17505,8 @@ func schema_pkg_apis_meta_v1_TableRow(ref common.ReferenceCallback) common.OpenA
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.TableRowCondition"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.TableRowCondition"),
 									},
 								},
 							},
@@ -16912,6 +17515,7 @@ func schema_pkg_apis_meta_v1_TableRow(ref common.ReferenceCallback) common.OpenA
 					"object": {
 						SchemaProps: spec.SchemaProps{
 							Description: "This field contains the requested additional information about each object based on the includeObject policy when requesting the Table. If \"None\", this field is empty, if \"Object\" this will be the default serialization of the object for the current API version, and if \"Metadata\" (the default) will contain the object metadata. Check the returned kind and apiVersion of the object before parsing. The media type of the object will always match the enclosing list - if this as a JSON table, these will be JSON encoded objects.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
@@ -16934,6 +17538,7 @@ func schema_pkg_apis_meta_v1_TableRowCondition(ref common.ReferenceCallback) com
 					"type": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Type of row condition. The only defined value is 'Completed' indicating that the object this row represents has reached a completed state and may be given less visual priority than other rows. Clients are not required to honor any conditions but should be consistent where possible about handling the conditions.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16941,6 +17546,7 @@ func schema_pkg_apis_meta_v1_TableRowCondition(ref common.ReferenceCallback) com
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status of the condition, one of True, False, Unknown.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -16988,6 +17594,7 @@ func schema_pkg_apis_meta_v1_Timestamp(ref common.ReferenceCallback) common.Open
 					"seconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -16995,6 +17602,7 @@ func schema_pkg_apis_meta_v1_Timestamp(ref common.ReferenceCallback) common.Open
 					"nanos": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.",
+							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -17061,8 +17669,9 @@ func schema_pkg_apis_meta_v1_UpdateOptions(ref common.ReferenceCallback) common.
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -17090,13 +17699,15 @@ func schema_pkg_apis_meta_v1_WatchEvent(ref common.ReferenceCallback) common.Ope
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"object": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},
@@ -17174,6 +17785,7 @@ func schema_k8sio_apimachinery_pkg_runtime_Unknown(ref common.ReferenceCallback)
 					"ContentEncoding": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ContentEncoding is encoding used to encode 'Raw' data. Unspecified means no encoding.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -17181,6 +17793,7 @@ func schema_k8sio_apimachinery_pkg_runtime_Unknown(ref common.ReferenceCallback)
 					"ContentType": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ContentType  is serialization method used to serialize 'Raw'. Unspecified means ContentTypeJSON.",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -17201,56 +17814,65 @@ func schema_k8sio_apimachinery_pkg_version_Info(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"major": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"minor": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"gitVersion": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"gitCommit": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"gitTreeState": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"buildDate": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"goVersion": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"compiler": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 					"platform": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the version of `controller-gen` in MakeFile , which is used to generate crd.
With use of this , now we can generate v1 version of CRD using the rule `make generate`. Earlier v1beta1 was getting generated.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
`make generate` now generates v1 version of CRDs by default instead of v1beta1.
```
