### PR TITLE
Automated cherry pick of #713: alpine and golang image updated

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,11 +19,11 @@ machine-controller-manager:
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
     steps:
       check:
-        image: 'golang:1.17.5'
+        image: 'golang:1.17.9'
       test:
         image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
       build:
-        image: 'golang:1.17.5'
+        image: 'golang:1.17.9'
         output_dir: 'binary'
   jobs:
     head-update:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder                                  #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.17.5 AS builder
+FROM golang:1.17.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/machine-controller-manager
 COPY . .
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.15.0 as base
+FROM alpine:3.15.4 as base
 
 RUN apk add --update bash curl tzdata
 WORKDIR /


### PR DESCRIPTION
Cherry pick of #713 on rel-v0.43.

#713: alpine and golang image updated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Base image updated to alpine `v3.15.4` and build image to golang `1.17.9`.
```