### PR TITLE
Add nodeName and providerID column while listing machines(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-clean:
 	@rm -f $(COVERPROFILE)
 
 generate: controller-gen
-	$(CONTROLLER_GEN) crd paths=./pkg/apis/machine/v1alpha1... output:crd:dir=kubernetes/crds output:stdout
+	$(CONTROLLER_GEN) crd paths=./pkg/apis/machine/v1alpha1/... output:crd:dir=kubernetes/crds output:stdout
 	@./hack/generate-code
 	@./hack/api-reference/generate-spec-doc.sh
 
@@ -163,7 +163,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/docs/documents/apis.md
+++ b/docs/documents/apis.md
@@ -1,9 +1,4 @@
----
-title: APIs
----
-
 ## Specification
-
 ### ProviderSpec Schema
 <br>
 <h3 id="AWSMachineClass">
@@ -2793,9 +2788,10 @@ string
 </p>
 <p>
 <p>AzureLinuxConfiguration is specifies the Linux operating system settings on the virtual machine. <br><br>For a list of
-supported Linux distributions, see <a href="https://docs.microsoft.com/en-us/azure/virtual-machines/linux/endorsed-distros">Endorsed Linux distributions on Azure
+supported Linux distributions, see <a href="https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-endorsed-distros?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json">Linux on Azure-Endorsed
 Distributions</a>
-<br><br> For running non-endorsed distributions, see <a href="https://docs.microsoft.com/en-us/azure/virtual-machines/linux/create-upload-generic">Information for community supported and non-endorsed distributions</a>.</p>
+<br><br> For running non-endorsed distributions, see <a href="https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json">Information for Non-Endorsed
+Distributions</a>.</p>
 </p>
 <table>
 <thead>
@@ -3179,8 +3175,9 @@ AzureNetworkInterfaceReference
 <a href="#AzureStorageProfile">AzureStorageProfile</a>)
 </p>
 <p>
-<p>AzureOSDisk specifies information about the operating system disk used by the virtual machine. <br><br> For more
-information about disks, see <a href="https://docs.microsoft.com/en-us/azure/virtual-machines/managed-disks-overview">Introduction to Azure managed disks</a>.</p>
+<p>AzureOSDisk is specifies information about the operating system disk used by the virtual machine. <br><br> For more
+information about disks, see <a href="https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json">About disks and VHDs for Azure virtual
+machines</a>.</p>
 </p>
 <table>
 <thead>
@@ -5927,8 +5924,7 @@ Kubernetes meta/v1.ObjectMeta
 <td>
 <em>(Optional)</em>
 <p>Standard object&rsquo;s metadata.
-More info: <a href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata
-">API Conventions - Metadata</a></p>
+More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata">https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata</a></p>
 Refer to the Kubernetes API documentation for the fields of the
 <code>metadata</code> field.
 </td>
@@ -5947,7 +5943,7 @@ MachineSpec
 <td>
 <em>(Optional)</em>
 <p>Specification of the desired behavior of the machine.
-More info: <a href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status">API Conventions - Spec and Status</a></p>
+More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p>
 <br/>
 <br/>
 <table>

--- a/kubernetes/crds/machine.sapcloud.io_alicloudmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_alicloudmachineclasses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: alicloudmachineclasses.machine.sapcloud.io
 spec:
@@ -65,6 +64,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               dataDisks:
                 items:
                   properties:
@@ -113,6 +113,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               securityGroupID:
                 type: string
               spotStrategy:
@@ -147,9 +148,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_awsmachineclasses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: awsmachineclasses.machine.sapcloud.io
 spec:
@@ -151,6 +150,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               ebsOptimized:
                 type: boolean
               iam:
@@ -220,6 +220,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               spotPrice:
                 type: string
               tags:
@@ -231,9 +232,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_azuremachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_azuremachineclasses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: azuremachineclasses.machine.sapcloud.io
 spec:
@@ -63,6 +62,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               location:
                 type: string
               properties:
@@ -237,6 +237,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               subnetInfo:
                 description: AzureSubnetInfo is the information containing the subnet
                   details
@@ -257,9 +258,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_gcpmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_gcpmachineclasses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: gcpmachineclasses.machine.sapcloud.io
 spec:
@@ -65,6 +64,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               deletionProtection:
                 type: boolean
               description:
@@ -162,6 +162,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               serviceAccounts:
                 items:
                   description: GCPServiceAccount describes service accounts for GCP.
@@ -196,9 +197,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: machineclasses.machine.sapcloud.io
 spec:
@@ -42,6 +41,7 @@ spec:
                   must be unique.
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
           kind:
             description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
@@ -100,14 +100,9 @@ spec:
                   must be unique.
                 type: string
             type: object
+            x-kubernetes-map-type: atomic
         required:
         - providerSpec
         type: object
     served: true
     storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: machinedeployments.machine.sapcloud.io
 spec:
@@ -148,6 +147,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               strategy:
                 description: The MachineDeployment strategy to use to replace existing
                   machines with new ones.
@@ -488,9 +488,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: machines.machine.sapcloud.io
 spec:
@@ -30,6 +29,12 @@ spec:
     - description: Node backing the machine object
       jsonPath: .metadata.labels.node
       name: Node
+      priority: 1
+      type: string
+    - description: ProviderID of the infra instance backing the machine object
+      jsonPath: .spec.providerID
+      name: ProviderID
+      priority: 1
       type: string
     name: v1alpha1
     schema:
@@ -278,9 +283,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -29,7 +29,6 @@ spec:
     - description: Node backing the machine object
       jsonPath: .metadata.labels.node
       name: Node
-      priority: 1
       type: string
     - description: ProviderID of the infra instance backing the machine object
       jsonPath: .spec.providerID

--- a/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: machinesets.machine.sapcloud.io
 spec:
@@ -121,6 +120,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               template:
                 description: MachineTemplateSpec describes the data a machine should
                   have when created from a template
@@ -410,9 +410,3 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_openstackmachineclasses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: openstackmachineclasses.machine.sapcloud.io
 spec:
@@ -68,6 +67,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               flavorName:
                 type: string
               imageID:
@@ -108,6 +108,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               securityGroups:
                 items:
                   type: string
@@ -137,9 +138,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kubernetes/crds/machine.sapcloud.io_packetmachineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_packetmachineclasses.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.2
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: packetmachineclasses.machine.sapcloud.io
 spec:
@@ -60,6 +59,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               facility:
                 items:
                   type: string
@@ -81,6 +81,7 @@ spec:
                       name must be unique.
                     type: string
                 type: object
+                x-kubernetes-map-type: atomic
               sshKeys:
                 items:
                   type: string
@@ -102,9 +103,3 @@ spec:
     served: true
     storage: true
     subresources: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -33,7 +33,8 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.currentStatus.phase`,description="Current status of the machine."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
-// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.metadata.labels.node`,description="Node backing the machine object"
+// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.metadata.labels.node`,description="Node backing the machine object",priority=1
+// +kubebuilder:printcolumn:name="ProviderID",type=string,JSONPath=`.spec.providerID`,description="ProviderID of the infra instance backing the machine object",priority=1
 
 // Machine is the representation of a physical or virtual machine.
 type Machine struct {

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -33,7 +33,7 @@ import (
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.currentStatus.phase`,description="Current status of the machine."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
-// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.metadata.labels.node`,description="Node backing the machine object",priority=1
+// +kubebuilder:printcolumn:name="Node",type=string,JSONPath=`.metadata.labels.node`,description="Node backing the machine object"
 // +kubebuilder:printcolumn:name="ProviderID",type=string,JSONPath=`.spec.providerID`,description="ProviderID of the infra instance backing the machine object",priority=1
 
 // Machine is the representation of a physical or virtual machine.


### PR DESCRIPTION
**What this PR does / why we need it**:
WIth this PR, when one runs the` kubectl get machines` command,`Node name` will be displayed as a column. If the `-owide` option is used then `ProviderID` will also be displayed as a column. The output will be as follows:
<img width="801" alt="Screenshot 2022-09-21 at 1 58 33 PM" src="https://user-images.githubusercontent.com/66425093/191455264-4b758cc8-c8ef-4e15-b6c0-35fa97605e73.png">

<img width="618" alt="Screenshot 2022-09-29 at 3 26 25 PM" src="https://user-images.githubusercontent.com/66425093/193002495-0287256a-34d6-47cb-a734-7df96ee28c32.png">



**Which issue(s) this PR fixes**:
Fixes #737 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Using `kubectl get machines` will display `Node` of the corresponding machine as a column. If `-owide` flag is used then the corresponding `ProviderID` will also be displayed.
```
