### PR TITLE
Add lint target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,15 @@ verify: check test
 check:
 	@.ci/check
 
+.PHONY: lint
+lint:
+	docker run --rm -v ${PWD}:/work -w /work golangci/golangci-lint:v1.43-alpine golangci-lint run \
+		--presets bugs \
+		--presets unused \
+		--max-issues-per-linter=0 \
+		--max-same-issues=0 \
+		--timeout 15m
+
 .PHONY: test
 test:
 	@.ci/test


### PR DESCRIPTION
**What this PR does / why we need it**:
The code is actually not linted and contains a lot of code which needs to be fixed to pass basic linting rules.

With this PR introduce a `make lint` target which enables developers to quickly see what errors needs to be fixed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Introduce make lint target to show actual open issues in the codebase.
```
