### PR TITLE
Machine VM Instance Initialization After Creation

### DIFF
--- a/pkg/util/provider/driver/driver.go
+++ b/pkg/util/provider/driver/driver.go
@@ -20,14 +20,24 @@ package driver
 import (
 	"context"
 
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 )
 
 // Driver is the common interface for creation/deletion of the VMs over different cloud-providers.
 type Driver interface {
 	// CreateMachine call is responsible for VM creation on the provider
 	CreateMachine(context.Context, *CreateMachineRequest) (*CreateMachineResponse, error)
+	// InitializeMachine call is responsible for VM initialization on the provider.
+	// This should one-time post VM creation activities like network configuration, etc.
+	//
+	// In case of an error, this operation should return an error with one of the following status codes
+	//  - codes.Unimplemented if the provider does not support VM instance initialization.
+	//  - codes.Uninitialized initialization of VM instance failed due to errors
+	//  - codes.NotFound if VM instance was not found.
+	//  - codes.Aborted if VM instance was aborted by the provider.
+	InitializeMachine(context.Context, *InitializeMachineRequest) (*InitializeMachineResponse, error)
 	// DeleteMachine call is responsible for VM deletion/termination on the provider
 	DeleteMachine(context.Context, *DeleteMachineRequest) (*DeleteMachineResponse, error)
 	// GetMachineStatus call get's the status of the VM backing the machine object on the provider
@@ -61,6 +71,32 @@ type CreateMachineResponse struct {
 	NodeName string
 
 	// LastKnownState represents the last state of the VM during an creation/deletion error
+	LastKnownState string
+}
+
+// InitializeMachineRequest encapsulates params for the VM Initialization operation in the Driver facade.
+type InitializeMachineRequest struct {
+	// Machine object representing VM that must be initialized
+	Machine *v1alpha1.Machine
+
+	// MachineClass backing the machine object
+	MachineClass *v1alpha1.MachineClass
+
+	//  Secret backing the machineClass object
+	Secret *corev1.Secret
+}
+
+// InitializeMachineResponse is the response for VM instance initialization (Driver.InitializeMachine).
+type InitializeMachineResponse struct {
+	// ProviderID is the unique identification of the VM at the cloud provider.
+	// ProviderID typically matches with the node.Spec.ProviderID on the node object.
+	// Eg: gce://project-name/region/vm-ID
+	ProviderID string
+
+	// NodeName is the name of the node-object registered to kubernetes.
+	NodeName string
+
+	// LastKnownState represents the last state of the VM instance after initialization operation.
 	LastKnownState string
 }
 

--- a/pkg/util/provider/driver/fake.go
+++ b/pkg/util/provider/driver/fake.go
@@ -74,6 +74,19 @@ func (d *FakeDriver) CreateMachine(ctx context.Context, createMachineRequest *Cr
 	return nil, d.Err
 }
 
+// InitializeMachine makes a call to the driver to initialize the VM instance of machine.
+func (d *FakeDriver) InitializeMachine(ctx context.Context, initMachineRequest *InitializeMachineRequest) (*InitializeMachineResponse, error) {
+	if d.Err == nil {
+		d.VMExists = true
+		return &InitializeMachineResponse{
+			ProviderID:     d.ProviderID,
+			NodeName:       d.NodeName,
+			LastKnownState: d.LastKnownState,
+		}, nil
+	}
+	return nil, d.Err
+}
+
 // DeleteMachine make a call to the driver to delete the machine.
 func (d *FakeDriver) DeleteMachine(ctx context.Context, deleteMachineRequest *DeleteMachineRequest) (*DeleteMachineResponse, error) {
 	d.VMExists = false

--- a/pkg/util/provider/machinecodes/codes/code_string.go
+++ b/pkg/util/provider/machinecodes/codes/code_string.go
@@ -62,6 +62,8 @@ func (c Code) String() string {
 		return "DataLoss"
 	case Unauthenticated:
 		return "Unauthenticated"
+	case Uninitialized:
+		return "Uninitialized"
 	default:
 		return "Code(" + strconv.FormatInt(int64(c), 10) + ")"
 	}

--- a/pkg/util/provider/machinecodes/codes/codes.go
+++ b/pkg/util/provider/machinecodes/codes/codes.go
@@ -144,6 +144,11 @@ const (
 	// Unauthenticated indicates the request does not have valid
 	// authentication credentials for the operation.
 	Unauthenticated Code = 16
+
+	// Uninitialized indicates that the VM instance initialization was not performed.
+	// This is meant to be used by providers in implementation of
+	// [github.com/gardener/machine-controller-manager/pkg/util/provider/driver.Driver.GetMachineStatus]
+	Uninitialized Code = 17
 )
 
 var strToCode = map[string]Code{

--- a/pkg/util/provider/machinecodes/codes/codes.go
+++ b/pkg/util/provider/machinecodes/codes/codes.go
@@ -169,6 +169,7 @@ var strToCode = map[string]Code{
 	"Unavailable":        Unavailable,
 	"DataLoss":           DataLoss,
 	"Unauthenticated":    Unauthenticated,
+	"Uninitialized":      Uninitialized,
 }
 
 // StringToCode coverts string into the Code.

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -360,8 +360,9 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		nodeName, providerID string
 
 		// Initializations
-		machine     = createMachineRequest.Machine
-		machineName = createMachineRequest.Machine.Name
+		machine                            = createMachineRequest.Machine
+		machineName                        = createMachineRequest.Machine.Name
+		newlyCreatedOrUninitializedMachine = false
 	)
 
 	// we should avoid mutating Secret, since it goes all the way into the Informer's store
@@ -390,6 +391,7 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 			klog.Errorf("Error occurred while decoding machine error for machine %q: %s", machine.Name, err)
 			return machineutils.MediumRetry, err
 		}
+		klog.Warningf("For machine %q, obtained VM error status as: %s", machineErr)
 
 		// Decoding machine error code
 		switch machineErr.Code() {
@@ -407,6 +409,7 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 					klog.Errorf("Error while creating machine %s: %s", machine.Name, err.Error())
 					return c.machineCreateErrorHandler(ctx, machine, createMachineResponse, err)
 				}
+				newlyCreatedOrUninitializedMachine = true
 
 				nodeName = createMachineResponse.NodeName
 				providerID = createMachineResponse.ProviderID
@@ -496,6 +499,9 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 
 			return machineutils.ShortRetry, err
 
+		case codes.Uninitialized:
+			newlyCreatedOrUninitializedMachine = true
+			klog.Infof("VM instance associated with machine %s was created but not initialized.", machine.Name)
 		default:
 			updateRetryPeriod, updateErr := c.machineStatusUpdate(
 				ctx,
@@ -517,6 +523,7 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 			}
 
 			return machineutils.MediumRetry, err
+
 		}
 	} else {
 		if machine.Labels[v1alpha1.NodeLabelKey] == "" || machine.Spec.ProviderID == "" {
@@ -554,7 +561,12 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		}
 		return machineutils.ShortRetry, err
 	}
-
+	if newlyCreatedOrUninitializedMachine {
+		retryPeriod, err := c.initializeMachine(ctx, createMachineRequest.Machine, createMachineRequest.MachineClass, createMachineRequest.Secret)
+		if err != nil {
+			return retryPeriod, err
+		}
+	}
 	if machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff {
 		clone := machine.DeepCopy()
 		clone.Status.LastOperation = v1alpha1.LastOperation{
@@ -583,6 +595,54 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 	}
 
 	return machineutils.LongRetry, nil
+}
+
+func (c *controller) initializeMachine(ctx context.Context, machine *v1alpha1.Machine, machineClass *v1alpha1.MachineClass, secret *corev1.Secret) (machineutils.RetryPeriod, error) {
+	req := &driver.InitializeMachineRequest{
+		Machine:      machine,
+		MachineClass: machineClass,
+		Secret:       secret,
+	}
+	klog.V(3).Infof("Initializing VM instance for Machine %q", machine.Name)
+	resp, err := c.driver.InitializeMachine(ctx, req)
+	if err != nil {
+		errStatus, ok := status.FromError(err)
+		if !ok {
+			klog.Errorf("Error occurred while decoding machine error for machine %q: %s", machine.Name, err)
+			return machineutils.MediumRetry, err
+		}
+		klog.Errorf("Error occurred while initializing VM instance for machine %q: %s", machine.Name, err)
+		switch errStatus.Code() {
+		case codes.Unimplemented:
+			klog.Warningf("Provider does not support Driver.InitializeMachine - skipping VM instance initialization for %q.", machine.Name)
+			return 0, nil
+		case codes.NotFound:
+			klog.Warningf("No VM instance found for machine %q. Skipping VM instance initialization.", machine.Name)
+			return 0, nil
+		case codes.Canceled, codes.Aborted:
+			klog.Warningf("VM instance initialization for machine %q was aborted/cancelled.", machine.Name)
+			return 0, nil
+		}
+		return c.machineStatusUpdate(
+			ctx,
+			machine,
+			v1alpha1.LastOperation{
+				Description:    fmt.Sprintf("Provider error: %s. %s", err.Error(), machineutils.InstanceInitialization),
+				ErrorCode:      errStatus.Code().String(),
+				State:          v1alpha1.MachineStateFailed,
+				Type:           v1alpha1.MachineOperationCreate,
+				LastUpdateTime: metav1.Now(),
+			},
+			v1alpha1.CurrentStatus{
+				Phase:          c.getCreateFailurePhase(machine),
+				LastUpdateTime: metav1.Now(),
+			},
+			machine.Status.LastKnownState,
+		)
+	}
+
+	klog.Infof("VM instance %q for machine %q was initialized with last known state: %q", resp.ProviderID, machine.Name, resp.LastKnownState)
+	return 0, nil
 }
 
 func (c *controller) triggerDeletionFlow(ctx context.Context, deleteMachineRequest *driver.DeleteMachineRequest) (machineutils.RetryPeriod, error) {

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -616,7 +616,7 @@ func (c *controller) initializeMachine(ctx context.Context, machine *v1alpha1.Ma
 		klog.Errorf("Error occurred while initializing VM instance for machine %q: %s", machine.Name, err)
 		switch errStatus.Code() {
 		case codes.Unimplemented:
-			klog.Warningf("Provider does not support Driver.InitializeMachine - skipping VM instance initialization for %q.", machine.Name)
+			klog.V(3).Infof("Provider does not support Driver.InitializeMachine - skipping VM instance initialization for %q.", machine.Name)
 			return 0, nil
 		case codes.NotFound:
 			klog.Warningf("No VM instance found for machine %q. Skipping VM instance initialization.", machine.Name)

--- a/pkg/util/provider/machinecontroller/machine_safety_test.go
+++ b/pkg/util/provider/machinecontroller/machine_safety_test.go
@@ -19,14 +19,15 @@ import (
 	"context"
 	"time"
 
-	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	v1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 )
 
 var _ = Describe("safety_logic", func() {
@@ -316,7 +317,7 @@ var _ = Describe("safety_logic", func() {
 				controlMachineObjects = append(controlMachineObjects, obj)
 			}
 
-			fakeDriver := driver.NewFakeDriver(false, "", "", "", nil, nil)
+			fakeDriver := driver.NewFakeDriver(false, "", "", "", nil, nil, nil)
 
 			c, trackers := createController(stop, testNamespace, controlMachineObjects, controlCoreObjects, nil, fakeDriver)
 			defer trackers.Stop()

--- a/pkg/util/provider/machinecontroller/machineclass_test.go
+++ b/pkg/util/provider/machinecontroller/machineclass_test.go
@@ -21,15 +21,16 @@ import (
 	"math"
 	"time"
 
-	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	customfake "github.com/gardener/machine-controller-manager/pkg/fakeclient"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	customfake "github.com/gardener/machine-controller-manager/pkg/fakeclient"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 )
 
 const (
@@ -80,6 +81,7 @@ var _ = Describe("machineclass", func() {
 					data.action.fakeDriver.NodeName,
 					data.action.fakeDriver.LastKnownState,
 					data.action.fakeDriver.Err,
+					nil,
 					nil,
 				)
 

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -27,6 +27,9 @@ const (
 	// GetVMStatus sets machine status to terminating and specifies next step as getting VMs
 	GetVMStatus = "Set machine status to termination. Now, getting VM Status"
 
+	// InstanceInitialization is a step that represents initialization of a VM instance (post-creation).
+	InstanceInitialization = "Initialize VM Instance"
+
 	// InitiateDrain specifies next step as initiate node drain
 	InitiateDrain = "Initiate node drain"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

See #871

Enhance the Machine Controller `triggerCreationFlow` to correctly handle post-creation instance initialization steps in  with appropriate retry handling. Ensure that workload is not scheduled until the machine phase is Running

**Which issue(s) this PR fixes**:
Fixes #871 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
 New method Driver.InitializeMachine added for Post-Creation VM Instance Initialization activities.
```
