### PR TITLE
IT suite waits to delete machine object

### DIFF
--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -861,6 +861,13 @@ func (c *IntegrationTestFramework) ControllerTests() {
 								Delete(ctx, "test-machine", metav1.DeleteOptions{})).
 							Should(gomega.BeNil(), "No Errors while deleting machine")
 
+						ginkgo.By("Waiting until test-machine machine object is deleted")
+						gomega.Eventually(
+							c.ControlCluster.IsTestMachineDeleted,
+							c.timeout,
+							c.pollingInterval).
+							Should(gomega.BeTrue())
+
 						ginkgo.By("Waiting until number of ready nodes is equal to number of initial  nodes")
 						gomega.Eventually(
 							c.TargetCluster.GetNumberOfNodes,

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -2,8 +2,11 @@ package helpers
 
 import (
 	"context"
+	"os"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -74,4 +77,15 @@ func (c *Cluster) CreateMachineDeployment(namespace string) error {
 			metav1.CreateOptions{},
 		)
 	return err
+}
+
+// IsTestMachineDeleted returns boolean value of presence of 'test-machine' object
+func (c *Cluster) IsTestMachineDeleted() bool {
+	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+	_, err := c.McmClient.
+		MachineV1alpha1().
+		Machines(controlClusterNamespace).
+		Get(context.Background(), "test-machine", metav1.GetOptions{})
+
+	return errors.IsNotFound(err)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the integration test suite's test case by adding another wait condition for the test machine object to be deleted. This is being added to make the tests more elegant though it is identified because of the significant impact in Azure.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I vendored these changes in the MCM-Provider-Azure and executed the Integration test. The test case in the context now works as expected.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
