### PR TITLE
Improved context with timeout for DrainNode

### DIFF
--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -996,12 +996,6 @@ func (o *Options) evictPodWithoutPVInternal(ctx context.Context, attemptEvict bo
 		if i >= nretries {
 			attemptEvict = false
 		}
-		select {
-		case <-ctx.Done():
-			// Timeout occurred. Abort and report the remaining pods.
-			returnCh <- fmt.Errorf("timeout occured while waiting for pod %q terminating scheduled on node %v", pod.Name, pod.Spec.NodeName)
-		default:
-		}
 		if attemptEvict {
 			err = o.evictPod(ctx, pod, policyGroupVersion)
 		} else {

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -996,6 +996,7 @@ func (o *Options) evictPodWithoutPVInternal(ctx context.Context, attemptEvict bo
 		if i >= nretries {
 			attemptEvict = false
 		}
+
 		if attemptEvict {
 			err = o.evictPod(ctx, pod, policyGroupVersion)
 		} else {

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -381,7 +381,6 @@ func (o *Options) evictPod(ctx context.Context, pod *corev1.Pod, policyGroupVers
 	}
 	klog.V(3).Infof("Attempting to evict the pod:%q from node %q", pod.Name, o.nodeName)
 	// TODO: Remember to change the URL manipulation func when Evction's version change
-	time.Sleep(6 * time.Minute)
 	return o.client.PolicyV1beta1().Evictions(eviction.Namespace).Evict(ctx, eviction)
 }
 

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1410,7 +1410,6 @@ func (c *controller) getEffectiveDrainTimeout(machine *v1alpha1.Machine) *metav1
 	} else {
 		effectiveDrainTimeout = &c.safetyOptions.MachineDrainTimeout
 	}
-	effectiveDrainTimeout.Duration -= time.Now().Sub(machine.DeletionTimestamp.Time)
 	return effectiveDrainTimeout
 }
 

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1043,9 +1043,6 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 		nodeNotReadyDuration                         = 5 * time.Minute
 		ReadonlyFilesystem      v1.NodeConditionType = "ReadonlyFilesystem"
 	)
-
-	drainContext, cancelFn := context.WithDeadline(ctx, time.Now().Add(timeOutDuration))
-	defer cancelFn()
 	if !isValidNodeName(nodeName) {
 		message := "Skipping drain as nodeName is not a valid one for machine."
 		printLogInitError(message, &err, &description, machine)
@@ -1155,7 +1152,7 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 				c.volumeAttachmentHandler,
 			)
 			klog.V(3).Infof("(drainNode) Invoking RunDrain, forceDeleteMachine: %t, forceDeletePods: %t, timeOutDuration: %s", forceDeletePods, forceDeleteMachine, timeOutDuration)
-			err = drainOptions.RunDrain(drainContext)
+			err = drainOptions.RunDrain(ctx)
 			if err == nil {
 				// Drain successful
 				klog.V(2).Infof("Drain successful for machine %q ,providerID %q, backing node %q. \nBuf:%v \nErrBuf:%v", machine.Name, getProviderID(machine), getNodeName(machine), buf, errBuf)

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1044,7 +1044,7 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 		ReadonlyFilesystem      v1.NodeConditionType = "ReadonlyFilesystem"
 	)
 
-	drainContext, cancelFn := context.WithDeadline(ctx, deleteMachineRequest.Machine.DeletionTimestamp.Add(timeOutDuration))
+	drainContext, cancelFn := context.WithDeadline(ctx, time.Now().Add(timeOutDuration))
 	defer cancelFn()
 	if !isValidNodeName(nodeName) {
 		message := "Skipping drain as nodeName is not a valid one for machine."
@@ -1114,7 +1114,7 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 		}
 
 		// update node with the machine's phase prior to termination
-		if err = c.UpdateNodeTerminationCondition(drainContext, machine); err != nil {
+		if err = c.UpdateNodeTerminationCondition(ctx, machine); err != nil {
 			if forceDeleteMachine {
 				klog.Warningf("Failed to update node conditions: %v. However, since it's a force deletion shall continue deletion of VM.", err)
 			} else {
@@ -1185,7 +1185,7 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 	}
 
 	updateRetryPeriod, updateErr := c.machineStatusUpdate(
-		drainContext,
+		ctx,
 		machine,
 		v1alpha1.LastOperation{
 			Description:    description,

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1043,6 +1043,7 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 		nodeNotReadyDuration                         = 5 * time.Minute
 		ReadonlyFilesystem      v1.NodeConditionType = "ReadonlyFilesystem"
 	)
+
 	if !isValidNodeName(nodeName) {
 		message := "Skipping drain as nodeName is not a valid one for machine."
 		printLogInitError(message, &err, &description, machine)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a drain Context in `RunDrain` with a timeout so that context cancels and machine can be force deleted later.
**Which issue(s) this PR fixes**:
Fixes #785 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Drain timeout is now correctly honored for Pod eviction during Machine Drain
```
