### PR TITLE
Scale down annotation value corrected

### DIFF
--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -113,11 +113,11 @@ const (
 	// ClusterAutoscalerScaleDownDisabledAnnotationKey annotation to disable the scale-down of the nodes.
 	ClusterAutoscalerScaleDownDisabledAnnotationKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
 	// ClusterAutoscalerScaleDownDisabledAnnotationValue annotation to disable the scale-down of the nodes.
-	ClusterAutoscalerScaleDownDisabledAnnotationValue = "True"
+	ClusterAutoscalerScaleDownDisabledAnnotationValue = "true"
 	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey annotation to disable the scale-down of the nodes.
 	ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled-by-mcm"
 	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue annotation to disable the scale-down of the nodes.
-	ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue = "True"
+	ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue = "true"
 
 	// RollbackRevisionNotFound is not found rollback event reason
 	RollbackRevisionNotFound = "DeploymentRollbackRevisionNotFound"


### PR DESCRIPTION
**What this PR does / why we need it**:
The annotation value of scale down annotation provided by CA has been changed from `True` to `true`. This will enable MCM to stop CA from scaling down during rolling update of machines.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The value for key `cluster-autoscaler.kubernetes.io/scale-down-disabled` placed by MCM is now `true` and not `True`. This typo stopped MCM from disabling CA from scaling down during rolling update.
```
