### PR TITLE
Switch leader election to endpointleases

### DIFF
--- a/kubernetes/deployment/in-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/in-tree/control-cluster-role.yaml
@@ -42,3 +42,19 @@ rules:
    - patch
    - update
    - watch
+-  apiGroups:
+   - coordination.k8s.io
+   resources:
+   - leases
+   verbs:
+   - create
+-  apiGroups:
+   - coordination.k8s.io
+   resources:
+   - leases
+   resourceNames:
+   - machine-controller-manager
+   verbs:
+   - get
+   - watch
+   - update

--- a/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
@@ -47,3 +47,19 @@ rules:
    - patch
    - update
    - watch
+-  apiGroups:
+   - coordination.k8s.io
+   resources:
+   - leases
+   verbs:
+   - create
+-  apiGroups:
+   - coordination.k8s.io
+   resources:
+   - leases
+   resourceNames:
+   - machine-controller-manager
+   verbs:
+   - get
+   - watch
+   - update

--- a/pkg/util/client/leaderelectionconfig/config.go
+++ b/pkg/util/client/leaderelectionconfig/config.go
@@ -44,7 +44,8 @@ func DefaultLeaderElectionConfiguration() options.LeaderElectionConfiguration {
 		LeaseDuration: metav1.Duration{Duration: DefaultLeaseDuration},
 		RenewDeadline: metav1.Duration{Duration: DefaultRenewDeadline},
 		RetryPeriod:   metav1.Duration{Duration: DefaultRetryPeriod},
-		ResourceLock:  rl.EndpointsResourceLock,
+		// TODO(acumino): migrate default to `leases` in one of the next releases
+		ResourceLock: rl.EndpointsLeasesResourceLock,
 	}
 }
 
@@ -69,5 +70,6 @@ func BindFlags(l *options.LeaderElectionConfiguration, fs *pflag.FlagSet) {
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
 		"The type of resource object that is used for locking during "+
-		"leader election. Supported options are `endpoints` (default) and `configmap`.")
+		"leader election. Supported options are 'endpoints', 'configmaps', "+
+		"'leases', 'endpointsleases' and 'configmapsleases'.")
 }


### PR DESCRIPTION
/kind enhancement

CC: @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The default leader election resource lock of `machine-controller-manager` has been changed from `endpoints` to `endpointsleases`.
```
```breaking operator
Components that deploy the `machine-controller-manager` will now have to adapt the RBAC rules to allow `machine-controller-manager` to maintain its leader election resource lock in `leases` as well.
```
