### PR TITLE
Remove Kubeconfig dependency for verification of control cluster in IT

### DIFF
--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -31,6 +31,8 @@ If the Control Cluster is a Gardener Shoot cluster then,
 
 If the Control Cluster is a Gardener SEED cluster, then the suite ideally employs the already existing `MachineClass` and Secrets. However,
 
+1. Define the variable `IS_CONTROL_SEED` in the `.env` file and set it to `true`. 
+`Warning:` Make sure to set the `CONTROL_NAMESPACE` variable to the shoot namespace where the control plane of the target resides.
 1. (Optional) User can employ a custom `MachineClass` for the tests using below steps:
     1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the shoot namespace of the Control Cluster. That is, the value of `metadata.namespace` should be `technicalID` of the Shoot and it will be of the pattern `shoot--<project>--<shoot-name>`.
     1. Create a `dev/machineclassv1.yaml` file and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`.

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -98,6 +98,9 @@ var (
 	// if true, control cluster is a seed
 	// only set this variable if operating in gardener context
 	isControlSeed = os.Getenv("IS_CONTROL_CLUSTER_SEED")
+
+	// To detect orphans with this tag
+	clusterTagSuffix = "integration-test-cluster"
 )
 
 // ProviderSpecPatch struct holds tags for provider, which we want to patch the  machineclass with
@@ -486,7 +489,7 @@ func (c *IntegrationTestFramework) scaleMcmDeployment(replicas int32) error {
 }
 
 func (c *IntegrationTestFramework) updatePatchFile() {
-	targetClusterName := controlClusterNamespace
+	targetClusterName := clusterTagSuffix
 	clusterTag := "kubernetes-io-cluster-" + targetClusterName
 	testRoleTag := "kubernetes-io-role-integration-test"
 
@@ -812,7 +815,7 @@ func (c *IntegrationTestFramework) SetupBeforeSuite() {
 		Get(ctx, testMachineClassResources[0], metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	clusterName := controlClusterNamespace
+	clusterName := clusterTagSuffix
 
 	ginkgo.By("Looking for secrets refered in machineclass in the control cluster")
 	secretData, err := c.ControlCluster.

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -98,7 +98,9 @@ var (
 	// if true, control cluster is a seed
 	// only set this variable if operating in gardener context
 	isControlSeed = os.Getenv("IS_CONTROL_CLUSTER_SEED")
+)
 
+const (
 	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker
 	targetClusterPlaceholder = "integration-test-cluster"
 )

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -94,6 +94,10 @@ var (
 
 	// if true, means that the tags present on VM are strings not key-value pairs
 	isTagsStrings = os.Getenv("TAGS_ARE_STRINGS")
+
+	// if true, control cluster is a seed
+	// only set this variable if operating in gardener context
+	isControlSeed = os.Getenv("IS_CONTROL_CLUSTER_SEED")
 )
 
 // ProviderSpecPatch struct holds tags for provider, which we want to patch the  machineclass with
@@ -205,17 +209,14 @@ func (c *IntegrationTestFramework) initalizeClusters() error {
 			return err
 		}
 	}
-
-	// Update namespace to use
-	if c.ControlCluster.IsSeed(c.TargetCluster) {
-		_, err := c.TargetCluster.ClusterName()
-		if err != nil {
-			log.Println("Failed to determine shoot cluster namespace")
-			return err
-		}
-		controlClusterNamespace, _ = c.TargetCluster.ClusterName()
-	} else if len(controlClusterNamespace) == 0 {
+	// set default control cluster namespace if not specified
+	if len(controlClusterNamespace) == 0 {
 		controlClusterNamespace = "default"
+	}
+	// Verify the control cluster namespace
+	err := c.ControlCluster.VerifyControlClusterNamespace(isControlSeed, controlClusterNamespace)
+	if err != nil {
+		return err
 	}
 
 	// setting env variable for later use
@@ -485,14 +486,14 @@ func (c *IntegrationTestFramework) scaleMcmDeployment(replicas int32) error {
 }
 
 func (c *IntegrationTestFramework) updatePatchFile() {
-	clusterName, _ := c.TargetCluster.ClusterName()
-	clusterTag := "kubernetes-io-cluster-" + clusterName
+	targetClusterName := controlClusterNamespace
+	clusterTag := "kubernetes-io-cluster-" + targetClusterName
 	testRoleTag := "kubernetes-io-role-integration-test"
 
 	patchMachineClassData := MachineClassPatch{
 		ProviderSpec: ProviderSpecPatch{
 			Tags: []string{
-				clusterName,
+				targetClusterName,
 				clusterTag,
 				testRoleTag,
 			},
@@ -573,8 +574,7 @@ func (c *IntegrationTestFramework) setupMachineClass() error {
 	// eg. tag (providerSpec.tags)  \"mcm-integration-test: "true"\"
 
 	ctx := context.Background()
-
-	if c.ControlCluster.IsSeed(c.TargetCluster) && len(v1MachineClassPath) == 0 {
+	if isControlSeed == "true" && len(v1MachineClassPath) == 0 {
 		if machineClasses, err := c.ControlCluster.McmClient.
 			MachineV1alpha1().
 			MachineClasses(controlClusterNamespace).
@@ -763,8 +763,7 @@ func (c *IntegrationTestFramework) SetupBeforeSuite() {
 	gomega.Expect(c.initalizeClusters()).To(gomega.BeNil())
 
 	//setting up MCM either locally or by deploying after checking conditions
-
-	if c.ControlCluster.IsSeed(c.TargetCluster) {
+	if isControlSeed == "true" {
 
 		if len(mcContainerImage) != 0 || len(mcmContainerImage) != 0 {
 			ginkgo.By("Updating MCM Deployemnt")
@@ -813,9 +812,7 @@ func (c *IntegrationTestFramework) SetupBeforeSuite() {
 		Get(ctx, testMachineClassResources[0], metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	ginkgo.By("Determining target cluster name")
-	clusterName, err := c.TargetCluster.ClusterName()
-	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	clusterName := controlClusterNamespace
 
 	ginkgo.By("Looking for secrets refered in machineclass in the control cluster")
 	secretData, err := c.ControlCluster.
@@ -1318,7 +1315,7 @@ func (c *IntegrationTestFramework) Cleanup() {
 		}
 
 	}
-	if c.ControlCluster.IsSeed(c.TargetCluster) {
+	if isControlSeed == "true" {
 		// scale back up the MCM deployment to 1 in the Control Cluster
 		// This is needed when IT suite runs locally against a Control & Target cluster
 

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -42,7 +42,12 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
-const dwdIgnoreScalingAnnotation = "dependency-watchdog.gardener.cloud/ignore-scaling"
+const (
+	dwdIgnoreScalingAnnotation = "dependency-watchdog.gardener.cloud/ignore-scaling"
+
+	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker
+	targetClusterPlaceholder = "integration-test-cluster"
+)
 
 var (
 	// path for storing log files (mcm & mc processes)
@@ -98,11 +103,6 @@ var (
 	// if true, control cluster is a seed
 	// only set this variable if operating in gardener context
 	isControlSeed = os.Getenv("IS_CONTROL_CLUSTER_SEED")
-)
-
-const (
-	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker
-	targetClusterPlaceholder = "integration-test-cluster"
 )
 
 // ProviderSpecPatch struct holds tags for provider, which we want to patch the  machineclass with

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -99,8 +99,8 @@ var (
 	// only set this variable if operating in gardener context
 	isControlSeed = os.Getenv("IS_CONTROL_CLUSTER_SEED")
 
-	// To detect orphans with this tag
-	clusterTagSuffix = "integration-test-cluster"
+	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker
+	targetClusterPlaceholder = "integration-test-cluster"
 )
 
 // ProviderSpecPatch struct holds tags for provider, which we want to patch the  machineclass with
@@ -489,14 +489,13 @@ func (c *IntegrationTestFramework) scaleMcmDeployment(replicas int32) error {
 }
 
 func (c *IntegrationTestFramework) updatePatchFile() {
-	targetClusterName := clusterTagSuffix
-	clusterTag := "kubernetes-io-cluster-" + targetClusterName
+	clusterTag := "kubernetes-io-cluster-" + targetClusterPlaceholder
 	testRoleTag := "kubernetes-io-role-integration-test"
 
 	patchMachineClassData := MachineClassPatch{
 		ProviderSpec: ProviderSpecPatch{
 			Tags: []string{
-				targetClusterName,
+				targetClusterPlaceholder,
 				clusterTag,
 				testRoleTag,
 			},
@@ -815,7 +814,7 @@ func (c *IntegrationTestFramework) SetupBeforeSuite() {
 		Get(ctx, testMachineClassResources[0], metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	clusterName := clusterTagSuffix
+	clusterName := targetClusterPlaceholder
 
 	ginkgo.By("Looking for secrets refered in machineclass in the control cluster")
 	secretData, err := c.ControlCluster.

--- a/pkg/test/integration/common/helpers/cluster.go
+++ b/pkg/test/integration/common/helpers/cluster.go
@@ -16,6 +16,7 @@ package helpers
 
 import (
 	"context"
+	"fmt"
 
 	mcmClientset "github.com/gardener/machine-controller-manager/pkg/client/clientset/versioned"
 	v1 "k8s.io/api/core/v1"
@@ -77,48 +78,6 @@ func NewCluster(kubeConfigPath string) (c *Cluster, e error) {
 	return c, err
 }
 
-// IsSeed checks whether the cluster is seed of target cluster
-func (c *Cluster) IsSeed(target *Cluster) bool {
-	/*
-		- (Check if the control cluster is a seed cluster
-			Try to retrieve the cluster-name (clusters[0].name) from the target kubeconfig passed in.
-			 ---- Check if there is any cluster resource available ( means it is a seed cluster ) and see if there is any cluster with name same as to target cluster-name
-			 ---- Alternatively check if there is a namespace with same name as that of cluster name found in kube config
-			 ---- when both control and target cluster are the same then return false
-			 kubectl get clusters -A
-			NAME                             AGE
-			shoot--landscape--project-shoot   46h
-	*/
-	controlClusterName, _ := c.ClusterName()
-	targetClusterName, _ := target.ClusterName()
-
-	if controlClusterName == targetClusterName {
-		return false
-	}
-	nameSpaces, _ := c.Clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
-	for _, namespace := range nameSpaces.Items {
-		if namespace.Name == targetClusterName {
-			return true
-		}
-	}
-	return false
-}
-
-// ClusterName retrieves cluster name from the kubeconfig
-func (c *Cluster) ClusterName() (string, error) {
-	var clusterName string
-	config, err := clientcmd.LoadFromFile(c.KubeConfigFilePath)
-	if err != nil {
-		return clusterName, err
-	}
-	for contextName, context := range config.Contexts {
-		if contextName == config.CurrentContext {
-			clusterName = context.Cluster
-		}
-	}
-	return clusterName, err
-}
-
 // GetSecretData combines secrets
 func (c *Cluster) GetSecretData(machineClassName string, secretRefs ...*v1.SecretReference) (map[string][]byte, error) {
 	var secretData map[string][]byte
@@ -162,4 +121,21 @@ func (c *Cluster) getSecret(ref *v1.SecretReference, MachineClassName string) (*
 		return nil, err
 	}
 	return secretRef, err
+}
+
+func (c *Cluster) VerifyControlClusterNamespace(isControlSeed string, controlClusterNamespace string) error {
+	if isControlSeed == "true" {
+		if controlClusterNamespace == "default" {
+			return fmt.Errorf("Cannot use default namespace when control cluster is a seed")
+		}
+	}
+
+	// check if control namespace exist inside control cluster
+	nameSpaces, _ := c.Clientset.CoreV1().Namespaces().List(context.Background(), metav1.ListOptions{})
+	for _, namespace := range nameSpaces.Items {
+		if namespace.Name == controlClusterNamespace {
+			return nil
+		}
+	}
+	return fmt.Errorf("Control Namespace not found inside control cluster")
 }

--- a/pkg/test/integration/common/helpers/cluster.go
+++ b/pkg/test/integration/common/helpers/cluster.go
@@ -123,6 +123,7 @@ func (c *Cluster) getSecret(ref *v1.SecretReference, MachineClassName string) (*
 	return secretRef, err
 }
 
+// VerifyControlClusterNamespace validates the control namespace inside the control cluster
 func (c *Cluster) VerifyControlClusterNamespace(isControlSeed string, controlClusterNamespace string) error {
 	if isControlSeed == "true" {
 		if controlClusterNamespace == "default" {

--- a/pkg/test/integration/common/helpers/cluster.go
+++ b/pkg/test/integration/common/helpers/cluster.go
@@ -123,7 +123,9 @@ func (c *Cluster) getSecret(ref *v1.SecretReference, MachineClassName string) (*
 	return secretRef, err
 }
 
-// VerifyControlClusterNamespace validates the control namespace inside the control cluster
+// VerifyControlClusterNamespace validates the control namespace provided by the user. It checks the following:-
+// 1. If it is a seed, then it should not use a default namespace as the control namespace.
+// 2. The control namespace should be present in the control cluster.
 func (c *Cluster) VerifyControlClusterNamespace(isControlSeed string, controlClusterNamespace string) error {
 	if isControlSeed == "true" {
 		if controlClusterNamespace == "default" {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the dependency on kubeconfig for identifying the control cluster as seed and also, updates the integration tests documentation.

**Which issue(s) this PR fixes**:
Fixes part of #853 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
