### PR TITLE
Mark machine failed during rollout also

### DIFF
--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -18,7 +18,9 @@ package controller
 
 import (
 	"context"
+	"flag"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -45,6 +47,12 @@ import (
 )
 
 func TestMachineControllerManagerSuite(t *testing.T) {
+	//for filtering out warning logs. Reflector short watch warning logs won't print now
+	klog.SetOutput(io.Discard)
+	flags := &flag.FlagSet{}
+	klog.InitFlags(flags)
+	flags.Set("logtostderr", "false")
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Machine Controller Manager Suite")
 }

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -35,7 +35,6 @@ import (
 
 	machineapi "github.com/gardener/machine-controller-manager/pkg/apis/machine"
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/gardener/machine-controller-manager/pkg/controller/autoscaler"
 	"github.com/gardener/machine-controller-manager/pkg/util/nodeops"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/drain"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
@@ -739,11 +738,6 @@ func (c *controller) reconcileMachineHealth(ctx context.Context, machine *v1alph
 					timeOutDuration,
 					machine.Status.Conditions,
 				)
-				// ensuring rollout of machineDeployment is not happening
-				if c.isRollingOut(machine) {
-					klog.V(2).Infof("Skipping marking machine=%s Failed, as rollout for corresponding machineDeployment is happening, will retry in next sync", machine.Name)
-					return machineutils.MediumRetry, nil
-				}
 
 				machineDeployName := getMachineDeploymentName(machine)
 				// creating lock for machineDeployment, if not allocated
@@ -1512,27 +1506,6 @@ func (c *controller) tryMarkingMachineFailed(ctx context.Context, machine, clone
 	err := fmt.Errorf("timedout waiting to acquire lock for machine %q", machine.Name)
 
 	return machineutils.ShortRetry, err
-}
-
-func (c *controller) isRollingOut(machine *v1alpha1.Machine) bool {
-	nodeName := machine.Labels["node"]
-	node, err := c.nodeLister.Get(nodeName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false
-		}
-		klog.Errorf("error fetching node object for machine %q", machine.Name)
-		return true
-	}
-
-	nodeAnnotations := node.Annotations
-	if nodeAnnotations == nil {
-		return false
-	} else if _, exists := nodeAnnotations[autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey]; exists {
-		return true
-	}
-
-	return false
 }
 
 func getProviderID(machine *v1alpha1.Machine) string {

--- a/pkg/util/provider/machinecontroller/machine_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_util_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	machinev1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/gardener/machine-controller-manager/pkg/controller/autoscaler"
 	"github.com/gardener/machine-controller-manager/pkg/fakeclient"
 	"github.com/gardener/machine-controller-manager/pkg/util/permits"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
@@ -2297,26 +2296,6 @@ var _ = Describe("machine_util", func() {
 				expect: expect{
 					retryPeriod:   machineutils.ShortRetry,
 					expectedPhase: v1alpha1.MachineFailed,
-				},
-			}),
-			Entry("HealthTimedout machine shouldn't be marked Failed, if rolling update happening", &data{
-				setup: setup{
-					machines: []*v1alpha1.Machine{
-						newMachine(
-							&machinev1.MachineTemplateSpec{ObjectMeta: *newObjectMeta(&metav1.ObjectMeta{GenerateName: machineSet1Deploy1}, 0)},
-							&machinev1.MachineStatus{Node: "node", Conditions: nodeConditions(false, false, false, false, false), CurrentStatus: machinev1.CurrentStatus{Phase: v1alpha1.MachineUnknown, LastUpdateTime: metav1.NewTime(time.Now().Add(-15 * time.Minute))}},
-							&metav1.OwnerReference{Name: machineSet1Deploy1},
-							nil, map[string]string{"node": "node-0"}, true, metav1.Now()),
-					},
-					nodes: []*v1.Node{
-						newNode(1, nil, map[string]string{autoscaler.ClusterAutoscalerScaleDownDisabledAnnotationByMCMKey: "true"}, &v1.NodeSpec{}, &v1.NodeStatus{Phase: corev1.NodeRunning, Conditions: nodeConditions(false, false, false, false, false)}),
-					},
-					targetMachineName: machineSet1Deploy1 + "-" + "0",
-				},
-				expect: expect{
-					retryPeriod:   machineutils.MediumRetry,
-					err:           nil,
-					expectedPhase: v1alpha1.MachineUnknown,
 				},
 			}),
 			Entry("simple machine WITHOUT creation Timeout(20 min) and Pending state", &data{


### PR DESCRIPTION
**What this PR does / why we need it**:
A bug where MCM was not marking machine as failed during rollout has been resolved.
In situation where the all the machines in the new or the old machineset go into `Unknown` state , as per the current logic the rollout would stop and won't proceed until we manually delete the machine.
This happens because machineSet controller is not aware of a `Unknown` state and so takes no action, and only machine controller could resolve this situation by marking the machine `Failed`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- this erroneous behavior was introduced recently as a part of the meltdown fix [PR](https://github.com/gardener/machine-controller-manager/pull/683) , to avoid making meltdown logic clash with the rollout logic as they are performed by two seperate controllers and also so that we don't surpass the `maxReplacement` value, but after looking back , machine were always marked `Failed` during rollout previously also , so this PR just kind of goes back to the previous logic
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Rollout freeze won't happen due to `Unknown` machines now.
```
