### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -5,6 +5,8 @@ machine-controller-manager:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -17,7 +19,7 @@ machine-controller-manager:
                 source: ~ # default
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/machine-controller-manager
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
               value:
@@ -38,7 +40,9 @@ machine-controller-manager:
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -47,9 +51,14 @@ machine-controller-manager:
       traits:
         version:
           preprocess: 'finalize'
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: 'bump_minor'
+        publish:
+          dockerimages:
+            machine-controller-manager:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,5 @@
 machine-controller-manager:
-  template: 'default'
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess:
@@ -19,7 +17,6 @@ machine-controller-manager:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/machine-controller-manager'
             resource_labels:
             - name: 'gardener.cloud/cve-categorisation'
@@ -50,6 +47,7 @@ machine-controller-manager:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor: ~
         release:
           nextversion: 'bump_minor'
         slack:
@@ -58,4 +56,3 @@ machine-controller-manager:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -31,7 +31,7 @@ machine-controller-manager:
       check:
         image: 'golang:1.21.4'
       test:
-        image: 'eu.gcr.io/gardener-project/gardener/testmachinery/base-step:stable'
+        image: europe-docker.pkg.dev/gardener-project/releases/testmachinery/base-step:stable
       build:
         image: 'golang:1.21.4'
         output_dir: 'binary'

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 -include .env
 include hack/tools.mk
 
-IMAGE_REPOSITORY   := eu.gcr.io/gardener-project/gardener/machine-controller-manager
+IMAGE_REPOSITORY   := europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager
 IMAGE_TAG          := $(shell cat VERSION)
 COVERPROFILE       := test/output/coverprofile.out
 

--- a/kubernetes/deployment/out-of-tree/deployment.yaml
+++ b/kubernetes/deployment/out-of-tree/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: machine-controller-manager
-        image: eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.39.0
+        image: europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager:v0.39.0
         imagePullPolicy: Always
         command:
           - ./machine-controller-manager


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

In addition, switch testmachinery-Image to new location in Artifact-Registry.

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.
```
