### PR TITLE
Allow deletion to proceed in case of VM initialization error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ kubectl
 
 # Autogen tags
 tags
+
+# dont check in tool binariess
+hack/tools/bin/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ IMAGE_REPOSITORY   := europe-docker.pkg.dev/gardener-project/public/gardener/mac
 IMAGE_TAG          := $(shell cat VERSION)
 COVERPROFILE       := test/output/coverprofile.out
 
-LEADER_ELECT 	   := "true"
+LEADER_ELECT 	   ?= "true" # If LEADER_ELECT is not set in the environment, use the default value "true"
 MACHINE_SAFETY_OVERSHOOTING_PERIOD:=1m
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)

--- a/hack/gardener_local_setup.sh
+++ b/hack/gardener_local_setup.sh
@@ -196,11 +196,13 @@ function set_makefile_env() {
   local target_project_dir target_kube_config_path
   target_project_dir="$1"
   target_kube_config_path="$2"
+  echo "IS_CONTROL_CLUSTER_SEED=true" > "${target_project_dir}/.env"
   {
-    printf "\n%s" "IS_CONTROL_CLUSTER_SEED=true" >"${target_project_dir}/.env"
-    printf "\n%s" "CONTROL_CLUSTER_NAMESPACE=shoot--${PROJECT}--${SHOOT}" >> "${target_project_dir}/.env"
-    printf "\n%s" "CONTROL_KUBECONFIG=${target_kube_config_path}/kubeconfig_control.yaml" >>"${target_project_dir}/.env"
-    printf "\n%s" "TARGET_KUBECONFIG=${target_kube_config_path}/kubeconfig_target.yaml" >>"${target_project_dir}/.env"
+    printf "CONTROL_CLUSTER_NAMESPACE=%s--%s\n" "${PROJECT}" "${SHOOT}";
+    printf "CONTROL_NAMESPACE=%s--%s\n" "${PROJECT}" "${SHOOT}";
+    printf "CONTROL_KUBECONFIG=%s\n" "${target_kube_config_path}/kubeconfig_control.yaml";
+    printf "TARGET_KUBECONFIG=%s\n" "${target_kube_config_path}/kubeconfig_target.yaml";
+    printf "LEADER_ELECT=false\n"
   } >>"${target_project_dir}/.env"
 }
 

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -969,6 +969,10 @@ func (c *controller) getVMStatus(ctx context.Context, getMachineStatusRequest *d
 				description = "Error occurred with decoding machine error status while getting VM status, aborting with retry. " + machineutils.GetVMStatus
 				state = v1alpha1.MachineStateFailed
 				retry = machineutils.ShortRetry
+			case codes.Uninitialized:
+				description = "VM instance was not initalized. Moving forward to node drain. " + machineutils.InitiateDrain
+				state = v1alpha1.MachineStateProcessing
+				retry = machineutils.ShortRetry
 
 			default:
 				// Error occurred with decoding machine error status, abort with retry.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the `triggerDeletionFlow`, specifically the  `getVMStatus` function to allow deletion of Unitialized VMs to proceed 

**Which issue(s) this PR fixes**:
Fixes #926 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where the `Unitialised` error code was blocking machine deletion
```
