### PR TITLE
No orphan collection during machine Controller freeze

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20211110012726-3cc51fd1e909 // keep this value in sync with k8s.io/apiserver
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed
+	github.com/go-logr/logr v0.4.0
 )
 
 require (
@@ -57,7 +58,6 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.3 // indirect
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/swag v0.19.5 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
There was a case where if machine controller is frozen due to API server not reachable, it still was doing orphan collection. This led to problem during control plane migration, where the MCM of the source seed control plane deleted the nodes every 20min(default orphan collection period) after the migration, which ideally it shouldn't do

**Which issue(s) this PR fixes**:
Fixes #718 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
orphan collection disabled when machine controller is frozen (Needs revendoring in providers to get enabled)
```
