### PR TITLE
Made the gen-crd-api-reference-docs binary platform independent

### DIFF
--- a/hack/api-reference/generate-spec-doc.sh
+++ b/hack/api-reference/generate-spec-doc.sh
@@ -14,5 +14,6 @@
 
 cd ./hack/api-reference
 GO111MODULE=on go install github.com/ahmetb/gen-crd-api-reference-docs@latest
-"$GOBIN"/gen-crd-api-reference-docs -config "providerspec-config.json" -api-dir "../../pkg/apis/machine/v1alpha1" -out-file="../../docs/documents/apis.md"sed 's/?id=//g' ../../docs/documents/apis.md > ../../docs/documents/apis-1.md
+"$GOBIN"/gen-crd-api-reference-docs -config "providerspec-config.json" -api-dir "../../pkg/apis/machine/v1alpha1" -out-file="../../docs/documents/apis.md"
+sed 's/?id=//g' ../../docs/documents/apis.md > ../../docs/documents/apis-1.md
 mv ../../docs/documents/apis-1.md ../../docs/documents/apis.md

--- a/hack/api-reference/generate-spec-doc.sh
+++ b/hack/api-reference/generate-spec-doc.sh
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 cd ./hack/api-reference
-./gen-crd-api-reference-docs -config "providerspec-config.json" -api-dir "../../pkg/apis/machine/v1alpha1" -out-file="../../docs/documents/apis.md"
-sed 's/?id=//g' ../../docs/documents/apis.md > ../../docs/documents/apis-1.md
+GO111MODULE=on go install github.com/ahmetb/gen-crd-api-reference-docs@latest
+"$GOBIN"/gen-crd-api-reference-docs -config "providerspec-config.json" -api-dir "../../pkg/apis/machine/v1alpha1" -out-file="../../docs/documents/apis.md"sed 's/?id=//g' ../../docs/documents/apis.md > ../../docs/documents/apis-1.md
 mv ../../docs/documents/apis-1.md ../../docs/documents/apis.md


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR installs the binary for the gen-crd-api-reference-docs each time so it is now platform independent.

**Which issue(s) this PR fixes**:
Fixes #694 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
