### PR TITLE
Added HSTS headers in healthz endpoint

### DIFF
--- a/pkg/handlers/health.go
+++ b/pkg/handlers/health.go
@@ -38,6 +38,8 @@ func Healthz(w http.ResponseWriter, r *http.Request) {
 	mutex.Lock()
 	isHealthy := healthy
 	mutex.Unlock()
+	w.Header().Set("Strict-Transport-Security", "max-age=31536000")
+	w.Header().Set("Content-Security-Policy", "default-src 'self'")
 	if isHealthy {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("OK"))


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds HSTS headers in the healthz endpoint
**Which issue(s) this PR fixes**:
Fixes #825 

**Special notes for your reviewer**:

**Release note**:
NONE

Format of block header: <category> <target_group>
Possible values:
- category:       bugfix
- target_group:   user
-->
```other operator

```
