### PR TITLE
Nullable time fields

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -393,10 +393,12 @@ spec:
                       description: Last time the condition transitioned from one status
                         to another.
                       format: date-time
+                      nullable: true
                       type: string
                     lastUpdateTime:
                       description: The last time this condition was updated.
                       format: date-time
+                      nullable: true
                       type: string
                     message:
                       description: A human readable message indicating details about
@@ -432,6 +434,7 @@ spec:
                         lastUpdateTime:
                           description: Last update time of current operation
                           format: date-time
+                          nullable: true
                           type: string
                         state:
                           description: State of operation

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -237,6 +237,7 @@ spec:
                   lastUpdateTime:
                     description: Last update time of current status
                     format: date-time
+                    nullable: true
                     type: string
                   phase:
                     description: MachinePhase is a label for the condition of a machines
@@ -260,6 +261,7 @@ spec:
                   lastUpdateTime:
                     description: Last update time of current operation
                     format: date-time
+                    nullable: true
                     type: string
                   state:
                     description: State of operation

--- a/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
@@ -315,6 +315,7 @@ spec:
                         lastUpdateTime:
                           description: Last update time of current operation
                           format: date-time
+                          nullable: true
                           type: string
                         state:
                           description: State of operation
@@ -349,6 +350,7 @@ spec:
                   lastUpdateTime:
                     description: Last update time of current operation
                     format: date-time
+                    nullable: true
                     type: string
                   state:
                     description: State of operation
@@ -368,6 +370,7 @@ spec:
                       description: The last time the condition transitioned from one
                         status to another.
                       format: date-time
+                      nullable: true
                       type: string
                     message:
                       description: A human readable message indicating details about

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -162,6 +162,7 @@ type CurrentStatus struct {
 	TimeoutActive bool
 
 	// Last update time of current status
+	// +nullable
 	LastUpdateTime metav1.Time
 }
 
@@ -191,6 +192,7 @@ type LastOperation struct {
 	Description string
 
 	// Last update time of current operation
+	// +nullable
 	LastUpdateTime metav1.Time
 
 	// State of operation
@@ -336,6 +338,7 @@ type MachineSetCondition struct {
 	Status ConditionStatus
 
 	// The last time the condition transitioned from one status to another.
+	//+nullable
 	LastTransitionTime metav1.Time
 
 	// The reason for the condition's last transition.
@@ -598,9 +601,11 @@ type MachineDeploymentCondition struct {
 	Status ConditionStatus
 
 	// The last time this condition was updated.
+	//+nullable
 	LastUpdateTime metav1.Time
 
 	// Last time the condition transitioned from one status to another.
+	//+nullable
 	LastTransitionTime metav1.Time
 
 	// The reason for the condition's last transition.

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -119,6 +119,7 @@ type LastOperation struct {
 	Description string `json:"description,omitempty"`
 
 	// Last update time of current operation
+	//+nullable
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
 
 	// State of operation
@@ -209,6 +210,7 @@ type CurrentStatus struct {
 	TimeoutActive bool `json:"timeoutActive,omitempty"`
 
 	// Last update time of current status
+	//+nullable
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
 }
 

--- a/pkg/apis/machine/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/machine/v1alpha1/machinedeployment_types.go
@@ -245,9 +245,11 @@ type MachineDeploymentCondition struct {
 	Status ConditionStatus `json:"status"`
 
 	// The last time this condition was updated.
+	//+nullable
 	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
 
 	// Last time the condition transitioned from one status to another.
+	//+nullable
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// The reason for the condition's last transition.

--- a/pkg/apis/machine/v1alpha1/machineset_types.go
+++ b/pkg/apis/machine/v1alpha1/machineset_types.go
@@ -102,6 +102,7 @@ type MachineSetCondition struct {
 
 	// The last time the condition transitioned from one status to another.
 	// +optional
+	//+nullable
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// The reason for the condition's last transition.


### PR DESCRIPTION
**What this PR does / why we need it**:
Made the metav1.time fields nullable as it was affecting Kubernetes clusters of k8s version < 1.20. for k8s version >=1.20 the field has been made nullable by default.
**Which issue(s) this PR fixes**:
Fixes #642 

**Special notes for your reviewer**:
couldn't recreate the error mentioned in the issue. But as per https://github.com/kubernetes/kubernetes/issues/86811#issuecomment-808932761 the issue is fixed in k8s version 1.20 for earlier versions the fix should work.
for testing need to create a older version seed to test.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
The metav1.time fields are now `nullable` for older version(<1.20) of k8s also. 
```
