### PR TITLE
Nit: Fix the format verb

### DIFF
--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -612,7 +612,7 @@ func SetReplicasAnnotations(is *v1alpha1.MachineSet, desiredReplicas, maxReplica
 		updated = true
 	}
 
-	klog.V(4).Infof("(SetReplicasAnnotations) ms.Name: %s desired: %s , max: %s , updated: %d", is.Name, desiredString, maxString, updated)
+	klog.V(4).Infof("(SetReplicasAnnotations) ms.Name: %s desired: %s , max: %s , updated: %t", is.Name, desiredString, maxString, updated)
 	return updated
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
```
{"log":"(SetReplicasAnnotations) ms.Name: shoot--foo--bar-default-z3-797b7 desired: 0 , max: 0 , updated: %!d(bool=true)","pid":"1","severity":"INFO","source":"deployment_util.go:615"}
```

The `updated` var is boolean, hence `%t` should be used instead of `%d`. Ref https://pkg.go.dev/fmt

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
