### PR TITLE
Include `UnavailableReplicas` in MCD status update check

### DIFF
--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -1192,6 +1192,7 @@ func statusUpdateRequired(old v1alpha1.MachineDeploymentStatus, new v1alpha1.Mac
 		old.ReadyReplicas == new.ReadyReplicas &&
 		old.Replicas == new.Replicas &&
 		old.UpdatedReplicas == new.UpdatedReplicas &&
+		old.UnavailableReplicas == new.UnavailableReplicas &&
 		reflect.DeepEqual(old.Conditions, new.Conditions) {
 		// If all conditions are matching
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Includes `UnavailableReplicas` in determining if the status of machine deployment needs to be updated.

**Which issue(s) this PR fixes**:
Fixes #832 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Included `UnavailableReplicas` in determining if a machine deployment status update is needed
```
