### PR TITLE
Add namespace to dummy machine object so that driver can rely on the namespace being set

### DIFF
--- a/pkg/util/provider/machinecontroller/machine_safety.go
+++ b/pkg/util/provider/machinecontroller/machine_safety.go
@@ -272,7 +272,8 @@ func (c *controller) checkMachineClass(ctx context.Context, machineClass *v1alph
 			// Creating a dummy machine object to create deleteMachineRequest
 			machine = &v1alpha1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: machineName,
+					Name:      machineName,
+					Namespace: machineClass.Namespace,
 				},
 				Spec: v1alpha1.MachineSpec{
 					ProviderID: machineID,


### PR DESCRIPTION
**What this PR does / why we need it**:

Add namespace to dummy machine object so that driver can rely on the namespace being set.

Some drivers may assume that the namespace of the machine resources is correctly set when a request is sent to them, e.g. see https://github.com/gardener/gardener/pull/10176. As the namespace of the machine is known due to its machine class, it should be always safe to set the correct namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
