### PR TITLE
Update short names for `Machine`, `MachineClass`, `MachineDeployment` and `MachineSet` resources

### DIFF
--- a/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machineclasses.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: MachineClassList
     plural: machineclasses
     shortNames:
-    - machclass
+    - mcc
     singular: machineclass
   scope: Namespaced
   versions:

--- a/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinedeployments.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: MachineDeploymentList
     plural: machinedeployments
     shortNames:
-    - machdeploy
+    - mcd
     singular: machinedeployment
   scope: Namespaced
   versions:

--- a/kubernetes/crds/machine.sapcloud.io_machines.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machines.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: MachineList
     plural: machines
     shortNames:
-    - mach
+    - mc
     singular: machine
   scope: Namespaced
   versions:

--- a/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
+++ b/kubernetes/crds/machine.sapcloud.io_machinesets.yaml
@@ -13,7 +13,7 @@ spec:
     listKind: MachineSetList
     plural: machinesets
     shortNames:
-    - machset
+    - mcs
     singular: machineset
   scope: Namespaced
   versions:

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -29,7 +29,7 @@ import (
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName="mach"
+// +kubebuilder:resource:shortName="mc"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.currentStatus.phase`,description="Current status of the machine."

--- a/pkg/apis/machine/v1alpha1/machineclass_types.go
+++ b/pkg/apis/machine/v1alpha1/machineclass_types.go
@@ -27,7 +27,7 @@ import (
 // +genclient
 // +genclient:noStatus
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName="machclass"
+// +kubebuilder:resource:shortName="mcc"
 // +kubebuilder:object:root=true
 
 // MachineClass can be used to templatize and re-use provider configuration

--- a/pkg/apis/machine/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/machine/v1alpha1/machinedeployment_types.go
@@ -26,7 +26,7 @@ import (
 // +genclient
 // +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:shortName="machdeploy"
+// +kubebuilder:resource:shortName="mcd"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas

--- a/pkg/apis/machine/v1alpha1/machineset_types.go
+++ b/pkg/apis/machine/v1alpha1/machineset_types.go
@@ -23,7 +23,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
-// +kubebuilder:resource:shortName="machset"
+// +kubebuilder:resource:shortName="mcs"
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the short names for `Machine`, `MachineClass`, `MachineDeployment` and `MachineSet` resources. The new and final ones are as follows:

1. `mc` - `machine`
2. `mcc` - `machineClass`
3. `mcd` - `machineDeployment`
4. `mcs` - `machineSet`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Added new short names for machine(mc), machineClass(mcc), machineDeployment(mcd), and machineSet(mcs) resources.
```
