### PR TITLE
Updated the docforge manifest & added index files

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,57 +1,9 @@
+nodesSelector:
+  path: /docs
 structure:
 - name: _index.md
-  source: /README.md
-- name: docs
   properties:
-      frontmatter:
-        title: Documentation
-  nodesSelector:
-    path: /docs
-  nodes:
-  - name: deployment
-    properties:
-      frontmatter:
-        title: Deployment
-        weight: 1
-        categories:
-          - Developers
-          - Operators
-    nodesSelector:
-      path: /docs/deployment
-  - name: development
-    properties:
-      frontmatter:
-        title: Development
-        weight: 2
-        categories:
-          - Developers
-    nodesSelector:
-      path: /docs/development
-  - name: documents
-    properties:
-      frontmatter:
-        title: Documents
-        weight: 3
-        categories:
-          - Developers
-    nodesSelector:
-      path: /docs/documents
-  - name: proposals
-    properties:
-      frontmatter:
-        title: Proposals
-        weight: 4
-        categories:
-          - Developers
-    nodesSelector:
-      path: /docs/proposals
-  - name: usage
-    properties:
-      frontmatter:
-        title: Usage
-        weight: 5
-        categories:
-          - Users
-          - Operators
-    nodesSelector:
-      path: /docs/usage
+    frontmatter:
+      title: Machine Controller Manager
+      description: Declarative way of managing machines for Kubernetes cluster
+  source: /README.md

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Along with the above Custom Controllers and Resources, MCM requires the `Machine
 
 ## Development
 
-To start using or developing the Machine Controller Manager, see the documentation in the `/docs` repository, please [find the index here](docs/README.md).
+To start using or developing the Machine Controller Manager, see the documentation in the `/docs` repository.
 
 ## FAQ
-An FAQ is available [here](docs/FAQ.md)
+An FAQ is available [here](docs/FAQ.md).
 
-## Cluster-api Implementation
+## cluster-api Implementation
 - `cluster-api` branch of machine-controller-manager implements the machine-api aspect of the [cluster-api project](https://github.com/kubernetes-sigs/cluster-api).
 - Link: https://github.com/gardener/machine-controller-manager/tree/cluster-api
 - Once cluster-api project gets stable, we may make `master` branch of MCM as well cluster-api compliant, with well-defined migration notes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,0 @@
-# Documentation Index
-
-## Using Out-of-Tree (External) provider support (Recommended)
-
-#### Development
-* [Adding support for a new cloud provider](development/cp_support_new.md)

--- a/docs/deployment/_index.md
+++ b/docs/deployment/_index.md
@@ -1,0 +1,7 @@
+---
+title: Deployment
+weight: 1
+categories:
+    - Developers
+    - Operators
+---

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -53,4 +53,4 @@ Machine-controller-manager supports several configurable parameters while deploy
 
 ## Usage
 
-To start using Machine Controller Manager, follow the links given at [usage here](../README.md).
+To start using Machine Controller Manager, follow the links given at [usage here](../../README.md).

--- a/docs/development/_index.md
+++ b/docs/development/_index.md
@@ -1,0 +1,6 @@
+---
+title: Development
+weight: 2
+categories:
+    - Developers
+---

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -97,4 +97,4 @@ GO111MODULE=on go build -mod=vendor -o managevm cmd/machine-controller-manager-c
 
 ## Usage
 
-To start using Machine Controller Manager, follow the links given at [usage here](../README.md).
+To start using Machine Controller Manager, follow the links given at [usage here](../../README.md).

--- a/docs/documents/_index.md
+++ b/docs/documents/_index.md
@@ -1,0 +1,6 @@
+---
+title: Documents
+weight: 3
+categories:
+    - Developers
+---

--- a/docs/proposals/_index.md
+++ b/docs/proposals/_index.md
@@ -1,0 +1,6 @@
+---
+title: Proposals
+weight: 4
+categories:
+    - Developers
+---

--- a/docs/todo/_index.md
+++ b/docs/todo/_index.md
@@ -1,0 +1,6 @@
+---
+title: To-Do
+weight: 6
+categories:
+    - Developers
+---

--- a/docs/usage/_index.md
+++ b/docs/usage/_index.md
@@ -1,0 +1,7 @@
+---
+title: Usage
+weight: 5
+categories:
+    - Users
+    - Operators
+---


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the file structure in the Machine controller Manager section of the public Gardener website, implementing the changes asked for in #829. It is connected to a [PR in gardener/documentation](https://github.com/gardener/documentation/pull/417) that modifies the manifest file there.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
