### PR TITLE
Support checking GKE version schema

### DIFF
--- a/pkg/util/k8sutils/version.go
+++ b/pkg/util/k8sutils/version.go
@@ -30,7 +30,7 @@ var (
 func init() {
 	var err error
 
-	ConstraintK8sGreaterEqual121, err = semver.NewConstraint(">= 1.21")
+	ConstraintK8sGreaterEqual121, err = semver.NewConstraint(">= 1.21-0")
 	utilruntime.Must(err)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The version format of GKE clusters is $K8S_VERSION-gke.$INTERNAL_NUMBER (e.g., 1.27.9-gke.300). This format is not fully compliant to the SEMVER spec and causes [this library](https://github.com/Masterminds/semver/) to mistakenly recognize, for example, a 1.27.9-gke.300 cluster to be older than 1.21. This is a known issue (e.g., https://github.com/helm/helm/issues/3810), and this change updates the version constraint to properly support GKE versions.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:

NONE

