### PR TITLE
[rel-v0.49] Automated cherry pick of #833: include unavailable replicas in mcd status update check

### DIFF
--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -1192,6 +1192,7 @@ func statusUpdateRequired(old v1alpha1.MachineDeploymentStatus, new v1alpha1.Mac
 		old.ReadyReplicas == new.ReadyReplicas &&
 		old.Replicas == new.Replicas &&
 		old.UpdatedReplicas == new.UpdatedReplicas &&
+		old.UnavailableReplicas == new.UnavailableReplicas &&
 		reflect.DeepEqual(old.Conditions, new.Conditions) {
 		// If all conditions are matching
 


### PR DESCRIPTION
/kind bug

Cherry pick of #833 on rel-v0.49.

#833: include unavailable replicas in mcd status update check

**Release note:**
```bugfix operator
Included `UnavailableReplicas` in determining if a machine deployment status update is needed
```
