### PR TITLE
Update `Progressing` condition on machineDeployment for nil `progressDeadlineSeconds`

### DIFF
--- a/pkg/apis/machine/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/machine/v1alpha1/machinedeployment_types.go
@@ -98,7 +98,7 @@ type MachineDeploymentSpec struct {
 	// process failed MachineDeployments and a condition with a ProgressDeadlineExceeded
 	// reason will be surfaced in the MachineDeployment status. Note that progress will
 	// not be estimated during the time a MachineDeployment is paused. This is not set
-	// by default.
+	// by default, which is treated as infinite deadline.
 	// +optional
 	ProgressDeadlineSeconds *int32 `json:"progressDeadlineSeconds,omitempty"`
 }
@@ -219,8 +219,8 @@ const (
 
 	// Progressing means the MachineDeployment is progressing. Progress for a MachineDeployment is
 	// considered when a new machine set is created or adopted, and when new machines scale
-	// up or old machines scale down. Progress is not estimated for paused MachineDeployments or
-	// when progressDeadlineSeconds is not specified.
+	// up or old machines scale down. Progress is not estimated for paused MachineDeployments. It is also updated
+	// if progressDeadlineSeconds is not specified(treated as infinite deadline), in which case it would never be updated to "false".
 	MachineDeploymentProgressing MachineDeploymentConditionType = "Progressing"
 
 	// ReplicaFailure is added in a MachineDeployment when one of its machines fails to be created

--- a/pkg/controller/machine_safety.go
+++ b/pkg/controller/machine_safety.go
@@ -358,6 +358,8 @@ func (c *controller) checkAndFreezeORUnfreezeMachineSets(ctx context.Context) er
 		lowerThreshold := higherThreshold - c.safetyOptions.SafetyDown
 
 		machineDeployments := c.getMachineDeploymentsForMachineSet(machineSet)
+		// if we have a parent machineDeployment than we use a different higherThreshold and lowerThreshold,
+		// keeping in mind the rolling update scenario, as we won't want to freeze during a normal rolling update.
 		if len(machineDeployments) >= 1 {
 			machineDeployment := machineDeployments[0]
 			if machineDeployment != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when `progressDeadlineSeconds` is nil , then no `Progressing` condition is added to machineDeployment. This PR adds that condition now. 
In gardener, currently we deploy machineDeployments with this field as `nil` , but we would also like to see if the deployment is rollingUpdating or not. Now that this condition would be present, we could achieve that.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- done as a pre-step for solving https://github.com/gardener/machine-controller-manager/issues/754

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
MachineDeployment would now have `Progressing` condition even when no progress Deadline is specified. This condition would never go to the reason `ProgressDeadlineExceeded` in that case.
```
