### PR TITLE
added expectedNodeDetails field

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -1204,16 +1204,18 @@ type MachineClass struct {
 	metav1.TypeMeta
 	// +optional
 	metav1.ObjectMeta
+	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
+	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
+	CredentialsSecretRef *corev1.SecretReference
+	// ExpectedNodeAttributes contains subfields the track all scale from zero resources
+	ExpectedNodeAttributes *ExpectedNodeAttributes
+	// Provider is the combination of name and location of cloud-specific drivers.
+	// eg. awsdriver//127.0.0.1:8080
+	Provider string
 	// Provider-specific configuration to use during node creation.
 	ProviderSpec runtime.RawExtension
 	// SecretRef stores the necessary secrets such as credentials or userdata.
 	SecretRef *corev1.SecretReference
-	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
-	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
-	CredentialsSecretRef *corev1.SecretReference
-	// Provider is the combination of name and location of cloud-specific drivers.
-	// eg. awsdriver//127.0.0.1:8080
-	Provider string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -1223,4 +1225,20 @@ type MachineClassList struct {
 	metav1.TypeMeta
 	metav1.ListMeta
 	Items []MachineClass
+}
+
+// ExpectedNodeAttributes contains subfields to track all scale from zero resources
+type ExpectedNodeAttributes struct {
+	// CPU cores of the expected node
+	CPU *int64
+	// GPU cores of the expected node
+	GPU *int64
+	// Instance type of the expected node
+	InstanceType *string
+	// Memory of the expected node
+	Memory *int64
+	// Region of the expected node
+	Region *string
+	// Zone of the expected node
+	Zone *string
 }

--- a/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -38,15 +38,19 @@ type MachineClass struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XPreserveUnknownFields
-	// Provider-specific configuration to use during node creation.
-	ProviderSpec runtime.RawExtension `json:"providerSpec"`
-	// SecretRef stores the necessary secrets such as credentials or userdata.
-	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
+
 	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
 	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
 	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`
+	// ExpectedNodeAttributes contains subfields the track all scale from zero resources
+	// +optional
+	ExpectedNodeAttributes *ExpectedNodeAttributes `json:"expectedNodeAttributes,omitempty"`
+	// Provider-specific configuration to use during node creation.
+	ProviderSpec runtime.RawExtension `json:"providerSpec"`
 	// Provider is the combination of name and location of cloud-specific drivers.
 	Provider string `json:"provider,omitempty"`
+	// SecretRef stores the necessary secrets such as credentials or userdata.
+	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -57,4 +61,26 @@ type MachineClassList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []MachineClass `json:"items"`
+}
+
+// ExpectedNodeAttributes contains subfields to track all scale from zero resources
+type ExpectedNodeAttributes struct {
+	// CPU cores of the expected node
+	// +optional
+	CPU *int64 `json:"cpu,omitempty"`
+	// GPU cores of the expected node
+	// +optional
+	GPU *int64 `json:"gpu,omitempty"`
+	// Instance type of the expected node
+	// +optional
+	InstanceType *string `json:"instanceType,omitempty"`
+	// Memory of the expected node
+	// +optional
+	Memory *int64 `json:"memory,omitempty"`
+	// Region of the expected node
+	// +optional
+	Region *string `json:"region,omitempty"`
+	// Zone of the expected node
+	// +optional
+	Zone *string `json:"zone,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will add the new `*expectedNodeDetails` field to the `MachineClass` API for generic scale from zero implementation in CA

**Which issue(s) this PR fixes**:
Fixes [#98](https://github.com/gardener/autoscaler/issues/98)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added *expectedNodeDetails field to the MachineClass API
```
