### PR TITLE
Fix edge-case where scale-from-zero of MCD is mistaken for a rolling update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,8 @@ add-license-headers: $(GO_ADD_LICENSE)
 
 .PHONY: sast
 sast: $(GOSEC)
-	@chmod +xw hack/sast.sh
 	@./hack/sast.sh
 
 .PHONY: sast-report
 sast-report:$(GOSEC)
-	@chmod +xw hack/sast.sh
 	@./hack/sast.sh --gosec-report true

--- a/pkg/apis/machine/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/machine/v1alpha1/machinedeployment_types.go
@@ -132,10 +132,9 @@ type RollingUpdateMachineDeployment struct {
 	// Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%).
 	// Absolute number is calculated from percentage by rounding down.
 	// This can not be 0 if MaxSurge is 0.
-	// By default, a fixed value of 1 is used.
-	// Example: when this is set to 30%, the old MC can be scaled down to 70% of desired machines
-	// immediately when the rolling update starts. Once new machines are ready, old MC
-	// can be scaled down further, followed by scaling up the new MC, ensuring
+	// Example: when this is set to 30%, the old machine set can be scaled down to 70% of desired machines
+	// immediately when the rolling update starts. Once new machines are ready, old machine set
+	// can be scaled down further, followed by scaling up the new machine set, ensuring
 	// that the total number of machines available at all times during the update is at
 	// least 70% of desired machines.
 	// +optional
@@ -146,12 +145,11 @@ type RollingUpdateMachineDeployment struct {
 	// Value can be an absolute number (ex: 5) or a percentage of desired machines (ex: 10%).
 	// This can not be 0 if MaxUnavailable is 0.
 	// Absolute number is calculated from percentage by rounding up.
-	// By default, a value of 1 is used.
-	// Example: when this is set to 30%, the new MC can be scaled up immediately when
-	// the rolling update starts, such that the total number of old and new machines do not exceed
+	// Example: when this is set to 30%, the new machine set can be scaled up immediately when
+	// the rolling update starts, such that the total number of old and new machines does not exceed
 	// 130% of desired machines. Once old machines have been killed,
-	// new MC can be scaled up further, ensuring that total number of machines running
-	// at any time during the update is atmost 130% of desired machines.
+	// new machine set can be scaled up further, ensuring that total number of machines running
+	// at any time during the update is utmost 130% of desired machines.
 	// +optional
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty"`
 }

--- a/pkg/apis/machine/validation/machinedeployment.go
+++ b/pkg/apis/machine/validation/machinedeployment.go
@@ -36,10 +36,10 @@ func canConvertIntOrStringToInt32(val *intstr.IntOrString, replicas int) bool {
 
 func validateUpdateStrategy(spec *machine.MachineDeploymentSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if spec.Strategy.Type != "RollingUpdate" && spec.Strategy.Type != "Recreate" {
+	if spec.Strategy.Type != machine.RollingUpdateMachineDeploymentStrategyType && spec.Strategy.Type != machine.RecreateMachineDeploymentStrategyType {
 		allErrs = append(allErrs, field.Required(fldPath.Child("strategy.type"), "Type can either be RollingUpdate or Recreate"))
 	}
-	if spec.Strategy.Type == "RollingUpdate" {
+	if spec.Strategy.Type == machine.RollingUpdateMachineDeploymentStrategyType {
 		if spec.Strategy.RollingUpdate == nil {
 			allErrs = append(allErrs, field.Required(fldPath.Child("strategy.rollingUpdate"), "RollingUpdate parameter cannot be nil for rolling update strategy"))
 		} else {

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -595,6 +595,7 @@ var _ = Describe("#controllerUtils", func() {
 			},
 		}
 		It("should return an empty list when machine sets have 0 replicas", func() {
+			testMachineSet.Spec.Replicas = 0
 			testMachineSets := []*machinev1.MachineSet{
 				testMachineSet,
 			}

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -552,4 +552,60 @@ var _ = Describe("#controllerUtils", func() {
 			}),
 		)
 	})
+	Describe("##FilterActiveMachineSets", func() {
+		testMachineSet := &machinev1.MachineSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "MachineSet-test",
+				Namespace: testNamespace,
+				Labels: map[string]string{
+					"test-label": "test-label",
+				},
+				Annotations: map[string]string{
+					"deployment.kubernetes.io/revision": "1",
+				},
+				UID: "1234567",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       "MachineDeployment",
+						Name:       "MachineDeployment-test",
+						UID:        "1234567",
+						Controller: nil,
+					},
+				},
+				Generation: 5,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "MachineSet",
+				APIVersion: "machine.sapcloud.io/v1alpha1",
+			},
+			Spec: machinev1.MachineSetSpec{
+				Replicas: 0,
+				Template: machinev1.MachineTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"test-label": "test-label",
+						},
+					},
+				},
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"test-label": "test-label",
+					},
+				},
+			},
+		}
+		It("should return an empty list when machine sets have 0 replicas", func() {
+			testMachineSets := []*machinev1.MachineSet{
+				testMachineSet,
+			}
+			Expect(FilterActiveMachineSets(testMachineSets)).To(HaveLen(0))
+		})
+		It("should return expected machine sets when replicas are positive", func() {
+			testMachineSet.Spec.Replicas = 1
+			testMachineSets := []*machinev1.MachineSet{
+				testMachineSet,
+			}
+			Expect(FilterActiveMachineSets(testMachineSets)).To(HaveLen(1))
+		})
+	})
 })

--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -666,6 +666,7 @@ func calculateDeploymentStatus(allISs []*v1alpha1.MachineSet, newIS *v1alpha1.Ma
 
 // isScalingEvent checks whether the provided deployment has been updated with a scaling event
 // by looking at the desired-replicas annotation in the active machine sets of the deployment, and returns if there was scale-out or not.
+// However, when there are no active machine sets, but the replica count in the machine deployment's spec > 0, it is recognized as a scale-out event.
 //
 // rsList should come from getReplicaSetsForDeployment(d).
 // machineMap should come from getmachineMapForDeployment(d, rsList).

--- a/pkg/controller/deployment_sync.go
+++ b/pkg/controller/deployment_sync.go
@@ -674,8 +674,16 @@ func (dc *controller) isScalingEvent(ctx context.Context, d *v1alpha1.MachineDep
 	if err != nil {
 		return false, err
 	}
+	if newIS == nil {
+		return false, nil
+	}
 	allISs := append(oldISs, newIS)
-	for _, is := range FilterActiveMachineSets(allISs) {
+	activeMachineSets := FilterActiveMachineSets(allISs)
+	//if this is a scale from zero scenario, return true
+	if len(activeMachineSets) == 0 && d.Spec.Replicas > 0 {
+		return true, nil
+	}
+	for _, is := range activeMachineSets {
 		desired, ok := GetDesiredReplicasAnnotation(is)
 		if !ok {
 			continue

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -40,7 +40,7 @@ func (c *Cluster) CreateMachine(namespace string) error {
 }
 
 // CreateMachineDeployment creates a test-machine-deployment with 3 replicas and returns error if it occurs
-func (c *Cluster) CreateMachineDeployment(namespace string) error {
+func (c *Cluster) CreateMachineDeployment(namespace string, replicas int32) error {
 	labels := map[string]string{"test-label": "test-label"}
 	_, err := c.McmClient.
 		MachineV1alpha1().
@@ -53,7 +53,7 @@ func (c *Cluster) CreateMachineDeployment(namespace string) error {
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.MachineDeploymentSpec{
-					Replicas:        3,
+					Replicas:        replicas,
 					MinReadySeconds: 500,
 					Strategy: v1alpha1.MachineDeploymentStrategy{
 						Type: v1alpha1.RollingUpdateMachineDeploymentStrategyType,


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR adds a check to distinguish between a rolling update and a scale-from-zero scenario. Additionally, it also updates the integration tests to verify MCM's behaviour for the scenario.

**Which issue(s) this PR fixes**:
Fixes #952 

**Special notes for your reviewer**:
Integration tests with mcm-provider-gcp passed successfully.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
MCM recognizes scaling-up of `machineDeployment` from 0 to more replicas as a scaling event rather than a rolling update.
```
