### PR TITLE
Automated cherry pick of #821: keep desired replicas annotation up to date even if no

### DIFF
--- a/pkg/controller/deployment_sync_test.go
+++ b/pkg/controller/deployment_sync_test.go
@@ -842,7 +842,7 @@ var _ = Describe("deployment_sync", func() {
 					err: false,
 				},
 			}),
-			Entry("if no scaling happened but DesiredReplicas Annotation for the only active machineSet is outdated, it should be updated with the correct value", &data{
+			Entry("if no scaling needed but DesiredReplicas Annotation for the only active machineSet is outdated, it should be updated with the correct value", &data{
 				setup: setup{
 					machineDeployment: newMachineDeployment(mDeploymentSpecTemplate, 1, 500, 2, 0, nil, nil, nil, nil),
 					oldISs: []*machinev1.MachineSet{


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #815 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An edge case where outdated DesiredReplicas annotation blocked a rolling update is fixed.
```
