### PR TITLE
Fix target name in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build-local:
 release: build build-local docker-image docker-login docker-push rename-binaries
 
 .PHONY: docker-image
-docker-images:
+docker-image:
 	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) --rm .
 
 .PHONY: docker-login


### PR DESCRIPTION
/kind bug

`./docs/deployment/kubernetes.md#build-the-docker-image` states that `make docker-image` is the corresponding target.

```
make docker-image IMAGE_REPOSITORY=$REPOSITORY IMAGE_TAG=$TAG
make: Nothing to be done for `docker-image'.
```

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
