### PR TITLE
Integration tests documentation update for incorporating .env file usage.

### DIFF
--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -9,7 +9,7 @@ Integration tests for `machine-controller-manager-provider-{provider-name}` can 
 1. Clone the repository `machine-controller-manager-provider-{provider-name}` on the local system.
 1. Navigate to `machine-controller-manager-provider-{provider-name}` directory and create a `dev` sub-directory in it.
 1. Create a `.env` file at the root of the `machine-controller-manager-provider-{provider-name}` project. This file serves as an environments file where all key-value pairs that are used in the `Makefile` are defined.
-1. Copy the kubeconfig of the Control Cluster into `dev/control-kubeconfig.yaml` and add an entry in the `.env` file with `CONTROL_KUBECONFIG=dev/control-kubeconfig.yaml`.
+1. Copy the kubeconfig of the Control Cluster into `dev/control-kubeconfig.yaml` and add an entry in the `.env` file with `CONTROL_KUBECONFIG=dev/control-kubeconfig.yaml`. 
 1. Add `CONTROL_NAMESPACE=<namespace of the control cluster>` to the `.env` file. This is the namespace that is used to deploy all resources and run tests.
 1. (optional) Copy the kubeconfig of the Target Cluster into `dev/target-kubeconfig.yaml` and add an entry in the `.env` file with `TARGET_KUBECONFIG=dev/target-kubeconfig.yaml`.
 1. If the tags on instances & associated resources on the provider are of `String` type (for example, GCP tags on its instances are of type `String` and not key-value pair) then add `TAGS_ARE_STRINGS := true` in the `Makefile` and export it. For GCP this has already been hard coded in the `Makefile`.

--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -22,7 +22,7 @@ Integration tests for `machine-controller-manager-provider-{provider-name}` can 
 ### Gardener Shoot as the Control Cluster 
 
 If the Control Cluster is a Gardener Shoot cluster then,
-git
+
 1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the `default` namespace of the Control Cluster.
 1. Create a `dev/machineclassv1.yaml` file in the cloned repository and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`. The name of the `MachineClass` itself should be `test-mc-v1`. The value of `providerSpec.secretRef.name` should be `test-mc-secret`. 
 1. (Optional) Create an additional `dev/machineclassv2.yaml` file similar to above but with a bigger machine type and add an entry in the `.env` file with `MACHINECLASS_V2=dev/machineclassv2.yaml`.

--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -22,10 +22,10 @@ Integration tests for `machine-controller-manager-provider-{provider-name}` can 
 ### Gardener Shoot as the Control Cluster 
 
 If the Control Cluster is a Gardener Shoot cluster then,
-
+git
 1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the `default` namespace of the Control Cluster.
 1. Create a `dev/machineclassv1.yaml` file in the cloned repository and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`. The name of the `MachineClass` itself should be `test-mc-v1`. The value of `providerSpec.secretRef.name` should be `test-mc-secret`. 
-1. (Optional) Create an additional `dev/machineclassv2.yaml` file similar to above but with a bigger machine type and and add an entry in the `.env` file with `MACHINECLASS_V2=dev/machineclassv2.yaml`.
+1. (Optional) Create an additional `dev/machineclassv2.yaml` file similar to above but with a bigger machine type and add an entry in the `.env` file with `MACHINECLASS_V2=dev/machineclassv2.yaml`.
 
 ### Gardener Seed as the Control Cluster 
 

--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -9,7 +9,7 @@ Integration tests for `machine-controller-manager-provider-{provider-name}` can 
 1. Clone the repository `machine-controller-manager-provider-{provider-name}` on the local system.
 1. Navigate to `machine-controller-manager-provider-{provider-name}` directory and create a `dev` sub-directory in it.
 1. Create a `.env` file at the root of the `machine-controller-manager-provider-{provider-name}` project. This file serves as an environments file where all key-value pairs that are used in the `Makefile` are defined.
-1. Copy the kubeconfig of the Control Cluster into `dev/control-kubeconfig.yaml` and add an entry in the `.env` file with `CONTROL_KUBECONFIG=dev/control-kubeconfig.yaml`. 
+1. Copy the kubeconfig of the Control Cluster into `dev/control-kubeconfig.yaml` and add an entry in the `.env` file with `CONTROL_KUBECONFIG=dev/control-kubeconfig.yaml`.
 1. Add `CONTROL_NAMESPACE=<namespace of the control cluster>` to the `.env` file. This is the namespace that is used to deploy all resources and run tests.
 1. (optional) Copy the kubeconfig of the Target Cluster into `dev/target-kubeconfig.yaml` and add an entry in the `.env` file with `TARGET_KUBECONFIG=dev/target-kubeconfig.yaml`.
 1. If the tags on instances & associated resources on the provider are of `String` type (for example, GCP tags on its instances are of type `String` and not key-value pair) then add `TAGS_ARE_STRINGS := true` in the `Makefile` and export it. For GCP this has already been hard coded in the `Makefile`.
@@ -24,8 +24,8 @@ Integration tests for `machine-controller-manager-provider-{provider-name}` can 
 If the Control Cluster is a Gardener Shoot cluster then,
 
 1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the `default` namespace of the Control Cluster.
-1. Create a `dev/machineclassv1.yaml` file in the cloned repository. The name of the `MachineClass` itself should be `test-mc-v1`. The value of `providerSpec.secretRef.name` should be `test-mc-secret`. 
-1. (Optional) Create an additional `dev/machineclassv2.yaml` file similar to above but with a bigger machine type and update the `Makefile` variable `MACHINECLASS_V2` to point to `dev/machineclassv2.yaml`.
+1. Create a `dev/machineclassv1.yaml` file in the cloned repository and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`. The name of the `MachineClass` itself should be `test-mc-v1`. The value of `providerSpec.secretRef.name` should be `test-mc-secret`. 
+1. (Optional) Create an additional `dev/machineclassv2.yaml` file similar to above but with a bigger machine type and and add an entry in the `.env` file with `MACHINECLASS_V2=dev/machineclassv2.yaml`.
 
 ### Gardener Seed as the Control Cluster 
 
@@ -33,7 +33,7 @@ If the Control Cluster is a Gardener SEED cluster, then the suite ideally employ
 
 1. (Optional) User can employ a custom `MachineClass` for the tests using below steps:
     1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the shoot namespace of the Control Cluster. That is, the value of `metadata.namespace` should be `technicalID` of the Shoot and it will be of the pattern `shoot--<project>--<shoot-name>`.
-    1. Create a `dev/machineclassv1.yaml` file.
+    1. Create a `dev/machineclassv1.yaml` file and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`.
         1. `providerSpec.secretRef.name` should refer the secret created in the previous step.
         1. `metadata.namespace` and `providerSpec.secretRef.namespace` should be `technicalID` (`shoot--<project>--<shoot-name>`) of the shoot.
         1.  The name of the `MachineClass` itself should be `test-mc-v1`.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR has the documentation update for how and where to specify the dynamic entries of the Make file for integration tests. ( use of .env file )

**Which issue(s) this PR fixes**:
Fixes #846

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
