### PR TITLE
Change integration test to add `gardener-node-agent` `secret` name to `machine`s and `MCD`s.

### DIFF
--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -95,6 +95,9 @@ var (
 	// if true, control cluster is a seed
 	// only set this variable if operating in gardener context
 	isControlSeed = os.Getenv("IS_CONTROL_CLUSTER_SEED")
+
+	//values for gardener-node-agent-secret-name
+	gnaSecretNameLabelValue = os.Getenv("GNA_SECRET_NAME")
 )
 
 // ProviderSpecPatch struct holds tags for provider, which we want to patch the  machineclass with
@@ -870,7 +873,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Probe nodes currently available in target cluster
 				initialNodes = c.TargetCluster.GetNumberOfNodes()
 				ginkgo.By("Checking for errors")
-				gomega.Expect(c.ControlCluster.CreateMachine(controlClusterNamespace)).To(gomega.BeNil())
+				gomega.Expect(c.ControlCluster.CreateMachine(controlClusterNamespace, gnaSecretNameLabelValue)).To(gomega.BeNil())
 
 				ginkgo.By("Waiting until number of ready nodes is 1 more than initial nodes")
 				gomega.Eventually(
@@ -961,7 +964,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				initialNodes = c.TargetCluster.GetNumberOfNodes()
 
 				ginkgo.By("Checking for errors")
-				gomega.Expect(c.ControlCluster.CreateMachineDeployment(controlClusterNamespace, 0)).To(gomega.BeNil())
+				gomega.Expect(c.ControlCluster.CreateMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 0)).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for Machine Set to be created")
 				gomega.Eventually(func() int { return c.getNumberOfMachineSets(ctx, controlClusterNamespace) }, c.timeout, c.pollingInterval).Should(gomega.BeNumerically("==", 1))

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -15,8 +15,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
+
 // CreateMachine creates a test-machine using machineclass "test-mc"
-func (c *Cluster) CreateMachine(namespace string) error {
+func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
 	_, err := c.McmClient.
 		MachineV1alpha1().
 		Machines(namespace).
@@ -32,6 +34,13 @@ func (c *Cluster) CreateMachine(namespace string) error {
 						Kind: "MachineClass",
 						Name: "test-mc-v1",
 					},
+					NodeTemplateSpec: v1alpha1.NodeTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								gnaSecretNameLabelKey: gnaSecretName,
+							},
+						},
+					},
 				},
 			},
 			metav1.CreateOptions{},
@@ -40,7 +49,7 @@ func (c *Cluster) CreateMachine(namespace string) error {
 }
 
 // CreateMachineDeployment creates a test-machine-deployment with 3 replicas and returns error if it occurs
-func (c *Cluster) CreateMachineDeployment(namespace string, replicas int32) error {
+func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string, replicas int32) error {
 	labels := map[string]string{"test-label": "test-label"}
 	_, err := c.McmClient.
 		MachineV1alpha1().
@@ -73,6 +82,13 @@ func (c *Cluster) CreateMachineDeployment(namespace string, replicas int32) erro
 							Class: v1alpha1.ClassSpec{
 								Kind: "MachineClass",
 								Name: "test-mc-v1",
+							},
+							NodeTemplateSpec: v1alpha1.NodeTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{
+									Labels: map[string]string{
+										gnaSecretNameLabelKey: gnaSecretName,
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the IT framework to add the `gardener-node-agent` `secret` name to the deployed machine object

**Which issue(s) this PR fixes**:
Fixes partially #960

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update IT framework to add gardener-node-agent secret to deployed machines
```
