### PR TITLE
Add short names for `Machine`, `MachineClass`, `MachineDeployment` and `MachineSet` resources

### DIFF
--- a/docs/documents/apis.md
+++ b/docs/documents/apis.md
@@ -1294,6 +1294,247 @@ Kubernetes core/v1.SecretReference
 </tbody>
 </table>
 <br>
+<h3 id="MachineDeployment">
+<b>MachineDeployment</b>
+</h3>
+<p>
+<p>MachineDeployment enables declarative updates for machines and MachineSets.</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code>
+</td>
+<td>
+string
+</td>
+<td>
+<code>
+machine.sapcloud.io.v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code>
+</td>
+<td>
+string
+</td>
+<td>
+<code>MachineDeployment</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>metadata</code>
+</td>
+<td>
+<em>
+<a href="#https%3a%2f%2fkubernetes.io%2fdocs%2freference%2fgenerated%2fkubernetes-api%2fv1.19%2f%23objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Standard object metadata.</p>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code>
+</td>
+<td>
+<em>
+<a href="#MachineDeploymentSpec">
+MachineDeploymentSpec
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specification of the desired behavior of the MachineDeployment.</p>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>replicas</code>
+</td>
+<td>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Number of desired machines. This is a pointer to distinguish between explicit
+zero and not specified. Defaults to 0.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>selector</code>
+</td>
+<td>
+<em>
+<a href="#https%3a%2f%2fkubernetes.io%2fdocs%2freference%2fgenerated%2fkubernetes-api%2fv1.19%2f%23labelselector-v1-meta">
+Kubernetes meta/v1.LabelSelector
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Label selector for machines. Existing MachineSets whose machines are
+selected by this will be the ones affected by this MachineDeployment.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>template</code>
+</td>
+<td>
+<em>
+<a href="#MachineTemplateSpec">
+MachineTemplateSpec
+</a>
+</em>
+</td>
+<td>
+<p>Template describes the machines that will be created.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>strategy</code>
+</td>
+<td>
+<em>
+<a href="#MachineDeploymentStrategy">
+MachineDeploymentStrategy
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The MachineDeployment strategy to use to replace existing machines with new ones.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>minReadySeconds</code>
+</td>
+<td>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Minimum number of seconds for which a newly created machine should be ready
+without any of its container crashing, for it to be considered available.
+Defaults to 0 (machine will be considered available as soon as it is ready)</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>revisionHistoryLimit</code>
+</td>
+<td>
+<em>
+*int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The number of old MachineSets to retain to allow rollback.
+This is a pointer to distinguish between explicit zero and not specified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>paused</code>
+</td>
+<td>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Indicates that the MachineDeployment is paused and will not be processed by the
+MachineDeployment controller.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rollbackTo</code>
+</td>
+<td>
+<em>
+<a href="#RollbackConfig">
+RollbackConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>DEPRECATED.
+The config this MachineDeployment is rolling back to. Will be cleared after rollback is done.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>progressDeadlineSeconds</code>
+</td>
+<td>
+<em>
+*int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The maximum time in seconds for a MachineDeployment to make progress before it
+is considered to be failed. The MachineDeployment controller will continue to
+process failed MachineDeployments and a condition with a ProgressDeadlineExceeded
+reason will be surfaced in the MachineDeployment status. Note that progress will
+not be estimated during the time a MachineDeployment is paused. This is not set
+by default.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code>
+</td>
+<td>
+<em>
+<a href="#MachineDeploymentStatus">
+MachineDeploymentStatus
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Most recently observed status of the MachineDeployment.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<br>
 <h3 id="MachineSet">
 <b>MachineSet</b>
 </h3>
@@ -4535,223 +4776,6 @@ Kubernetes meta/v1.Duration
 <td>
 <em>(Optional)</em>
 <p>NodeConditions are the set of conditions if set to true for MachineHealthTimeOut, machine will be declared failed.</p>
-</td>
-</tr>
-</tbody>
-</table>
-<br>
-<h3 id="MachineDeployment">
-<b>MachineDeployment</b>
-</h3>
-<p>
-<p>Deployment enables declarative updates for machines and MachineSets.</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Type</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code>
-</td>
-<td>
-<em>
-<a href="#https%3a%2f%2fkubernetes.io%2fdocs%2freference%2fgenerated%2fkubernetes-api%2fv1.19%2f%23objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Standard object metadata.</p>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code>
-</td>
-<td>
-<em>
-<a href="#MachineDeploymentSpec">
-MachineDeploymentSpec
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Specification of the desired behavior of the MachineDeployment.</p>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>replicas</code>
-</td>
-<td>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Number of desired machines. This is a pointer to distinguish between explicit
-zero and not specified. Defaults to 0.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>selector</code>
-</td>
-<td>
-<em>
-<a href="#https%3a%2f%2fkubernetes.io%2fdocs%2freference%2fgenerated%2fkubernetes-api%2fv1.19%2f%23labelselector-v1-meta">
-Kubernetes meta/v1.LabelSelector
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Label selector for machines. Existing MachineSets whose machines are
-selected by this will be the ones affected by this MachineDeployment.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>template</code>
-</td>
-<td>
-<em>
-<a href="#MachineTemplateSpec">
-MachineTemplateSpec
-</a>
-</em>
-</td>
-<td>
-<p>Template describes the machines that will be created.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>strategy</code>
-</td>
-<td>
-<em>
-<a href="#MachineDeploymentStrategy">
-MachineDeploymentStrategy
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The MachineDeployment strategy to use to replace existing machines with new ones.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>minReadySeconds</code>
-</td>
-<td>
-<em>
-int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Minimum number of seconds for which a newly created machine should be ready
-without any of its container crashing, for it to be considered available.
-Defaults to 0 (machine will be considered available as soon as it is ready)</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>revisionHistoryLimit</code>
-</td>
-<td>
-<em>
-*int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The number of old MachineSets to retain to allow rollback.
-This is a pointer to distinguish between explicit zero and not specified.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>paused</code>
-</td>
-<td>
-<em>
-bool
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Indicates that the MachineDeployment is paused and will not be processed by the
-MachineDeployment controller.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>rollbackTo</code>
-</td>
-<td>
-<em>
-<a href="#RollbackConfig">
-RollbackConfig
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>DEPRECATED.
-The config this MachineDeployment is rolling back to. Will be cleared after rollback is done.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>progressDeadlineSeconds</code>
-</td>
-<td>
-<em>
-*int32
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>The maximum time in seconds for a MachineDeployment to make progress before it
-is considered to be failed. The MachineDeployment controller will continue to
-process failed MachineDeployments and a condition with a ProgressDeadlineExceeded
-reason will be surfaced in the MachineDeployment status. Note that progress will
-not be estimated during the time a MachineDeployment is paused. This is not set
-by default.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code>
-</td>
-<td>
-<em>
-<a href="#MachineDeploymentStatus">
-MachineDeploymentStatus
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Most recently observed status of the MachineDeployment.</p>
 </td>
 </tr>
 </tbody>

--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -12,6 +12,8 @@ spec:
     kind: MachineClass
     listKind: MachineClassList
     plural: machineclasses
+    shortNames:
+    - machcls
     singular: machineclass
   scope: Namespaced
   versions:

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -12,6 +12,8 @@ spec:
     kind: MachineDeployment
     listKind: MachineDeploymentList
     plural: machinedeployments
+    shortNames:
+    - machdeploy
     singular: machinedeployment
   scope: Namespaced
   versions:
@@ -43,7 +45,8 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Deployment enables declarative updates for machines and MachineSets.
+        description: MachineDeployment enables declarative updates for machines and
+          MachineSets.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -12,6 +12,8 @@ spec:
     kind: Machine
     listKind: MachineList
     plural: machines
+    shortNames:
+    - mach
     singular: machine
   scope: Namespaced
   versions:

--- a/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
@@ -12,6 +12,8 @@ spec:
     kind: MachineSet
     listKind: MachineSetList
     plural: machinesets
+    shortNames:
+    - machset
     singular: machineset
   scope: Namespaced
   versions:

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -29,6 +29,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:shortName="mach"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.currentStatus.phase`,description="Current status of the machine."

--- a/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -27,6 +27,7 @@ import (
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:shortName="machcls"
 // +kubebuilder:object:root=true
 
 // MachineClass can be used to templatize and re-use provider configuration

--- a/pkg/apis/machine/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/machine/v1alpha1/machinedeployment_types.go
@@ -26,6 +26,7 @@ import (
 // +genclient
 // +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+// +kubebuilder:resource:shortName="machdeploy"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
@@ -34,7 +35,8 @@ import (
 // +kubebuilder:printcolumn:name="Up-to-date",type=integer,JSONPath=`.status.updatedReplicas`,description="Total number of non-terminated machines targeted by this machine deployment that have the desired template spec."
 // +kubebuilder:printcolumn:name="Available",type=integer,JSONPath=`.status.availableReplicas`,description="Total number of available machines (ready for at least minReadySeconds) targeted by this machine deployment."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\nPopulated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata"
-// Deployment enables declarative updates for machines and MachineSets.
+
+// MachineDeployment enables declarative updates for machines and MachineSets.
 type MachineDeployment struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/apis/machine/v1alpha1/machineset_types.go
+++ b/pkg/apis/machine/v1alpha1/machineset_types.go
@@ -23,6 +23,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
+// +kubebuilder:resource:shortName="machset"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2518,7 +2518,7 @@ func schema_pkg_apis_machine_v1alpha1_MachineDeployment(ref common.ReferenceCall
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Deployment enables declarative updates for machines and MachineSets.",
+				Description: "MachineDeployment enables declarative updates for machines and MachineSets.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds short names for `machine`, `machineclass`, `machinedeployment` and `machineset` resources. The abbreviations are as follows:
1. mach -> machines.
<img width="531" alt="Screenshot 2022-10-10 at 10 59 08 AM" src="https://user-images.githubusercontent.com/66425093/194805025-df7d6312-d571-4f2a-b61f-07d64d3817ef.png">
2. machcls -> machineclass
<img width="139" alt="Screenshot 2022-10-10 at 10 59 20 AM" src="https://user-images.githubusercontent.com/66425093/194805064-d361e625-d259-46fc-b566-f609c78c57d6.png">
3. machdeploy -> machinedeployment
<img width="532" alt="Screenshot 2022-10-10 at 11 04 45 AM" src="https://user-images.githubusercontent.com/66425093/194805088-f05de006-82a3-4dbf-b626-540bc462129b.png">
4. machset -> machineset
<img width="470" alt="Screenshot 2022-10-10 at 11 04 52 AM" src="https://user-images.githubusercontent.com/66425093/194805097-911defc8-b713-41c3-a625-2ec7d3a2a7b4.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The testing was done by running IT on dev cluster with `mcm` and `mcm-provider-aws` run locally.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
6. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added new short names for machine(mach), machineClass(machcls), machineDeployment(machdeploy), and machineSet(machset) resources.
```
