### PR TITLE
Add cve categorization for mcm

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,6 +21,15 @@ machine-controller-manager:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'low'
     steps:
       check:
         image: 'golang:1.19.4'


### PR DESCRIPTION
**What this PR does / why we need it**:
Add cve categorization for MCM.

The categorization was initially defined here and it transferred as defined to the MCM repository: 
- https://github.com/gardener/gardener-extension-provider-aws/pull/684
- https://github.com/gardener/gardener-extension-provider-gcp/pull/546
- https://github.com/gardener/gardener-extension-provider-azure/pull/621
- https://github.com/gardener/gardener-extension-provider-openstack/pull/553
- https://github.com/gardener/gardener-extension-provider-alicloud/pull/562
- https://github.com/gardener/gardener-extension-provider-vsphere/pull/362

We move the cve categorization to the MCM repository as the categorization can't be taken into consideration when it is defined in the respective provider extension project. Once this behaviour has changed we can remove the categorisation here again.

**Release note**:
```other operator
CVE categorization for MCM has been added.
```
