### PR TITLE
Trigger orphan collection on OutOfRange machine status

### DIFF
--- a/pkg/util/provider/machinecontroller/controller.go
+++ b/pkg/util/provider/machinecontroller/controller.go
@@ -197,7 +197,9 @@ func NewController(
 	controller.machineSafetyOrphanVMsQueue.Add("")
 	controller.machineSafetyAPIServerQueue.Add("")
 	machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		// deleteMachineToSafety makes sure that orphan VM handler is invoked
+		// updateMachineToSafety makes sure that orphan VM handler is invoked on some specific machine obj updates
+		UpdateFunc: controller.updateMachineToSafety,
+		// deleteMachineToSafety makes sure that orphan VM handler is invoked on any machine deletion
 		DeleteFunc: controller.deleteMachineToSafety,
 	})
 

--- a/pkg/util/provider/machinecontroller/machine_safety.go
+++ b/pkg/util/provider/machinecontroller/machine_safety.go
@@ -19,11 +19,13 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/cache"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -304,6 +306,17 @@ func (c *controller) checkMachineClass(ctx context.Context, machineClass *v1alph
 	}
 
 	return machineutils.LongRetry, nil
+}
+
+// updateMachineToSafety enqueues into machineSafetyQueue when a machine is updated to particular status
+func (c *controller) updateMachineToSafety(oldObj, newObj interface{}) {
+	oldMachine := oldObj.(*v1alpha1.Machine)
+	newMachine := newObj.(*v1alpha1.Machine)
+
+	if !strings.Contains(oldMachine.Status.LastOperation.Description, codes.OutOfRange.String()) && strings.Contains(newMachine.Status.LastOperation.Description, codes.OutOfRange.String()) {
+		klog.Warningf("Multiple VMs backing machine obj %q found, triggering orphan collection.", newMachine.Name)
+		c.enqueueMachineSafetyOrphanVMsKey(newMachine)
+	}
 }
 
 // deleteMachineToSafety enqueues into machineSafetyQueue when a new machine is deleted

--- a/pkg/util/provider/machinecontroller/machine_safety.go
+++ b/pkg/util/provider/machinecontroller/machine_safety.go
@@ -313,6 +313,11 @@ func (c *controller) updateMachineToSafety(oldObj, newObj interface{}) {
 	oldMachine := oldObj.(*v1alpha1.Machine)
 	newMachine := newObj.(*v1alpha1.Machine)
 
+	if oldMachine == nil || newMachine == nil {
+		klog.Errorf("Couldn't convert to machine resource from object")
+		return
+	}
+
 	if !strings.Contains(oldMachine.Status.LastOperation.Description, codes.OutOfRange.String()) && strings.Contains(newMachine.Status.LastOperation.Description, codes.OutOfRange.String()) {
 		klog.Warningf("Multiple VMs backing machine obj %q found, triggering orphan collection.", newMachine.Name)
 		c.enqueueMachineSafetyOrphanVMsKey(newMachine)
@@ -322,6 +327,10 @@ func (c *controller) updateMachineToSafety(oldObj, newObj interface{}) {
 // deleteMachineToSafety enqueues into machineSafetyQueue when a new machine is deleted
 func (c *controller) deleteMachineToSafety(obj interface{}) {
 	machine := obj.(*v1alpha1.Machine)
+	if machine == nil {
+		klog.Errorf("Couldn't convert to machine resource from object")
+		return
+	}
 	c.enqueueMachineSafetyOrphanVMsKey(machine)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Till now orphan collection triggers on machine obj deletion or after 30min.
But to handle cases which arise due to eventual inconsistency in AWS , where multiple VMs can start backing a machine obj, in that case to stop machine-controller to reach the VM quota , orphan collection is now also triggered if machine object is updated with a `OutOfRange` error description.
The update of machine obj to `OutOfRange` can only happen by `GetMachineStatus` call , which is called only during a machine creation or deletion.

So in summary , orphan collection will be triggered in three cases now
* during creation if multiple VM are seen
* during deletion
* after 30min of last logic run for each machine object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I haven't enqueued in the orphan queue if status contains OOR error now , but only if the machine obj status `earlier didn't have ` OOR error and now have it. 
This is to deal with scenario where machine obj has OOR error already and any other status update event triggers. So if we enqueue just on presence of OOR error ,then orphan logic will be triggered almost all the time

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
orphan collection is also triggered if machine obj is updated with having multiple backing VMs
```
