### PR TITLE
Change short name of `Machineclass` from `machcls` to `machclass`

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: MachineClassList
     plural: machineclasses
     shortNames:
-    - machcls
+    - machclass
     singular: machineclass
   scope: Namespaced
   versions:

--- a/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -27,7 +27,7 @@ import (
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName="machcls"
+// +kubebuilder:resource:shortName="machclass"
 // +kubebuilder:object:root=true
 
 // MachineClass can be used to templatize and re-use provider configuration


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the short name of `machineclass` resource from `machcls` to `machclass`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Machine class short name changed to `machclass` from `machcls` 
```
