### PR TITLE
Fix CRD manifests

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -56,6 +56,7 @@ spec:
           providerSpec:
             description: Provider-specific configuration to use during node creation.
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           secretRef:
             description: SecretRef stores the necessary secrets such as credentials
               or userdata.

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -204,6 +204,7 @@ spec:
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   spec:
                     description: 'Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
@@ -250,6 +251,7 @@ spec:
                         properties:
                           metadata:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             description: NodeSpec describes the attributes that a
                               node is created with.

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -16,7 +16,18 @@ spec:
     singular: machine
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Current status of the machine.
+      jsonPath: .status.currentStatus.phase
+      name: Status
+      type: string
+    - description: |-
+        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Machine is the representation of a physical or virtual machine.

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -19,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Machine TODO
+        description: Machine is the representation of a physical or virtual machine.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -76,6 +76,7 @@ spec:
                 properties:
                   metadata:
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   spec:
                     description: NodeSpec describes the attributes that a node is
                       created with.

--- a/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
@@ -128,6 +128,7 @@ spec:
                   metadata:
                     description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   spec:
                     description: 'Specification of the desired behavior of the machine.
                       More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
@@ -174,6 +175,7 @@ spec:
                         properties:
                           metadata:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           spec:
                             description: NodeSpec describes the attributes that a
                               node is created with.

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -32,7 +32,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// Machine TODO
+// Machine is the representation of a physical or virtual machine.
 type Machine struct {
 	// ObjectMeta for machine object
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -81,6 +81,7 @@ type ClassSpec struct {
 
 // NodeTemplateSpec describes the data a node should have when created from a template
 type NodeTemplateSpec struct {
+	// +kubebuilder:validation:XPreserveUnknownFields
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -31,6 +31,8 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.currentStatus.phase`,description="Current status of the machine."
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
 
 // Machine is the representation of a physical or virtual machine.
 type Machine struct {

--- a/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -37,6 +37,7 @@ type MachineClass struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	// +kubebuilder:validation:XPreserveUnknownFields
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension `json:"providerSpec"`
 	// SecretRef stores the necessary secrets such as credentials or userdata.

--- a/pkg/apis/machine/v1alpha1/shared_types.go
+++ b/pkg/apis/machine/v1alpha1/shared_types.go
@@ -24,6 +24,7 @@ import (
 
 // MachineTemplateSpec describes the data a machine should have when created from a template
 type MachineTemplateSpec struct {
+	// +kubebuilder:validation:XPreserveUnknownFields
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
 	// +optional

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2309,7 +2309,7 @@ func schema_pkg_apis_machine_v1alpha1_Machine(ref common.ReferenceCallback) comm
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Machine TODO",
+				Description: "Machine is the representation of a physical or virtual machine.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"metadata": {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the CRD manifests for several objects that use `metav1.ObjectMeta` or `runtime.RawExtension`. It's necessary to set `x-kubernetes-preserve-unknown-fields: true` for these types because otherwise data underneath related fields is pruned and leads to validation errors in MCM.

Example:

```
I0824 09:05:30.777736       1 machine_controller_util.go:366] List machines failed on decodeProviderSpecAndSecret: machine codes error: code = [Internal] message = [Error while validating ProviderSpec [spec.disks: Required value: at least one disk is required spec.machineType: Required value: machineType is required spec.region: Required value: region is required spec.zone: Required value: zone is required spec.networkInterfaces.networkInterfaces: Required value: at least one network interface is required spec.scheduling.onHostMaintenance: Unsupported value: "": supported values: "MIGRATE", "TERMINATE" spec.serviceAccounts: Required value: at least one service account is required]]
# Please edit the object below. Lines beginning with a '#' will be ignored,
```

I added additional printer columns for `Machines` that we already use in Gardener along the way (4bb8db0636bbc35bfaa7e32e5fdf481ae746d2fb).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed in the pre-delivered CRD manifests for MCM (`/kubernetes/crds`). It caused data to be pruned from MCM related resources and led to reconciliation issues.
```
