### PR TITLE
Remove NotManagedByMCM when not applicable

### DIFF
--- a/pkg/util/provider/app/options/options.go
+++ b/pkg/util/provider/app/options/options.go
@@ -24,13 +24,12 @@ package options
 import (
 	"time"
 
+	drain "github.com/gardener/machine-controller-manager/pkg/util/provider/drain"
+	machineconfig "github.com/gardener/machine-controller-manager/pkg/util/provider/options"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/component-base/logs"
-
-	drain "github.com/gardener/machine-controller-manager/pkg/util/provider/drain"
-	machineconfig "github.com/gardener/machine-controller-manager/pkg/util/provider/options"
 
 	"github.com/gardener/machine-controller-manager/pkg/util/client/leaderelectionconfig"
 

--- a/pkg/util/provider/app/options/options.go
+++ b/pkg/util/provider/app/options/options.go
@@ -24,12 +24,13 @@ package options
 import (
 	"time"
 
-	drain "github.com/gardener/machine-controller-manager/pkg/util/provider/drain"
-	machineconfig "github.com/gardener/machine-controller-manager/pkg/util/provider/options"
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/component-base/logs"
+
+	drain "github.com/gardener/machine-controller-manager/pkg/util/provider/drain"
+	machineconfig "github.com/gardener/machine-controller-manager/pkg/util/provider/options"
 
 	"github.com/gardener/machine-controller-manager/pkg/util/client/leaderelectionconfig"
 
@@ -70,7 +71,7 @@ func NewMCServer() *MCServer {
 				MaxEvictRetries:                          drain.DefaultMaxEvictRetries,
 				PvDetachTimeout:                          metav1.Duration{Duration: 2 * time.Minute},
 				PvReattachTimeout:                        metav1.Duration{Duration: 90 * time.Second},
-				MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 30 * time.Minute},
+				MachineSafetyOrphanVMsPeriod:             metav1.Duration{Duration: 15 * time.Minute},
 				MachineSafetyAPIServerStatusCheckPeriod:  metav1.Duration{Duration: 1 * time.Minute},
 				MachineSafetyAPIServerStatusCheckTimeout: metav1.Duration{Duration: 30 * time.Second},
 			},

--- a/pkg/util/provider/machinecontroller/machine_safety.go
+++ b/pkg/util/provider/machinecontroller/machine_safety.go
@@ -193,8 +193,9 @@ func (c *controller) AnnotateNodesUnmanagedByMCM(ctx context.Context) (machineut
 					machineutils.NotManagedByMCM: "1",
 				}
 
+				klog.V(3).Infof("Adding NotManagedByMCM annotation to Node %q", node.Name)
 				// err is returned only when node update fails
-				if err := c.updateNodeWithAnnotation(ctx, nodeCopy, annotations); err != nil {
+				if err := c.updateNodeWithAnnotations(ctx, nodeCopy, annotations); err != nil {
 					return machineutils.MediumRetry, err
 				}
 			}
@@ -206,9 +207,8 @@ func (c *controller) AnnotateNodesUnmanagedByMCM(ctx context.Context) (machineut
 			klog.V(3).Infof("Removing NotManagedByMCM annotation from Node %q associated with Machine %q", node.Name, machine.Name)
 			nodeCopy := node.DeepCopy()
 			delete(nodeCopy.Annotations, machineutils.NotManagedByMCM)
-			_, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeCopy, metav1.UpdateOptions{})
-			if err != nil {
-				klog.Errorf("Failed to remove NotManagedByMCM from Node %q associated with Machine %q due to: %s", node.Name, machine.Name, err)
+			if err := c.updateNodeWithAnnotations(ctx, nodeCopy, nil); err != nil {
+				return machineutils.MediumRetry, err
 			}
 		}
 	}

--- a/pkg/util/provider/machinecontroller/machine_safety_util.go
+++ b/pkg/util/provider/machinecontroller/machine_safety_util.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func (c *controller) updateNodeWithAnnotation(ctx context.Context, node *v1.Node, annotations map[string]string) error {
+func (c *controller) updateNodeWithAnnotations(ctx context.Context, node *v1.Node, annotations map[string]string) error {
 
 	// Initialize node annotations if empty
 	if node.Annotations == nil {
@@ -37,10 +37,9 @@ func (c *controller) updateNodeWithAnnotation(ctx context.Context, node *v1.Node
 	_, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
 
 	if err != nil {
-		klog.Errorf("Couldn't patch the node %q , Error: %s", node.Name, err)
+		klog.Errorf("Failed to update annotations for Node %q due to error: %s", node.Name, err)
 		return err
 	}
-	klog.V(2).Infof("Annotated node %q was annotated with NotManagedByMCM successfully", node.Name)
 
 	return nil
 }

--- a/pkg/util/provider/machinecontroller/machine_safety_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_safety_util_test.go
@@ -17,13 +17,14 @@ package controller
 import (
 	"context"
 
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 )
 
 var _ = Describe("machine_safety_util", func() {
@@ -56,7 +57,7 @@ var _ = Describe("machine_safety_util", func() {
 				testNode := data.action.node
 				expectedNode := data.expect.node
 
-				err := c.updateNodeWithAnnotation(context.TODO(), testNode, data.action.annotations)
+				err := c.updateNodeWithAnnotations(context.TODO(), testNode, data.action.annotations)
 
 				waitForCacheSync(stop, c)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

See https://github.com/gardener/machine-controller-manager/issues/863

**Which issue(s) this PR fixes**:
Fixes #863 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Removes `node.machine.sapcloud.io/not-managed-by-mcm` annotation from nodes managed by the MCM.
```
```other operator
The default `machine-safety-orphan-vms-period` has been reduced from 30m to 15m.
```
