### PR TITLE
Remove PreserveUnknown field of CredenetialSecretRef

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -42,7 +42,6 @@ spec:
                   must be unique.
                 type: string
             type: object
-            x-kubernetes-preserve-unknown-fields: true
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client

--- a/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -44,7 +44,6 @@ type MachineClass struct {
 	// NodeTemplate contains subfields to track all node resources and other node info required to scale nodegroup from zero
 	NodeTemplate *NodeTemplate `json:"nodeTemplate,omitempty"`
 
-	// +kubebuilder:validation:XPreserveUnknownFields
 	// CredentialsSecretRef can optionally store the credentials (in this case the SecretRef does not need to store them).
 	// This might be useful if multiple machine classes with the same credentials but different user-datas are used.
 	CredentialsSecretRef *corev1.SecretReference `json:"credentialsSecretRef,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
`CredentialSecretRef` doesn't require `x-kubernetes-preserve-unknown-fields: true` field in machineClass CRD. Its removed using this PR.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Refer to [this](https://github.com/gardener/gardener/pull/5266#discussion_r784038131) discussion for reason.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
