### PR TITLE
Update version of clusterroles, add resoureName for leases

### DIFF
--- a/kubernetes/deployment/in-tree/control-cluster-role-binding.yaml
+++ b/kubernetes/deployment/in-tree/control-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-controller-manager-control

--- a/kubernetes/deployment/in-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/in-tree/control-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-controller-manager-control
@@ -53,6 +53,7 @@ rules:
    - leases
    resourceNames:
    - machine-controller-manager
+   - machine-controller
    verbs:
    - get
    - watch

--- a/kubernetes/deployment/in-tree/target-cluster-role-binding.yaml
+++ b/kubernetes/deployment/in-tree/target-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-controller-manager-target

--- a/kubernetes/deployment/in-tree/target-cluster-role.yaml
+++ b/kubernetes/deployment/in-tree/target-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-controller-manager-target

--- a/kubernetes/deployment/out-of-tree/control-cluster-role-binding.yaml
+++ b/kubernetes/deployment/out-of-tree/control-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-controller-manager-control

--- a/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
+++ b/kubernetes/deployment/out-of-tree/control-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-controller-manager-control
@@ -58,6 +58,7 @@ rules:
    - leases
    resourceNames:
    - machine-controller-manager
+   - machine-controller
    verbs:
    - get
    - watch

--- a/kubernetes/deployment/out-of-tree/target-cluster-role-binding.yaml
+++ b/kubernetes/deployment/out-of-tree/target-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-controller-manager-target

--- a/kubernetes/deployment/out-of-tree/target-cluster-role.yaml
+++ b/kubernetes/deployment/out-of-tree/target-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-controller-manager-target

--- a/pkg/test/integration/common/helpers/handling_files.go
+++ b/pkg/test/integration/common/helpers/handling_files.go
@@ -14,7 +14,7 @@ import (
 	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	mcmscheme "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/api/apps/v1"
-	rbacv1bata1 "k8s.io/api/rbac/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -150,20 +150,20 @@ func (c *Cluster) applyFile(filePath string, namespace string) error {
 					return err
 				}
 			case "ClusterRoleBinding":
-				resource := obj.(*rbacv1bata1.ClusterRoleBinding)
+				resource := obj.(*rbacv1.ClusterRoleBinding)
 				for i := range resource.Subjects {
 					resource.Subjects[i].Namespace = namespace
 				}
 
-				if _, err := c.Clientset.RbacV1beta1().
+				if _, err := c.Clientset.RbacV1().
 					ClusterRoleBindings().
 					Create(ctx, resource, metav1.CreateOptions{}); err != nil {
 					return err
 				}
 			case "ClusterRole":
-				resource := obj.(*rbacv1bata1.ClusterRole)
+				resource := obj.(*rbacv1.ClusterRole)
 
-				if _, err := c.Clientset.RbacV1beta1().
+				if _, err := c.Clientset.RbacV1().
 					ClusterRoles().
 					Create(ctx, resource, metav1.CreateOptions{}); err != nil {
 					return err
@@ -306,7 +306,7 @@ func (c *Cluster) deleteResource(filePath string, namespace string) error {
 					return err
 				}
 			case "ClusterRoleBinding":
-				resource := obj.(*rbacv1bata1.ClusterRoleBinding)
+				resource := obj.(*rbacv1.ClusterRoleBinding)
 				for i := range resource.Subjects {
 					resource.Subjects[i].Namespace = namespace
 				}
@@ -320,7 +320,7 @@ func (c *Cluster) deleteResource(filePath string, namespace string) error {
 					return err
 				}
 			case "ClusterRole":
-				resource := obj.(*rbacv1bata1.ClusterRole)
+				resource := obj.(*rbacv1.ClusterRole)
 				if err := c.Clientset.RbacV1beta1().
 					ClusterRoles().
 					Delete(


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the rule for leases in cluster role and moves clusterroles/clusterrolebindings to v1 from v1beta1. This is needed for the mcm-provider IT to work when running the controllers inside a cluster and not as a local process. 

**Which issue(s) this PR fixes**:
Fixes #674 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
resourceName `machine-controller` added for leases in clusterrole. Updated version of Clusterroles and Clusterrolebindings to v1.
```
