### PR TITLE
Keep `DesiredReplicas` annotation up to date even if no scaling happens

### DIFF
--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -404,7 +404,10 @@ func (dc *controller) scale(ctx context.Context, deployment *v1alpha1.MachineDep
 	// deployment. If there is no active machine set, then we should scale up the newest machine set.
 	if activeOrLatest := FindActiveOrLatest(newIS, oldISs); activeOrLatest != nil {
 		if (activeOrLatest.Spec.Replicas) == (deployment.Spec.Replicas) {
-			return nil
+			// to deal with the case where the DesiredReplicas annotation is outdated (issue - https://github.com/gardener/machine-controller-manager/issues/815)
+			klog.V(3).Infof("DesiredReplicas annotation possibly outdated for the machineSet %s, updating if needed...", activeOrLatest.Name)
+			_, _, err := dc.scaleMachineSet(ctx, activeOrLatest, deployment.Spec.Replicas, deployment, "no-op")
+			return err
 		}
 		klog.V(3).Infof("Scaling latest/theOnlyActive machineSet %s", activeOrLatest.Name)
 		_, _, err := dc.scaleMachineSetAndRecordEvent(ctx, activeOrLatest, deployment.Spec.Replicas, deployment)

--- a/pkg/controller/deployment_sync_test.go
+++ b/pkg/controller/deployment_sync_test.go
@@ -841,7 +841,7 @@ var _ = Describe("deployment_sync", func() {
 					err: false,
 				},
 			}),
-			Entry("if no scaling happened but DesiredReplicas Annotation for the only active machineSet is outdated, it should be updated with the correct value", &data{
+			Entry("if no scaling needed but DesiredReplicas Annotation for the only active machineSet is outdated, it should be updated with the correct value", &data{
 				setup: setup{
 					machineDeployment: newMachineDeployment(mDeploymentSpecTemplate, 1, 500, 2, 0, nil, nil, nil, nil),
 					oldISs: []*machinev1.MachineSet{

--- a/pkg/controller/deployment_sync_test.go
+++ b/pkg/controller/deployment_sync_test.go
@@ -455,8 +455,9 @@ var _ = Describe("deployment_sync", func() {
 					controlObjects = append(controlObjects, data.setup.oldISs[i])
 				}
 
-				controlObjects = append(controlObjects, data.setup.newIS)
-
+				if data.setup.newIS != nil {
+					controlObjects = append(controlObjects, data.setup.newIS)
+				}
 				c, trackers := createController(stop, testNamespace, controlObjects, nil, nil)
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
@@ -838,6 +839,21 @@ var _ = Describe("deployment_sync", func() {
 						),
 					},
 					err: false,
+				},
+			}),
+			Entry("if no scaling happened but DesiredReplicas Annotation for the only active machineSet is outdated, it should be updated with the correct value", &data{
+				setup: setup{
+					machineDeployment: newMachineDeployment(mDeploymentSpecTemplate, 1, 500, 2, 0, nil, nil, nil, nil),
+					oldISs: []*machinev1.MachineSet{
+						newMachineSet(mSetSpecTemplate, nameMachineSet1, 1, 500, nil, nil, map[string]string{DesiredReplicasAnnotation: "2", MaxReplicasAnnotation: "3"}, nil),
+					},
+					newIS: nil,
+				},
+				expect: expect{
+					err: false,
+					machineSets: []*machinev1.MachineSet{
+						newMachineSet(mSetSpecTemplate, nameMachineSet1, 1, 500, nil, nil, map[string]string{DesiredReplicasAnnotation: "1", MaxReplicasAnnotation: "3"}, nil),
+					},
 				},
 			}),
 		)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #815 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An edge case where outdated DesiredReplicas annotation blocked a rolling update is fixed.
```
