### PR TITLE
Automated cherry pick of #806: Turn `CrashloopBackoff` machines to `Running` quicker

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -220,7 +220,7 @@ const (
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
 
-	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. It means that machine object is present but there is no corresponding node object.
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. It means that machine object is present but there is no corresponding VM.
 	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -211,7 +211,7 @@ const (
 	// MachineRunning means node is ready and running successfully
 	MachineRunning MachinePhase = "Running"
 
-	// MachineRunning means node is terminating
+	// MachineTerminating means node is terminating
 	MachineTerminating MachinePhase = "Terminating"
 
 	// MachineUnknown indicates that the node is not ready at the movement
@@ -220,7 +220,7 @@ const (
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
 
-	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. It means that machine object is present but there is no corresponding node object.
 	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -146,7 +146,7 @@ const (
 	// MachineRunning means node is ready and running successfully
 	MachineRunning MachinePhase = "Running"
 
-	// MachineRunning means node is terminating
+	// MachineTerminating means node is terminating
 	MachineTerminating MachinePhase = "Terminating"
 
 	// MachineUnknown indicates that the node is not ready at the movement
@@ -155,7 +155,7 @@ const (
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
 
-	// MachineCrashLoopBackOff means creation or deletion of the machine is failing.
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. It means that machine object is present but there is no corresponding node object.
 	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -155,7 +155,7 @@ const (
 	// MachineFailed means operation failed leading to machine status failure
 	MachineFailed MachinePhase = "Failed"
 
-	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. It means that machine object is present but there is no corresponding node object.
+	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. It means that machine object is present but there is no corresponding VM.
 	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
 )
 

--- a/pkg/util/provider/app/options/options.go
+++ b/pkg/util/provider/app/options/options.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/component-base/logs"
 
 	"github.com/gardener/machine-controller-manager/pkg/util/client/leaderelectionconfig"
 
@@ -108,6 +109,8 @@ func (s *MCServer) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "machine-safety-apiserver-statuscheck-period", s.SafetyOptions.MachineSafetyAPIServerStatusCheckPeriod.Duration, "Time period (in duration) used to poll for APIServer's health by safety controller")
 	fs.StringVar(&s.NodeConditions, "node-conditions", s.NodeConditions, "List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.")
 	fs.StringVar(&s.BootstrapTokenAuthExtraGroups, "bootstrap-token-auth-extra-groups", s.BootstrapTokenAuthExtraGroups, "Comma-separated list of groups to set bootstrap token's \"auth-extra-groups\" field to")
+
+	logs.AddFlags(fs)
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/pkg/util/provider/app/options/options.go
+++ b/pkg/util/provider/app/options/options.go
@@ -110,7 +110,7 @@ func (s *MCServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.NodeConditions, "node-conditions", s.NodeConditions, "List of comma-separated/case-sensitive node-conditions which when set to True will change machine to a failed state after MachineHealthTimeout duration. It may further be replaced with a new machine if the machine is backed by a machine-set object.")
 	fs.StringVar(&s.BootstrapTokenAuthExtraGroups, "bootstrap-token-auth-extra-groups", s.BootstrapTokenAuthExtraGroups, "Comma-separated list of groups to set bootstrap token's \"auth-extra-groups\" field to")
 
-	logs.AddFlags(fs)
+	logs.AddFlags(fs) // adds --v flag for log level.
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 	// TODO: DefaultFeatureGate is global and it adds all k8s flags

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -173,7 +173,7 @@ func (c *controller) reconcileClusterMachine(ctx context.Context, machine *v1alp
 			return retry, err
 		}
 	}
-	if machine.Spec.ProviderID == "" || machine.Status.CurrentStatus.Phase == "" {
+	if machine.Spec.ProviderID == "" || machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff {
 		return c.triggerCreationFlow(
 			ctx,
 			&driver.CreateMachineRequest{

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -497,7 +497,7 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		return machineutils.ShortRetry, err
 	}
 
-	if machine.Status.CurrentStatus.Phase == "" {
+	if machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff {
 		clone := machine.DeepCopy()
 		clone.Status.LastOperation = v1alpha1.LastOperation{
 			Description:    "Creating machine on cloud provider",

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1315,7 +1315,7 @@ func (c *controller) getEffectiveNodeConditions(machine *v1alpha1.Machine) *stri
 
 // UpdateNodeTerminationCondition updates termination condition on the node object
 func (c *controller) UpdateNodeTerminationCondition(ctx context.Context, machine *v1alpha1.Machine) error {
-	if machine.Status.CurrentStatus.Phase == "" {
+	if machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR turns `CLBF` machines to `Pending` if the `driver.CreateMachine` call was successful in the previous reconciliation. This will help the `reconcileMachineHealth` to turn the `Pending` to the `Running` phase when the machine is reconciled due to node object creation. 

**Which issue(s) this PR fixes**:
Fixes #805 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
`CrashloopBackoff` machines will turn to `Running` quicker .
```
