### PR TITLE
Build with go-1.17.x

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,11 +19,11 @@ machine-controller-manager:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
     steps:
       check:
-        image: 'golang:1.16.6'
+        image: 'golang:1.17.3'
       test:
         image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
       build:
-        image: 'golang:1.16.6'
+        image: 'golang:1.17.3'
         output_dir: 'binary'
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 #############      builder                                  #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS builder
+FROM golang:1.17.3 AS builder
+
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager
 COPY . .
@@ -7,7 +8,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 as base
+FROM alpine:3.14.2 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /


### PR DESCRIPTION
**What this PR does / why we need it**:

Build with go-1.17.3 to align with the g/g project, also use the same build and run containers as in g/g

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Build with go-1.17.3 to align with the g/g project, also use the same build and run containers as in g/g
```
