### PR TITLE
Env var  for IT tests

### DIFF
--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -31,8 +31,9 @@ If the Control Cluster is a Gardener Shoot cluster then,
 
 If the Control Cluster is a Gardener SEED cluster, then the suite ideally employs the already existing `MachineClass` and Secrets. However,
 
-1. Define the variable `IS_CONTROL_SEED` in the `.env` file and set it to `true`. 
+1. Define the variable `IS_CONTROL_CLUSTER_SEED` in the `.env` file and set it to `true`. 
 `Warning:` Make sure to set the `CONTROL_NAMESPACE` variable to the shoot namespace where the control plane of the target resides.
+1. Please pass `TARGET_RESOURCE_GROUP` in the `.env` file and set it to the name of the target cluster. This is only required for Azure clusters.
 1. (Optional) User can employ a custom `MachineClass` for the tests using below steps:
     1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the shoot namespace of the Control Cluster. That is, the value of `metadata.namespace` should be `technicalID` of the Shoot and it will be of the pattern `shoot--<project>--<shoot-name>`.
     1. Create a `dev/machineclassv1.yaml` file and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`.

--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -33,7 +33,7 @@ If the Control Cluster is a Gardener SEED cluster, then the suite ideally employ
 
 1. Define the variable `IS_CONTROL_CLUSTER_SEED` in the `.env` file and set it to `true`. 
 `Warning:` Make sure to set the `CONTROL_NAMESPACE` variable to the shoot namespace where the control plane of the target resides.
-1. Please pass `TARGET_RESOURCE_GROUP` in the `.env` file and set it to the name of the target cluster. This is compulsory for Azure clusters.
+1. Please pass `TARGET_RESOURCE_GROUP` in the `.env` file. It will be used for the `ResourceGroupName` in Azure clusters. Keep it as target cluster name for gardener shoot clusters.This is compulsory for Azure clusters.
 1. (Optional) User can employ a custom `MachineClass` for the tests using below steps:
     1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the shoot namespace of the Control Cluster. That is, the value of `metadata.namespace` should be `technicalID` of the Shoot and it will be of the pattern `shoot--<project>--<shoot-name>`.
     1. Create a `dev/machineclassv1.yaml` file and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`.

--- a/docs/development/integration_tests.md
+++ b/docs/development/integration_tests.md
@@ -33,7 +33,7 @@ If the Control Cluster is a Gardener SEED cluster, then the suite ideally employ
 
 1. Define the variable `IS_CONTROL_CLUSTER_SEED` in the `.env` file and set it to `true`. 
 `Warning:` Make sure to set the `CONTROL_NAMESPACE` variable to the shoot namespace where the control plane of the target resides.
-1. Please pass `TARGET_RESOURCE_GROUP` in the `.env` file and set it to the name of the target cluster. This is only required for Azure clusters.
+1. Please pass `TARGET_RESOURCE_GROUP` in the `.env` file and set it to the name of the target cluster. This is compulsory for Azure clusters.
 1. (Optional) User can employ a custom `MachineClass` for the tests using below steps:
     1. Deploy a `Secret` named `test-mc-secret` (that contains the provider secret and cloud-config) in the shoot namespace of the Control Cluster. That is, the value of `metadata.namespace` should be `technicalID` of the Shoot and it will be of the pattern `shoot--<project>--<shoot-name>`.
     1. Create a `dev/machineclassv1.yaml` file and add an entry in the `.env` file with `MACHINECLASS_V1=dev/machineclassv1.yaml`.

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -44,14 +44,13 @@ import (
 
 const (
 	dwdIgnoreScalingAnnotation = "dependency-watchdog.gardener.cloud/ignore-scaling"
-
-	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker
-	targetClusterPlaceholder = "integration-test-cluster"
 )
 
 var (
 	// path for storing log files (mcm & mc processes)
 	targetDir = filepath.Join("..", "..", "..", ".ci", "controllers-test", "logs")
+	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker
+	targetClusterName = os.Getenv("TARGET_RESOURCE_GROUP")
 	// machine-controller-manager log file
 	mcmLogFile = filepath.Join(targetDir, "mcm_process.log")
 
@@ -491,13 +490,13 @@ func (c *IntegrationTestFramework) scaleMcmDeployment(replicas int32) error {
 }
 
 func (c *IntegrationTestFramework) updatePatchFile() {
-	clusterTag := "kubernetes-io-cluster-" + targetClusterPlaceholder
+	clusterTag := "kubernetes-io-cluster-" + targetClusterName
 	testRoleTag := "kubernetes-io-role-integration-test"
 
 	patchMachineClassData := MachineClassPatch{
 		ProviderSpec: ProviderSpecPatch{
 			Tags: []string{
-				targetClusterPlaceholder,
+				targetClusterName,
 				clusterTag,
 				testRoleTag,
 			},
@@ -822,7 +821,7 @@ func (c *IntegrationTestFramework) SetupBeforeSuite() {
 		Get(ctx, testMachineClassResources[0], metav1.GetOptions{})
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	clusterName := targetClusterPlaceholder
+	clusterName := targetClusterName
 
 	ginkgo.By("Looking for secrets refered in machineclass in the control cluster")
 	secretData, err := c.ControlCluster.

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -49,7 +49,7 @@ const (
 var (
 	// path for storing log files (mcm & mc processes)
 	targetDir = filepath.Join("..", "..", "..", ".ci", "controllers-test", "logs")
-	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker
+	// Suffix for the`kubernetes-io-cluster` tag and cluster name for the orphan resource tracker. Currently relevant only for Azure
 	targetClusterName = os.Getenv("TARGET_RESOURCE_GROUP")
 	// machine-controller-manager log file
 	mcmLogFile = filepath.Join(targetDir, "mcm_process.log")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new env var `TARGET_RESOURCE_GROUP`
This PR also corrects the use of `IS_CONTROL_CLUSTER_SEED` in the docs
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
