### PR TITLE
Fix make generate

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -53,7 +53,7 @@ $(CONVERSION_GEN):
 	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install k8s.io/code-generator/cmd/conversion-gen@$(CODE_GENERATOR_VERSION)
 
 $(OPENAPI_GEN):
-	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install k8s.io/code-generator/cmd/openapi-gen@$(CODE_GENERATOR_VERSION)
+	GOBIN=$(abspath $(TOOLS_BIN_DIR)) go install k8s.io/kube-openapi/cmd/openapi-gen
 
 $(VGOPATH):
 	@if test -x $(TOOLS_BIN_DIR)/vgopath && ! $(TOOLS_BIN_DIR)/vgopath version | grep -q $(VGOPATH_VERSION); then \


### PR DESCRIPTION
**What this PR does / why we need it**:
`openapi-gen` has been remove from code-generator repo. Use `kube-openapi` `openapi-gen` instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
