### PR TITLE
Updated docs of IT and Moved Dynamic content from Makefile to .env file.

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-# This file is used to set variables which will be referenced in the Makefile
-# Currently variables defined in this file are used for local testing only.
-# hack/local_setup.sh will populate variables and hack/local_restore.sh will clear the variables.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include .env
+-include .env
 include hack/tools.mk
 
 IMAGE_REPOSITORY   := eu.gcr.io/gardener-project/gardener/machine-controller-manager

--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -13,7 +13,7 @@ Integration tests for `machine-controller-manager-provider-{provider-name}` can 
 1. Add `CONTROL_NAMESPACE=<namespace of the control cluster>` to the `.env` file. This is the namespace that is used to deploy all resources and run tests.
 1. (optional) Copy the kubeconfig of the Target Cluster into `dev/target-kubeconfig.yaml` and add an entry in the `.env` file with `TARGET_KUBECONFIG=dev/target-kubeconfig.yaml`.
 1. If the tags on instances & associated resources on the provider are of `String` type (for example, GCP tags on its instances are of type `String` and not key-value pair) then add `TAGS_ARE_STRINGS := true` in the `Makefile` and export it. For GCP this has already been hard coded in the `Makefile`.
-1. If the intention is to run any controllers in the control cluster, then `.env` should have at least one of `MCM_IMAGE` and `MC_IMAGE` defined. These images will be used along with `kubernetes/deployment.yaml` to deploy/update controllers in the Control Cluster. If the intention is to run the controllers locally then remove `MCM_IMAGE` and `MC_IMAGE` key-value pairs defined in `.env` and set `MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME=machine-controller-manager` in the `.env` file.
+1. If the intention is to run any controllers in the control cluster, then `.env` should have at least one of `MCM_IMAGE` and `MC_IMAGE` defined. These images will be used along with `kubernetes/deployment.yaml` to deploy/update controllers in the Control Cluster. If the intention is to run the controllers locally then remove `MCM_IMAGE` and `MC_IMAGE` key-value pairs defined in `.env` and add `MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME=machine-controller-manager` in the `.env` file.
 1. In order to apply the CRDs when the Control Cluster is a Gardener Shoot or if none of the controller images are specified, `machine-controller-manager` repository will be cloned automatically. Incase, this repository already exists in local system, then create a softlink as below which helps to test changes in `machine-controller-manager` quickly.
     ```bash
     ln -sf <path-for-machine-controller-manager-repo> dev/mcm
@@ -24,8 +24,8 @@ Integration tests for `machine-controller-manager-provider-{provider-name}` can 
 If the Control Cluster is a Gardener Shoot cluster then,
 
 1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the `default` namespace of the Control Cluster.
-1. Create a `dev/machineclassv1.yaml` file in the cloned repository. The name of the `MachineClass` itself should be `test-mc-v1`. The value of `providerSpec.secretRef.name` should be `test-mc-secret`. 
-1. (Optional) Create an additional `dev/machineclassv2.yaml` file similar to above but with a bigger machine type and update the `Makefile` variable `MACHINECLASS_V2` to point to `dev/machineclassv2.yaml`.
+1. Create a `dev/machineclassv1.yaml` file in the cloned repository and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`. The name of the `MachineClass` itself should be `test-mc-v1`. The value of `providerSpec.secretRef.name` should be `test-mc-secret`. 
+1. (Optional) Create an additional `dev/machineclassv2.yaml` file similar to above but with a bigger machine type and add an entry in the `.env` file with `MACHINECLASS_V2=dev/machineclassv2.yaml`.
 
 ### Gardener Seed as the Control Cluster 
 
@@ -33,7 +33,7 @@ If the Control Cluster is a Gardener SEED cluster, then the suite ideally employ
 
 1. (Optional) User can employ a custom `MachineClass` for the tests using below steps:
     1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the shoot namespace of the Control Cluster. That is, the value of `metadata.namespace` should be `technicalID` of the Shoot and it will be of the pattern `shoot--<project>--<shoot-name>`.
-    1. Create a `dev/machineclassv1.yaml` file.
+    1. Create a `dev/machineclassv1.yaml` file and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`.
         1. `providerSpec.secretRef.name` should refer the secret created in the previous step.
         1. `metadata.namespace` and `providerSpec.secretRef.namespace` should be `technicalID` (`shoot--<project>--<shoot-name>`) of the shoot.
         1.  The name of the `MachineClass` itself should be `test-mc-v1`.

--- a/hack/gardener_local_restore.sh
+++ b/hack/gardener_local_restore.sh
@@ -115,9 +115,9 @@ function delete_generated_configs() {
   echo "Removing downloaded kubeconfigs..."
   rm -f "${ABSOLUTE_KUBE_CONFIG_PATH}"/*.yaml
   rm -f "${ABSOLUTE_PROVIDER_KUBECONFIG_PATH}"/*.yaml
-  echo "Clearing .env files..."
-  sed -r -i '/^#/!d' "${PROJECT_DIR}"/.env
-  sed -r -i '/^#/!d' "${PROVIDER_MCM_PROJECT_DIR}"/.env
+  echo "Deleting .env files..."
+  rm -f "${PROJECT_DIR}"/.env
+  rm -f "${PROVIDER_MCM_PROJECT_DIR}"/.env
   echo "Removing generated admin kube config json if any..."
   rm -f "${SCRIPT_DIR}"/admin-kube-config-request.json
 }

--- a/hack/non_gardener_local_restore.sh
+++ b/hack/non_gardener_local_restore.sh
@@ -104,9 +104,9 @@ function delete_generated_configs() {
   echo "Removing downloaded kubeconfigs..."
   rm -f "${ABSOLUTE_KUBE_CONFIG_PATH}"/*.yaml
   rm -f "${ABSOLUTE_PROVIDER_KUBECONFIG_PATH}"/*.yaml
-  echo "Clearing .env files..."
-  sed -r -i '/^#/!d' "${PROJECT_DIR}"/.env
-  sed -r -i '/^#/!d' "${PROVIDER_MCM_PROJECT_DIR}"/.env
+  echo "Deleting .env files..."
+  rm -f "${PROJECT_DIR}"/.env
+  rm -f "${PROVIDER_MCM_PROJECT_DIR}"/.env
 }
 
 function main() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the documentation of Integration tests and moves the dynamic content of Makefile to the .env file.

**Which issue(s) this PR fixes**:
Fixes #846

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
