### PR TITLE
 Fix Rotation of log files in IT

### DIFF
--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -687,17 +687,17 @@ func (c *IntegrationTestFramework) setupMachineClass() error {
 // If the file exists already then it renames it so that a new file can be created
 func rotateLogFile(fileName string) (*os.File, error) {
 	if _, err := os.Stat(fileName); err == nil { // !strings.Contains(err.Error(), "no such file or directory") {
-		no_of_files := 1
+		noOfFiles := 1
 		temp := fileName + "." + strconv.Itoa(no_of_files)
 		_, err := os.Stat(temp)
 		// Finding the total number of log files
 		for err == nil {
-			no_of_files += 1
+			noOfFiles += 1
 			temp = fileName + "." + strconv.Itoa(no_of_files)
 			_, err = os.Stat(temp)
 		}
 		// Renaming all log files having last characters as ".x" where x >=1
-		for i := no_of_files - 1; i > 0; i-- {
+		for i := noOfFiles - 1; i > 0; i-- {
 			f := fmt.Sprintf("%s.%d", fileName, i)
 			fNew := fmt.Sprintf("%s.%d", fileName, i+1)
 			if err := os.Rename(f, fNew); err != nil {
@@ -711,6 +711,7 @@ func rotateLogFile(fileName string) (*os.File, error) {
 			return nil, fmt.Errorf("failed to rename file %s to %s: %w", fileName, fNew, err)
 		}
 	}
+	// Creating a new log file
 	return os.Create(fileName)
 }
 

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -698,7 +698,6 @@ func rotateLogFile(fileName string) (*os.File, error) {
 		}
 		// Renaming all such files
 		for i := no_of_files - 1; i > 0; i-- {
-			fmt.Println()
 			f := fmt.Sprintf("%s.%d", fileName, i)
 			fNew := fmt.Sprintf("%s.%d", fileName, i+1)
 			if err := os.Rename(f, fNew); err != nil {

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -686,10 +687,22 @@ func (c *IntegrationTestFramework) setupMachineClass() error {
 // If the file exists already then it renames it so that a new file can be created
 func rotateLogFile(fileName string) (*os.File, error) {
 	if _, err := os.Stat(fileName); err == nil { // !strings.Contains(err.Error(), "no such file or directory") {
-		for i := 9; i > 0; i-- {
+		no_of_files := 1
+		temp := fileName + "." + strconv.Itoa(no_of_files)
+		_, err := os.Stat(temp)
+		// Finding number of log files ending with ".x" ( x -> 1,2,3... )
+		for err == nil {
+			no_of_files += 1
+			temp = fileName + "." + strconv.Itoa(no_of_files)
+			_, err = os.Stat(temp)
+		}
+		// Renaming all such files
+		for i := no_of_files - 1; i > 0; i-- {
+			fmt.Println()
 			f := fmt.Sprintf("%s.%d", fileName, i)
 			fNew := fmt.Sprintf("%s.%d", fileName, i+1)
 			if err := os.Rename(f, fNew); err != nil {
+				fmt.Println(i, " ")
 				return nil, fmt.Errorf("failed to rename file %s to %s: %w", f, fNew, err)
 			}
 		}

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -688,12 +688,12 @@ func (c *IntegrationTestFramework) setupMachineClass() error {
 func rotateLogFile(fileName string) (*os.File, error) {
 	if _, err := os.Stat(fileName); err == nil { // !strings.Contains(err.Error(), "no such file or directory") {
 		noOfFiles := 1
-		temp := fileName + "." + strconv.Itoa(no_of_files)
+		temp := fileName + "." + strconv.Itoa(noOfFiles)
 		_, err := os.Stat(temp)
 		// Finding the total number of log files
 		for err == nil {
-			noOfFiles += 1
-			temp = fileName + "." + strconv.Itoa(no_of_files)
+			noOfFiles++
+			temp = fileName + "." + strconv.Itoa(noOfFiles)
 			_, err = os.Stat(temp)
 		}
 		// Renaming all log files having last characters as ".x" where x >=1

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -690,13 +690,13 @@ func rotateLogFile(fileName string) (*os.File, error) {
 		no_of_files := 1
 		temp := fileName + "." + strconv.Itoa(no_of_files)
 		_, err := os.Stat(temp)
-		// Finding number of log files ending with ".x" ( x -> 1,2,3... )
+		// Finding the total number of log files
 		for err == nil {
 			no_of_files += 1
 			temp = fileName + "." + strconv.Itoa(no_of_files)
 			_, err = os.Stat(temp)
 		}
-		// Renaming all such files
+		// Renaming all log files having last characters as ".x" where x >=1
 		for i := no_of_files - 1; i > 0; i-- {
 			f := fmt.Sprintf("%s.%d", fileName, i)
 			fNew := fmt.Sprintf("%s.%d", fileName, i+1)
@@ -705,6 +705,7 @@ func rotateLogFile(fileName string) (*os.File, error) {
 				return nil, fmt.Errorf("failed to rename file %s to %s: %w", f, fNew, err)
 			}
 		}
+		// Renaming the log file without suffix ".x" to log file ending with ".1"
 		fNew := fmt.Sprintf("%s.%d", fileName, 1)
 		if err := os.Rename(fileName, fNew); err != nil {
 			return nil, fmt.Errorf("failed to rename file %s to %s: %w", fileName, fNew, err)

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -687,21 +687,19 @@ func (c *IntegrationTestFramework) setupMachineClass() error {
 // If the file exists already then it renames it so that a new file can be created
 func rotateLogFile(fileName string) (*os.File, error) {
 	if _, err := os.Stat(fileName); err == nil { // !strings.Contains(err.Error(), "no such file or directory") {
-		noOfFiles := 1
-		temp := fileName + "." + strconv.Itoa(noOfFiles)
+		noOfFiles := 0
+		temp := fileName + "." + strconv.Itoa(noOfFiles+1)
 		_, err := os.Stat(temp)
-		// Finding the total number of log files
+		// Finding the log files ending with ".x" where x >= 1 and renaming
 		for err == nil {
 			noOfFiles++
-			temp = fileName + "." + strconv.Itoa(noOfFiles)
+			temp = fileName + "." + strconv.Itoa(noOfFiles+1)
 			_, err = os.Stat(temp)
 		}
-		// Renaming all log files having last characters as ".x" where x >=1
-		for i := noOfFiles - 1; i > 0; i-- {
+		for i := noOfFiles; i > 0; i-- {
 			f := fmt.Sprintf("%s.%d", fileName, i)
 			fNew := fmt.Sprintf("%s.%d", fileName, i+1)
 			if err := os.Rename(f, fNew); err != nil {
-				fmt.Println(i, " ")
 				return nil, fmt.Errorf("failed to rename file %s to %s: %w", f, fNew, err)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the rotation of Log files issue on multiple runs of Integration tests. 

**Which issue(s) this PR fixes**:
Fixes:- Part of #853 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
