### PR TITLE
Annotate mcm during Integration Tests

### DIFF
--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+const dwdIgnoreScalingAnnotation = "dependency-watchdog.gardener.cloud/ignore-scaling"
+
 var (
 	// path for storing log files (mcm & mc processes)
 	targetDir = filepath.Join("..", "..", "..", ".ci", "controllers-test", "logs")
@@ -442,6 +444,11 @@ func (c *IntegrationTestFramework) scaleMcmDeployment(replicas int32) error {
 			return getErr
 		}
 
+		if replicas == 0 {
+			result.ObjectMeta.Annotations[dwdIgnoreScalingAnnotation] = "true"
+		} else if replicas == 1 {
+			delete(result.ObjectMeta.Annotations, dwdIgnoreScalingAnnotation)
+		}
 		// if number of replicas is not equal to the required replicas then update
 		if *result.Spec.Replicas != replicas {
 			*result.Spec.Replicas = replicas


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an annotation to stop scaling up of MCM automatically by Dependency-watchdog during integration tests.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
MCM is annotated to ignore scaling by DWD during IT. Annotation is removed after the tests
```
