### PR TITLE
update local_setup.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,9 @@ download-kubeconfigs:
 	read SEED; \
 	echo "enter shoot name"; \
 	read SHOOT; \
-	./hack/local_setup.sh --SEED $$SEED --SHOOT $$SHOOT --PROJECT $$PROJECT;
+	echo "enter cluster provider(gcp|aws|azure|vsphere|openstack|alicloud|metal|equinix-metal)"; \
+	read PROVIDER; \
+	./hack/local_setup.sh --SEED $$SEED --SHOOT $$SHOOT --PROJECT $$PROJECT --PROVIDER $$PROVIDER
 
 .PHONY: local-mcm-up
 local-mcm-up: download-kubeconfigs

--- a/hack/local_setup.sh
+++ b/hack/local_setup.sh
@@ -128,9 +128,9 @@ scaleDownMCM() {
 
 updateMCMMakefile() {
      # Point the makefiles to the correct kubeconfigs to use for local run
-     sed -i -e "s/\(CONTROL_NAMESPACE :=\).*/\1 shoot--"${PROJECT}"--"${SHOOT}"/1" "${PROJECT_ROOT}"/makefile
-     sed -i -e "s/\(CONTROL_KUBECONFIG :=\).*/\1 dev\/kubeconfigs\/kubeconfig_control.yaml/1" "${PROJECT_ROOT}"/makefile
-     sed -i -e "s/\(TARGET_KUBECONFIG :=\).*/\1 dev\/kubeconfigs\/kubeconfig_target.yaml/1" "${PROJECT_ROOT}"/makefile
+     sed -i -e "s/\(CONTROL_NAMESPACE *:=\).*/\1 shoot--"${PROJECT}"--"${SHOOT}"/1" "${PROJECT_ROOT}"/makefile
+     sed -i -e "s/\(CONTROL_KUBECONFIG *:=\).*/\1 dev\/kubeconfigs\/kubeconfig_control.yaml/1" "${PROJECT_ROOT}"/makefile
+     sed -i -e "s/\(TARGET_KUBECONFIG *:=\).*/\1 dev\/kubeconfigs\/kubeconfig_target.yaml/1" "${PROJECT_ROOT}"/makefile
 }
 
 exportVariables() {
@@ -141,9 +141,9 @@ exportVariables() {
 
 updateProviderMakefile() {
      # Makefile of provider also needs to point at those kubeconfigs
-     sed -i -e "s/\(CONTROL_NAMESPACE := \).*/\1 shoot--"${PROJECT}"--"${SHOOT}"/1" "${PROVIDER_PATH}"/makefile
-     sed -i -e "s/\(CONTROL_KUBECONFIG := \).*/\1 dev\/kubeconfigs\/kubeconfig_control.yaml/1" "${PROVIDER_PATH}"/makefile
-     sed -i -e "s/\(TARGET_KUBECONFIG := \).*/\1 dev\/kubeconfigs\/kubeconfig_target.yaml/1" "${PROVIDER_PATH}"/makefile
+     sed -i -e "s/\(CONTROL_NAMESPACE *:= *\).*/\1 shoot--"${PROJECT}"--"${SHOOT}"/1" "${PROVIDER_PATH}"/makefile
+     sed -i -e "s/\(CONTROL_KUBECONFIG *:= *\).*/\1 dev\/kubeconfigs\/kubeconfig_control.yaml/1" "${PROVIDER_PATH}"/makefile
+     sed -i -e "s/\(TARGET_KUBECONFIG *:= *\).*/\1 dev\/kubeconfigs\/kubeconfig_target.yaml/1" "${PROVIDER_PATH}"/makefile
 }
 
 main

--- a/hack/local_setup.sh
+++ b/hack/local_setup.sh
@@ -16,6 +16,7 @@
 
 
 # THE SCRIPT SHOULD BE RUN WHILE IN THE `machine-controller-manager/hack` FOLDER & IT ASSUMES THAT IN THE PARENT DIRECTORY OF MCM THE MCM PROVIDER IS ALSO PRESENT
+# THE SCRIPT ALSO ASSUMES THAT THERE THE `machine-controller-manager-provider-<provider-name>/dev/kubeconfigs` FOLDER EXISTS.
 
 #HOW TO CALL 
 ################################################################################################

--- a/hack/local_setup.sh
+++ b/hack/local_setup.sh
@@ -21,7 +21,7 @@
 #HOW TO CALL 
 ################################################################################################
 
-# ./local_setup.sh --PROJECT <project-name> --SEED <seed-name> --SHOOT <shoot-name>
+# ./local_setup.sh --PROJECT <project-name> --SEED <seed-name> --SHOOT <shoot-name> --PROVIDER <cluster-provider-name>
 
 ################################################################################################
 #!/usr/bin/env bash
@@ -33,6 +33,7 @@ set -o pipefail
 declare SEED 
 declare SHOOT
 declare PROJECT 
+declare PROVIDER
 declare CURRENT_DIR
 declare PROJECT_ROOT
 declare KUBECONFIG_PATH
@@ -69,12 +70,10 @@ main() {
 }
 
 setPaths() {
-
      CURRENT_DIR=$(dirname $0)
      PROJECT_ROOT="${CURRENT_DIR}"/..
      KUBECONFIG_PATH="${PROJECT_ROOT}"/dev/kubeconfigs
-     PROVIDER=$(ls "${PROJECT_ROOT}"/../ | grep machine-controller-manager-provider-${SEED}.*)
-     PROVIDER_PATH="${PROJECT_ROOT}"/../${PROVIDER}
+     PROVIDER_PATH="${PROJECT_ROOT}"/../machine-controller-manager-provider-${PROVIDER}
      PROVIDER_KUBECONFIG_PATH="${PROVIDER_PATH}"/dev/kubeconfigs
 }
 

--- a/hack/local_setup.sh
+++ b/hack/local_setup.sh
@@ -73,7 +73,8 @@ setPaths() {
      CURRENT_DIR=$(dirname $0)
      PROJECT_ROOT="${CURRENT_DIR}"/..
      KUBECONFIG_PATH="${PROJECT_ROOT}"/dev/kubeconfigs
-     PROVIDER_PATH="${PROJECT_ROOT}"/../machine-controller-manager-provider-"${SEED}"
+     PROVIDER=$(ls "${PROJECT_ROOT}"/../ | grep machine-controller-manager-provider-${SEED}.*)
+     PROVIDER_PATH="${PROJECT_ROOT}"/../${PROVIDER}
      PROVIDER_KUBECONFIG_PATH="${PROVIDER_PATH}"/dev/kubeconfigs
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
settles a problem with local_setup.sh working with the providers where it allowed only a single space before and after `:=`. But now, it'll allow for any number of spaces b/w `variable_name` and `:=` in the provider's makefile and mcm's makefile.
Now provider is to be passed as a separate entity from the seed name, which was earlier passed as one. This makes the local setup ready to work on other providers, like azure and vsphere, where the seed name can be az or anything, but the provider name is azure.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
