### PR TITLE
Refactor ClusterAutoscaler annotations to a separate package

### DIFF
--- a/pkg/controller/autoscaler/types.go
+++ b/pkg/controller/autoscaler/types.go
@@ -1,0 +1,12 @@
+package autoscaler
+
+const (
+	// ClusterAutoscalerScaleDownDisabledAnnotationKey annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+	// ClusterAutoscalerScaleDownDisabledAnnotationValue annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationValue = "true"
+	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled-by-mcm"
+	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue annotation to disable the scale-down of the nodes.
+	ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue = "true"
+)

--- a/pkg/controller/deployment_recreate.go
+++ b/pkg/controller/deployment_recreate.go
@@ -26,18 +26,18 @@ import (
 	"context"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/controller/autoscaler"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 )
 
 // rolloutRecreate implements the logic for recreating a machine set.
 func (dc *controller) rolloutRecreate(ctx context.Context, d *v1alpha1.MachineDeployment, isList []*v1alpha1.MachineSet, machineMap map[types.UID]*v1alpha1.MachineList) error {
-
 	clusterAutoscalerScaleDownAnnotations := make(map[string]string)
-	clusterAutoscalerScaleDownAnnotations[ClusterAutoscalerScaleDownDisabledAnnotationKey] = ClusterAutoscalerScaleDownDisabledAnnotationValue
+	clusterAutoscalerScaleDownAnnotations[autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationKey] = autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationValue
 
 	// We do this to avoid accidentally deleting the user provided annotations.
-	clusterAutoscalerScaleDownAnnotations[ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey] = ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue
+	clusterAutoscalerScaleDownAnnotations[autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey] = autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue
 
 	// Don't create a new RS if not already existed, so that we avoid scaling up before scaling down.
 	newIS, oldISs, err := dc.getAllMachineSetsAndSyncRevision(ctx, d, isList, machineMap, false)

--- a/pkg/controller/deployment_rolling_test.go
+++ b/pkg/controller/deployment_rolling_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	machinev1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/controller/autoscaler"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -29,7 +30,6 @@ import (
 )
 
 var _ = Describe("deployment_rolling", func() {
-
 	Describe("#taintNodesBackingMachineSets", func() {
 		type setup struct {
 			nodes       []*corev1.Node
@@ -121,7 +121,6 @@ var _ = Describe("deployment_rolling", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(actualNode.Spec.Taints).Should(ConsistOf(expectedNode.Spec.Taints))
 				}
-
 			},
 			Entry("taints on nodes backing machineSet", &data{
 				setup: setup{
@@ -613,8 +612,8 @@ var _ = Describe("deployment_rolling", func() {
 					),
 					existingAnnotations: map[string]string{
 						"anno1": "anno1",
-						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
-						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationKey:      autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationValue,
 					},
 				},
 				action: action{
@@ -637,8 +636,8 @@ var _ = Describe("deployment_rolling", func() {
 						nil,
 					),
 					annotations: map[string]string{
-						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
-						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationKey:      autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationValue,
 					},
 				},
 				expect: expect{
@@ -669,7 +668,7 @@ var _ = Describe("deployment_rolling", func() {
 					),
 					existingAnnotations: map[string]string{
 						"anno1": "anno1",
-						ClusterAutoscalerScaleDownDisabledAnnotationKey: ClusterAutoscalerScaleDownDisabledAnnotationValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationKey: autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationValue,
 					},
 				},
 				action: action{
@@ -692,14 +691,14 @@ var _ = Describe("deployment_rolling", func() {
 						nil,
 					),
 					annotations: map[string]string{
-						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
-						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationKey:      autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationValue,
 					},
 				},
 				expect: expect{
 					nodeAnnotations: map[string]string{
 						"anno1": "anno1",
-						ClusterAutoscalerScaleDownDisabledAnnotationKey: ClusterAutoscalerScaleDownDisabledAnnotationValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationKey: autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationValue,
 					},
 					err: false,
 				},
@@ -747,8 +746,8 @@ var _ = Describe("deployment_rolling", func() {
 						nil,
 					),
 					annotations: map[string]string{
-						ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
-						ClusterAutoscalerScaleDownDisabledAnnotationKey:      ClusterAutoscalerScaleDownDisabledAnnotationValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue,
+						autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationKey:      autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationValue,
 					},
 				},
 				expect: expect{

--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -110,14 +110,6 @@ const (
 	// PreferNoScheduleKey is used to identify machineSet nodes on which PreferNoSchedule taint is added on
 	// older machineSets during a rolling update
 	PreferNoScheduleKey = "deployment.machine.sapcloud.io/prefer-no-schedule"
-	// ClusterAutoscalerScaleDownDisabledAnnotationKey annotation to disable the scale-down of the nodes.
-	ClusterAutoscalerScaleDownDisabledAnnotationKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
-	// ClusterAutoscalerScaleDownDisabledAnnotationValue annotation to disable the scale-down of the nodes.
-	ClusterAutoscalerScaleDownDisabledAnnotationValue = "true"
-	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey annotation to disable the scale-down of the nodes.
-	ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey = "cluster-autoscaler.kubernetes.io/scale-down-disabled-by-mcm"
-	// ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue annotation to disable the scale-down of the nodes.
-	ClusterAutoscalerScaleDownDisabledAnnotationByMCMValue = "true"
 
 	// RollbackRevisionNotFound is not found rollback event reason
 	RollbackRevisionNotFound = "DeploymentRollbackRevisionNotFound"
@@ -316,7 +308,7 @@ func SetNewMachineSetAnnotations(deployment *v1alpha1.MachineDeployment, newIS *
 			klog.Warningf("Updating machine set revision OldRevision not int %s", err)
 			return false
 		}
-		//If the RS annotation is empty then initialise it to 0
+		// If the RS annotation is empty then initialise it to 0
 		oldRevisionInt = 0
 	}
 	newRevisionInt, err := strconv.ParseInt(newRevision, 10, 64)
@@ -366,7 +358,7 @@ func SetNewMachineSetNodeTemplate(deployment *v1alpha1.MachineDeployment, newIS 
 			klog.Warningf("Updating machine set revision OldRevision not int %s", err)
 			return false
 		}
-		//If the RS annotation is empty then initialise it to 0
+		// If the RS annotation is empty then initialise it to 0
 		oldRevisionInt = 0
 	}
 	newRevisionInt, err := strconv.ParseInt(newRevision, 10, 64)
@@ -416,7 +408,7 @@ func SetNewMachineSetConfig(deployment *v1alpha1.MachineDeployment, newIS *v1alp
 			klog.Warningf("Updating machine set revision OldRevision not int %s", err)
 			return false
 		}
-		//If the RS annotation is empty then initialise it to 0
+		// If the RS annotation is empty then initialise it to 0
 		oldRevisionInt = 0
 	}
 	newRevisionInt, err := strconv.ParseInt(newRevision, 10, 64)
@@ -511,7 +503,6 @@ func copyMachineDeploymentNodeTemplatesToMachineSet(deployment *v1alpha1.Machine
 // and returns true if machine set's configuration is changed.
 // Note that apply and revision configuration are not copied.
 func copyMachineDeploymentConfigToMachineSet(deployment *v1alpha1.MachineDeployment, is *v1alpha1.MachineSet) bool {
-
 	isConfigChanged := !(apiequality.Semantic.DeepEqual(deployment.Spec.Template.Spec.MachineConfiguration, is.Spec.Template.Spec.MachineConfiguration))
 
 	if isConfigChanged {
@@ -1188,7 +1179,6 @@ func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired
 
 // statusUpdateRequired checks for if status update is required comparing two MachineDeployment statuses
 func statusUpdateRequired(old v1alpha1.MachineDeploymentStatus, new v1alpha1.MachineDeploymentStatus) bool {
-
 	if old.AvailableReplicas == new.AvailableReplicas &&
 		old.CollisionCount == new.CollisionCount &&
 		len(old.FailedMachines) == len(new.FailedMachines) &&

--- a/pkg/util/provider/machinecontroller/machine_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_util_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	machinev1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	mcmcore "github.com/gardener/machine-controller-manager/pkg/controller"
+	"github.com/gardener/machine-controller-manager/pkg/controller/autoscaler"
 	"github.com/gardener/machine-controller-manager/pkg/fakeclient"
 	"github.com/gardener/machine-controller-manager/pkg/util/permits"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
@@ -48,9 +48,7 @@ const (
 )
 
 var _ = Describe("machine_util", func() {
-
 	Describe("#syncMachineNodeTemplates", func() {
-
 		type setup struct {
 			machine *machinev1.Machine
 		}
@@ -96,7 +94,7 @@ var _ = Describe("machine_util", func() {
 					Expect(err).To(Equal(data.expect.err))
 				}
 
-				//updatedNodeObject, _ := c.nodeLister.Get(nodeObject.Name)
+				// updatedNodeObject, _ := c.nodeLister.Get(nodeObject.Name)
 				updatedNodeObject, _ := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), nodeObject.Name, metav1.GetOptions{})
 
 				if data.expect.node != nil {
@@ -134,11 +132,12 @@ var _ = Describe("machine_util", func() {
 										},
 									},
 									Spec: corev1.NodeSpec{
-										Taints: []corev1.Taint{{
-											Key:    "key1",
-											Value:  "value1",
-											Effect: "NoSchedule",
-										},
+										Taints: []corev1.Taint{
+											{
+												Key:    "key1",
+												Value:  "value1",
+												Effect: "NoSchedule",
+											},
 										},
 									},
 								},
@@ -437,11 +436,9 @@ var _ = Describe("machine_util", func() {
 				},
 			}),
 		)
-
 	})
 
 	Describe("#SyncMachineLabels", func() {
-
 		type setup struct{}
 		type action struct {
 			node    *corev1.Node
@@ -871,11 +868,9 @@ var _ = Describe("machine_util", func() {
 				},
 			}),
 		)
-
 	})
 
 	Describe("#SyncMachineAnnotations", func() {
-
 		type setup struct{}
 		type action struct {
 			node    *corev1.Node
@@ -1289,11 +1284,9 @@ var _ = Describe("machine_util", func() {
 				},
 			}),
 		)
-
 	})
 
 	Describe("#SyncMachineTaints", func() {
-
 		type setup struct{}
 		type action struct {
 			node    *corev1.Node
@@ -1868,11 +1861,9 @@ var _ = Describe("machine_util", func() {
 				},
 			}),
 		)
-
 	})
 
 	Describe("#isMachineStatusSimilar", func() {
-
 		type setup struct {
 			m1, m2 machinev1.MachineStatus
 		}
@@ -2006,11 +1997,9 @@ var _ = Describe("machine_util", func() {
 				},
 			}),
 		)
-
 	})
 
 	Describe("#validateNodeTemplate", func() {
-
 		type setup struct {
 			machineClass *machinev1.MachineClass
 		}
@@ -2125,10 +2114,10 @@ var _ = Describe("machine_util", func() {
 		type setup struct {
 			machines []*v1alpha1.Machine
 			nodes    []*v1.Node
-			//targetMachineName is name of machine for which `reconcileMachineHealth()` needs to be called
-			//Its must this machine in machine list
+			// targetMachineName is name of machine for which `reconcileMachineHealth()` needs to be called
+			// Its must this machine in machine list
 			targetMachineName string
-			//to check case when lock can't be acquired for long time
+			// to check case when lock can't be acquired for long time
 			lockAlreadyAcquired bool
 		}
 		type expect struct {
@@ -2320,7 +2309,7 @@ var _ = Describe("machine_util", func() {
 							nil, map[string]string{"node": "node-0"}, true, metav1.Now()),
 					},
 					nodes: []*v1.Node{
-						newNode(1, nil, map[string]string{mcmcore.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: "true"}, &v1.NodeSpec{}, &v1.NodeStatus{Phase: corev1.NodeRunning, Conditions: nodeConditions(false, false, false, false, false)}),
+						newNode(1, nil, map[string]string{autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: "true"}, &v1.NodeSpec{}, &v1.NodeStatus{Phase: corev1.NodeRunning, Conditions: nodeConditions(false, false, false, false, false)}),
 					},
 					targetMachineName: machineSet1Deploy1 + "-" + "0",
 				},
@@ -2405,7 +2394,7 @@ var _ = Describe("machine_util", func() {
 			Expect(getErr).To(BeNil())
 			Expect(data.expect.expectedPhase).To(Equal(updatedTargetMachine.Status.CurrentStatus.Phase))
 		},
-			//Note: Test cases assume 1 maxReplacements per machinedeployment
+			// Note: Test cases assume 1 maxReplacements per machinedeployment
 
 			Entry("2 HealthTimedOut machines: from different machinedeployments,only 1 machine per machineDeployment present, targetMachine should be marked Failed", &data{
 				setup: setup{


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors autoscaler annotations to a separate package. This is necessary because with the inclusion of https://github.com/gardener/machine-controller-manager/pull/683 build targets for mcm-extensions that  depend on https://github.com/gardener/machine-controller-manager/tree/master/pkg/util/provider/app to start the machine controller will now include `gardener/machine-controller-manager/tree/master/pkg/driver` in their build.

This is problematic because the extensions now have a dependency on the infrastructure provider clients bundled with MCM that may conflict with their versions. It is better if this import chain is eliminated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Refactor autoscaler annotation to a separate package
```
