### PR TITLE
Fixed MCM restart during cleanup

### DIFF
--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -690,11 +690,11 @@ func (c *IntegrationTestFramework) setupMachineClass() error {
 // rotateLogFile takes file name as input and returns a file object obtained by os.Create
 // If the file exists already then it renames it so that a new file can be created
 func rotateAndAppendLogFile(fileName string, isRotate bool) (*os.File, error) {
-	if !isRotate{
-		if _, err := os.Stat(fileName); err != nil{
+	if !isRotate {
+		if _, err := os.Stat(fileName); err != nil {
 			return os.Create(fileName)
 		}
-		return os.OpenFile(fileName,os.O_APPEND|os.O_WRONLY,0600)
+		return os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, 0600)
 	}
 	if _, err := os.Stat(fileName); err == nil { // !strings.Contains(err.Error(), "no such file or directory") {
 		noOfFiles := 0
@@ -1227,7 +1227,7 @@ func (c *IntegrationTestFramework) Cleanup() {
 				ginkgo.By("Restarting Machine Controller ")
 				outputFile, err := rotateAndAppendLogFile(mcLogFile, false)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_,err = outputFile.WriteString("\n------------RESTARTED MC------------\n")
+				_, err = outputFile.WriteString("\n------------RESTARTED MC------------\n")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				args := strings.Fields(
 					fmt.Sprintf(
@@ -1248,7 +1248,7 @@ func (c *IntegrationTestFramework) Cleanup() {
 				ginkgo.By("Restarting Machine Controller Manager")
 				outputFile, err := rotateAndAppendLogFile(mcmLogFile, false)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				_,err = outputFile.WriteString("\n------------RESTARTED MCM------------\n")
+				_, err = outputFile.WriteString("\n------------RESTARTED MCM------------\n")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				args := strings.Fields(
 					fmt.Sprintf(
@@ -1258,7 +1258,7 @@ func (c *IntegrationTestFramework) Cleanup() {
 						c.TargetCluster.KubeConfigFilePath,
 						controlClusterNamespace),
 				)
-				mcmsession, err = gexec.Start(exec.Command(args[0], args[1:]...), outputFile, outputFile)				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				mcmsession, err = gexec.Start(exec.Command(args[0], args[1:]...), outputFile, outputFile)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				break
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue where MCM was unable to restart during cleanup which lead to cleanup failure

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The logs for the restarted MCM and MC will now be appended to the existing logs itself.

<img width="1153" alt="Screenshot 2023-12-12 at 10 37 28 AM" src="https://github.com/gardener/machine-controller-manager/assets/57896905/e0b779fd-9b31-4144-8881-3faded0e3e1b">

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
