### PR TITLE
Migrate leader election to leases

### DIFF
--- a/kubernetes/deployment/in-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/in-tree/control-cluster-role.yaml
@@ -31,7 +31,6 @@ rules:
    - nodes/status
    - configmaps
    - secrets
-   - endpoints
    - events
    verbs:
    - create

--- a/kubernetes/deployment/in-tree/target-cluster-role.yaml
+++ b/kubernetes/deployment/in-tree/target-cluster-role.yaml
@@ -7,7 +7,6 @@ rules:
    - ""
    resources:
    - nodes
-   - endpoints
    - replicationcontrollers
    - pods
    verbs:

--- a/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
@@ -36,7 +36,6 @@ rules:
    - nodes/status
    - configmaps
    - secrets
-   - endpoints
    - events
    verbs:
    - create

--- a/kubernetes/deployment/out-of-tree/target-cluster-role.yaml
+++ b/kubernetes/deployment/out-of-tree/target-cluster-role.yaml
@@ -7,7 +7,6 @@ rules:
    - ""
    resources:
    - nodes
-   - endpoints
    - replicationcontrollers
    - pods
    verbs:

--- a/pkg/util/client/leaderelectionconfig/config.go
+++ b/pkg/util/client/leaderelectionconfig/config.go
@@ -44,8 +44,7 @@ func DefaultLeaderElectionConfiguration() options.LeaderElectionConfiguration {
 		LeaseDuration: metav1.Duration{Duration: DefaultLeaseDuration},
 		RenewDeadline: metav1.Duration{Duration: DefaultRenewDeadline},
 		RetryPeriod:   metav1.Duration{Duration: DefaultRetryPeriod},
-		// TODO(acumino): migrate default to `leases` in one of the next releases
-		ResourceLock: rl.EndpointsLeasesResourceLock,
+		ResourceLock:  rl.LeasesResourceLock,
 	}
 }
 


### PR DESCRIPTION
/kind enhancement

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4742

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The default leader election resource lock of `machine-controller-manager` has been changed from `endpointsleases` to `leases`.
Please make sure, that you had at least `machine-controller-manager@v0.43.0` running before upgrading to `v0.46.0`, so that it has successfully acquired leadership with the hybrid resource lock (`endpointsleases`) at least once.
```
