### PR TITLE
Build Multi-Arch Images 📦

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -42,21 +42,8 @@ cd "${SOURCE_PATH}"
 
 ###############################################################################
 
-# If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux OS, amd64 architectures and without CGO enablement.
-if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build \
-    -a \
-    -v \
-    -mod=vendor \
-    -o "${BINARY_PATH}/rel/machine-controller-manager" \
-    cmd/machine-controller-manager/controller_manager.go
-
-# If the LOCAL_BUILD environment variable is set, we simply run `go build`.
-else
-  GO111MODULE=on go build \
-    -v \
-    -mod=vendor \
-    -o "${BINARY_PATH}/machine-controller-manager" \
-    cmd/machine-controller-manager/controller_manager.go
-fi
+CGO_ENABLED=0 GO111MODULE=on go build \
+  -v \
+  -mod=vendor \
+  -o "${BINARY_PATH}/machine-controller-manager" \
+  cmd/machine-controller-manager/controller_manager.go

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,6 +8,10 @@ machine-controller-manager:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           machine-controller-manager:
             inputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ WORKDIR /
 #############      machine-controller-manager               #############
 FROM base AS machine-controller-manager
 
-COPY --from=builder /go/src/github.com/gardener/machine-controller-manager/bin/rel/machine-controller-manager /machine-controller-manager
+COPY --from=builder /go/src/github.com/gardener/machine-controller-manager/bin/machine-controller-manager /machine-controller-manager
 ENTRYPOINT ["/machine-controller-manager"]

--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,8 @@ revendor:
 build:
 	@.ci/build
 
-.PHONY: build-local
-build-local:
-	@env LOCAL_BUILD=1 .ci/build
-
 .PHONY: release
-release: build build-local docker-image docker-login docker-push rename-binaries
+release: build docker-image docker-login docker-push
 
 .PHONY: docker-image
 docker-image:
@@ -115,16 +111,9 @@ docker-push:
 	@if ! docker images $(IMAGE_REPOSITORY) | awk '{ print $$2 }' | grep -q -F $(IMAGE_TAG); then echo "$(IMAGE_REPOSITORY) version $(IMAGE_TAG) is not yet built. Please run 'make docker-images'"; false; fi
 	@gcloud docker -- push $(IMAGE_REPOSITORY):$(IMAGE_TAG)
 
-.PHONY: rename-binaries
-rename-binaries:
-	@if [[ -f bin/machine-controller-manager ]]; then cp bin/machine-controller-manager machine-controller-manager-darwin-amd64; fi
-	@if [[ -f bin/rel/machine-controller-manager ]]; then cp bin/rel/machine-controller-manager machine-controller-manager-linux-amd64; fi
-
 .PHONY: clean
 clean:
 	@rm -rf bin/
-	@rm -f *linux-amd64
-	@rm -f *darwin-amd64
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images with support for `linux/amd64` and `linux/arm64`.

/kind enhancement
/area delivery

**Which issue(s) this PR fixes**:
Fixes parts of https://github.com/gardener/gardener/issues/6258

**Special notes for your reviewer**:
The `build` steps have been unified along the way, i.e. `make build` builds the MCM binary locally for the system the build is executed on and `make docker-image` builds the MCM binary within the docker image. There is no dedicated local linux/amd64 build anymore as I didn't see any benefit of keeping it. Please let me know if you think otherwise.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Published docker images for Machine-Controller-Manager are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
