### PR TITLE
Set `CONTROL_CLUSTER_NAMESPACE` env variable for integration tests

### DIFF
--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -200,6 +200,9 @@ func (c *IntegrationTestFramework) initalizeClusters() error {
 	} else if len(controlClusterNamespace) == 0 {
 		controlClusterNamespace = "default"
 	}
+
+	// setting env variable for later use
+	os.Setenv("CONTROL_CLUSTER_NAMESPACE", controlClusterNamespace)
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
for IT the env variable `CONTROL_CLUSTER_NAMESPACE` can remain unset(it can be set explicitly though by user) even when the code interprets the value of cluster namespace. 
But in some other parts of code to know the cluster namespace its beneficial if `CONTROL_CLUSTER_NAMESPACE` is set.
This PR sets the env variable.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
