### PR TITLE
Fixed unable to be parsed link

### DIFF
--- a/docs/documents/apis.md
+++ b/docs/documents/apis.md
@@ -5958,8 +5958,7 @@ MachineSpec
 <td>
 <em>(Optional)</em>
 <p>Specification of the desired behavior of the machine.
-More info: <a href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-">API Conventions - Spec and Status</a></p>
+More info: <a href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status">API Conventions - Spec and Status</a></p>
 <br/>
 <br/>
 <table>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an unable to be parsed link in the documentation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Fixes issue in merging a PR in the [gardener/documentation](https://github.com/gardener/documentation/pull/400#issuecomment-1467630127) repository.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
