### PR TITLE
Modify Machine Creation flow to make sure node label is updated before initialization of VM. Modify Deletion flow to call DeleteMachine even if VM is not found.

### DIFF
--- a/pkg/util/provider/driver/fake.go
+++ b/pkg/util/provider/driver/fake.go
@@ -92,17 +92,14 @@ func (d *FakeDriver) DeleteMachine(_ context.Context, deleteMachineRequest *Dele
 
 // GetMachineStatus makes a gRPC call to the driver to check existance of machine
 func (d *FakeDriver) GetMachineStatus(_ context.Context, _ *GetMachineStatusRequest) (*GetMachineStatusResponse, error) {
-	switch {
-	case !d.VMExists:
+	if !d.VMExists {
 		errMessage := "Fake plugin is returning no VM instances backing this machine object"
 		return nil, status.Error(codes.NotFound, errMessage)
-	case d.Err != nil:
-		return nil, d.Err
 	}
 	return &GetMachineStatusResponse{
 		ProviderID: d.ProviderID,
 		NodeName:   d.NodeName,
-	}, nil
+	}, d.Err
 }
 
 // ListMachines have to list machines

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -521,6 +521,8 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		if machine.Labels[v1alpha1.NodeLabelKey] == "" || machine.Spec.ProviderID == "" {
 			klog.V(2).Infof("Found VM with required machine name. Adopting existing machine: %q with ProviderID: %s", machineName, getMachineStatusResponse.ProviderID)
 		}
+		//clean me up. I'm dirty.
+		//TODO@thiyyakat add a pointer to a boolean variable indicating whether initialization has happened successfully.
 		nodeName = getMachineStatusResponse.NodeName
 		providerID = getMachineStatusResponse.ProviderID
 	}

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -545,8 +545,6 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 			klog.Warningf("Machine UPDATE failed for %q. Retrying, error: %s", machine.Name, err)
 		} else {
 			klog.V(2).Infof("Machine labels/annotations UPDATE for %q", machine.Name)
-			// Return error even when machine object is updated
-			err = fmt.Errorf("Machine creation in process. Machine UPDATE successful")
 		}
 	}
 	if uninitializedMachine {
@@ -554,6 +552,8 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		if err != nil {
 			return retryPeriod, err
 		}
+		// Return error even when machine object is updated
+		err = fmt.Errorf("Machine creation in process. Machine UPDATE successful")
 		return machineutils.ShortRetry, err
 	}
 	if machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff {

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -548,13 +548,13 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 			// Return error even when machine object is updated
 			err = fmt.Errorf("Machine creation in process. Machine UPDATE successful")
 		}
-		return machineutils.ShortRetry, err
 	}
 	if uninitializedMachine {
 		retryPeriod, err := c.initializeMachine(ctx, createMachineRequest.Machine, createMachineRequest.MachineClass, createMachineRequest.Secret)
 		if err != nil {
 			return retryPeriod, err
 		}
+		return machineutils.ShortRetry, err
 	}
 	if machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff {
 		clone := machine.DeepCopy()

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -492,6 +492,8 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		case codes.Uninitialized:
 			uninitializedMachine = true
 			klog.Infof("VM instance associated with machine %s was created but not initialized.", machine.Name)
+			//clean me up. I'm dirty.
+			//TODO@thiyyakat add a pointer to a boolean variable indicating whether initialization has happened successfully.
 			nodeName = getMachineStatusResponse.NodeName
 			providerID = getMachineStatusResponse.ProviderID
 
@@ -521,8 +523,6 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		if machine.Labels[v1alpha1.NodeLabelKey] == "" || machine.Spec.ProviderID == "" {
 			klog.V(2).Infof("Found VM with required machine name. Adopting existing machine: %q with ProviderID: %s", machineName, getMachineStatusResponse.ProviderID)
 		}
-		//clean me up. I'm dirty.
-		//TODO@thiyyakat add a pointer to a boolean variable indicating whether initialization has happened successfully.
 		nodeName = getMachineStatusResponse.NodeName
 		providerID = getMachineStatusResponse.ProviderID
 	}

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -492,6 +492,8 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		case codes.Uninitialized:
 			uninitializedMachine = true
 			klog.Infof("VM instance associated with machine %s was created but not initialized.", machine.Name)
+			nodeName = getMachineStatusResponse.NodeName
+			providerID = getMachineStatusResponse.ProviderID
 
 		default:
 			updateRetryPeriod, updateErr := c.machineStatusUpdate(
@@ -522,39 +524,10 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		nodeName = getMachineStatusResponse.NodeName
 		providerID = getMachineStatusResponse.ProviderID
 	}
-
-	//Update labels
-	_, machineNodeLabelPresent := createMachineRequest.Machine.Labels[v1alpha1.NodeLabelKey]
-	_, machinePriorityAnnotationPresent := createMachineRequest.Machine.Annotations[machineutils.MachinePriority]
-
-	if !machineNodeLabelPresent || !machinePriorityAnnotationPresent || machine.Spec.ProviderID == "" {
-		clone := machine.DeepCopy()
-		if clone.Labels == nil {
-			clone.Labels = make(map[string]string)
-		}
-		clone.Labels[v1alpha1.NodeLabelKey] = nodeName
-		if clone.Annotations == nil {
-			clone.Annotations = make(map[string]string)
-		}
-		if clone.Annotations[machineutils.MachinePriority] == "" {
-			clone.Annotations[machineutils.MachinePriority] = "3"
-		}
-		clone.Spec.ProviderID = providerID
-		_, err := c.controlMachineClient.Machines(clone.Namespace).Update(ctx, clone, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Warningf("Machine UPDATE failed for %q. Retrying, error: %s", machine.Name, err)
-		} else {
-			klog.V(2).Infof("Machine labels/annotations UPDATE for %q", machine.Name)
-		}
-	}
-	if uninitializedMachine {
-		retryPeriod, err := c.initializeMachine(ctx, createMachineRequest.Machine, createMachineRequest.MachineClass, createMachineRequest.Secret)
-		if err != nil {
-			return retryPeriod, err
-		}
-		// Return error even when machine object is updated
-		err = fmt.Errorf("Machine creation in process. Machine UPDATE successful")
-		return machineutils.ShortRetry, err
+	//Update labels, providerID and initialize the VM
+	retryPeriod, err := c.updateLabelsAndInitializeMachine(ctx, createMachineRequest, nodeName, providerID, uninitializedMachine)
+	if err != nil {
+		return retryPeriod, err
 	}
 	if machine.Status.CurrentStatus.Phase == "" || machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff {
 		clone := machine.DeepCopy()
@@ -574,13 +547,50 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 			klog.Warningf("Machine/status UPDATE failed for %q. Retrying, error: %s", machine.Name, err)
 		} else {
 			klog.V(2).Infof("Machine/status UPDATE for %q during creation", machine.Name)
-
 			// Return error even when machine object is updated
 			err = fmt.Errorf("Machine creation in process. Machine/Status UPDATE successful")
 		}
 		return machineutils.ShortRetry, err
 	}
 	return machineutils.LongRetry, nil
+}
+
+func (c *controller) updateLabelsAndInitializeMachine(ctx context.Context, createMachineRequest *driver.CreateMachineRequest, nodeName, providerID string, shouldInitializeMachine bool) (retryPeriod machineutils.RetryPeriod, err error) {
+	_, machineNodeLabelPresent := createMachineRequest.Machine.Labels[v1alpha1.NodeLabelKey]
+	_, machinePriorityAnnotationPresent := createMachineRequest.Machine.Annotations[machineutils.MachinePriority]
+	clone := createMachineRequest.Machine.DeepCopy()
+	if !machineNodeLabelPresent || !machinePriorityAnnotationPresent || createMachineRequest.Machine.Spec.ProviderID == "" {
+		if clone.Labels == nil {
+			clone.Labels = make(map[string]string)
+		}
+		clone.Labels[v1alpha1.NodeLabelKey] = nodeName
+		if clone.Annotations == nil {
+			clone.Annotations = make(map[string]string)
+		}
+		if clone.Annotations[machineutils.MachinePriority] == "" {
+			clone.Annotations[machineutils.MachinePriority] = "3"
+		}
+		clone.Spec.ProviderID = providerID
+		var updatedMachine *v1alpha1.Machine
+		updatedMachine, err = c.controlMachineClient.Machines(clone.Namespace).Update(ctx, clone, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Warningf("Machine labels/annotations UPDATE failed for %q. Will retry after VM initialization (if required), error: %s", createMachineRequest.Machine.Name, err)
+			clone = createMachineRequest.Machine.DeepCopy()
+		} else {
+			clone = updatedMachine
+			klog.V(2).Infof("Machine labels/annotations UPDATE for %q", clone.Name)
+			err = fmt.Errorf("Machine creation in process. Machine labels/annotations update is successful.")
+		}
+	}
+	if shouldInitializeMachine {
+		retryPeriod, err = c.initializeMachine(ctx, clone, createMachineRequest.MachineClass, createMachineRequest.Secret)
+		if err != nil {
+			return retryPeriod, err
+		}
+		// Return error even when machine object is updated
+		err = fmt.Errorf("Machine creation in process. Machine initialization (if required) is successful.")
+	}
+	return machineutils.ShortRetry, err
 }
 
 func (c *controller) initializeMachine(ctx context.Context, machine *v1alpha1.Machine, machineClass *v1alpha1.MachineClass, secret *corev1.Secret) (machineutils.RetryPeriod, error) {
@@ -643,7 +653,7 @@ func (c *controller) triggerDeletionFlow(ctx context.Context, deleteMachineReque
 		return c.setMachineTerminationStatus(ctx, deleteMachineRequest)
 
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.GetVMStatus):
-		return c.getVMStatus(
+		return c.updateMachineStatusAndNodeLabel(
 			ctx,
 			&driver.GetMachineStatusRequest{
 				Machine:      deleteMachineRequest.Machine,

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -545,7 +545,7 @@ var _ = Describe("machine", func() {
 							ProviderID: "fakeID",
 						},
 					}, nil, nil, nil, map[string]string{v1alpha1.NodeLabelKey: "fakeNode-0"}, true, metav1.Now()),
-					err:   fmt.Errorf("Machine creation in process. Machine initialization (if required) is successful."),
+					err:   fmt.Errorf("machine creation in process. Machine initialization (if required) is successful"),
 					retry: machineutils.ShortRetry,
 				},
 			}),
@@ -623,7 +623,7 @@ var _ = Describe("machine", func() {
 						true,
 						metav1.Now(),
 					),
-					err:   fmt.Errorf("Machine creation in process. Machine/Status UPDATE successful"),
+					err:   fmt.Errorf("machine creation in process. Machine/Status UPDATE successful"),
 					retry: machineutils.ShortRetry,
 				},
 			}),
@@ -1016,7 +1016,7 @@ var _ = Describe("machine", func() {
 						true,
 						metav1.Now(),
 					),
-					err:   fmt.Errorf("Machine creation in process. Machine/Status UPDATE successful"),
+					err:   fmt.Errorf("machine creation in process. Machine/Status UPDATE successful"),
 					retry: machineutils.ShortRetry,
 				},
 			}),
@@ -1504,7 +1504,7 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					err:   fmt.Errorf("Machine deletion in process. VM with matching ID found"),
+					err:   fmt.Errorf("machine deletion in process. VM with matching ID found"),
 					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -545,7 +545,7 @@ var _ = Describe("machine", func() {
 							ProviderID: "fakeID",
 						},
 					}, nil, nil, nil, map[string]string{v1alpha1.NodeLabelKey: "fakeNode-0"}, true, metav1.Now()),
-					err:   fmt.Errorf("Machine creation in process. Machine UPDATE successful"),
+					err:   fmt.Errorf("Machine creation in process. Machine initialization (if required) is successful."),
 					retry: machineutils.ShortRetry,
 				},
 			}),
@@ -1068,6 +1068,7 @@ var _ = Describe("machine", func() {
 								Kind: "MachineClass",
 								Name: "machineClass",
 							},
+							ProviderID: "fakeID",
 						},
 					}, &v1alpha1.MachineStatus{
 						CurrentStatus: v1alpha1.CurrentStatus{
@@ -1079,7 +1080,7 @@ var _ = Describe("machine", func() {
 							State:       v1alpha1.MachineStateFailed,
 							Type:        v1alpha1.MachineOperationCreate,
 						},
-					}, nil, nil, nil, true, metav1.Now()),
+					}, nil, nil, map[string]string{v1alpha1.NodeLabelKey: "fakeNode-0"}, true, metav1.Now()),
 					err:   status.Error(codes.Uninitialized, "VM instance could not be initialized"),
 					retry: machineutils.ShortRetry,
 				},

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -963,7 +963,7 @@ func (c *controller) updateMachineStatusAndNodeLabel(ctx context.Context, getMac
 		// Figure out node label either by checking all nodes for label matching machine name or retrieving it using GetMachineStatus
 		nodeName, err = c.getNodeName(ctx, getMachineStatusRequest)
 		if err == nil {
-			if err := c.updateMachineNodeLabel(ctx, getMachineStatusRequest.Machine, nodeName); err != nil {
+			if err = c.updateMachineNodeLabel(ctx, getMachineStatusRequest.Machine, nodeName); err != nil {
 				return machineutils.ShortRetry, err
 			}
 			isNodeLabelUpdated = true

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -973,7 +973,7 @@ func (c *controller) updateMachineStatusAndNodeLabel(ctx context.Context, getMac
 				description = "Error occurred with decoding machine error status while getting VM status, aborting without retry. " + err.Error() + " " + machineutils.GetVMStatus
 				state = v1alpha1.MachineStateFailed
 				retry = machineutils.LongRetry
-				err = fmt.Errorf("Machine deletion has failed. %s", description)
+				err = fmt.Errorf("machine deletion has failed. %s", description)
 			} else {
 				// Decoding machine error code
 				switch machineErr.Code() {
@@ -1010,7 +1010,7 @@ func (c *controller) updateMachineStatusAndNodeLabel(ctx context.Context, getMac
 		state = v1alpha1.MachineStateProcessing
 		retry = machineutils.ShortRetry
 		// Return error even when machine object is updated to ensure reconcilation is restarted
-		err = fmt.Errorf("Machine deletion in process. VM with matching ID found")
+		err = fmt.Errorf("machine deletion in process. VM with matching ID found")
 	}
 	updateRetryPeriod, updateErr := c.machineStatusUpdate(
 		ctx,

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -960,12 +960,10 @@ func (c *controller) getVMStatus(ctx context.Context, getMachineStatusRequest *d
 		isNodeLabelUpdated = true
 	} else {
 		// Figure out node label either by checking all nodes for label matching machine name or retrieving it using GetMachineStatus
-		// TODO check if this is the right function to use, also is err a new variable?
 		// get all nodes and check if any node has the machine name as label
 		nodes, err := c.nodeLister.List(labels.Everything())
 		if err == nil {
 			for _, node := range nodes {
-				//TODO check if label key should be declared as constant somewhere
 				if node.Labels["node.gardener.cloud/machine-name"] == getMachineStatusRequest.Machine.Name {
 					nodeName := node.Name
 					err = c.updateMachineNodeLabel(ctx, getMachineStatusRequest.Machine, nodeName)

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -963,7 +963,7 @@ func (c *controller) getVMStatus(ctx context.Context, getMachineStatusRequest *d
 		// TODO check if this is the right function to use, also is err a new variable?
 		// get all nodes and check if any node has the machine name as label
 		nodes, err := c.nodeLister.List(labels.Everything())
-		if err != nil {
+		if err == nil {
 			for _, node := range nodes {
 				//TODO check if label key should be declared as constant somewhere
 				if node.Labels["node.gardener.cloud/machine-name"] == getMachineStatusRequest.Machine.Name {
@@ -1023,15 +1023,14 @@ func (c *controller) getVMStatus(ctx context.Context, getMachineStatusRequest *d
 					}
 				}
 			}
-
 		}
-		if isNodeLabelUpdated {
-			description = machineutils.InitiateDrain
-			state = v1alpha1.MachineStateProcessing
-			retry = machineutils.ShortRetry
-			// Return error even when machine object is updated to ensure reconcilation is restarted
-			err = fmt.Errorf("Machine deletion in process. VM with matching ID found")
-		}
+	}
+	if isNodeLabelUpdated {
+		description = machineutils.InitiateDrain
+		state = v1alpha1.MachineStateProcessing
+		retry = machineutils.ShortRetry
+		// Return error even when machine object is updated to ensure reconcilation is restarted
+		err = fmt.Errorf("Machine deletion in process. VM with matching ID found")
 	}
 	updateRetryPeriod, updateErr := c.machineStatusUpdate(
 		ctx,


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR changes `triggerCreationFlow` to update machine labels before proceeding to initialization.  This was done to make sure that the labels are always updated even in the case of initialization failures. 

It also changes `getVMStatus` to update the labels in the following way:
1. list all the nodes and find matching machine name label ( effective when #919 and https://github.com/gardener/gardener/pull/10014 are released)
2. If the above does not find a node name, do a `GetMachineStatus` call and populate the node name. 

In addition, `getVMStatus` will always redirect to `initiateDrain`. 

A change was also made to remove error logs when `InitializeMachine` is not implemented by a provider.


**Which issue(s) this PR fixes**:
Fixes #934 #936
Fixes part of #933 

**Special notes for your reviewer**:

The changes in the PR were tested by doing the following:
Manually returned an error from machine-controller-manager-provider-azure's `CreateMachine` code after NIC is created, such that the VM is not created. The machine was then marked for deletion. The logs showed that the NIC was deleted successfully.

Manually returned codes.Uninitialized error code from InitializeMachine for AWS. On triggering creation of machine, found that initialization is tried in a loop after shortRetry. 

Manually returned codes.Uninitialized from `initializeMachine` after the call to `driver.initializeMachine`. The logs show that the machine state update is successful. In the next reconciliation, since the machine is found to be initialized, machine goes to running.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`getVMStatus` always redirects to `InitiateDrain`. It also populates the node label on the machine object by checking `node.gardener.cloud/machine-name` label on the nodes. 
```

```bugfix operator
Fixed a bug where failure of machine initialization caused label updates to not happen. 
```
