### PR TITLE
Fix Race conditions in Targeted Deletion of machines by CA

### DIFF
--- a/pkg/util/annotations/annotations.go
+++ b/pkg/util/annotations/annotations.go
@@ -6,7 +6,10 @@
 package annotations
 
 import (
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	v1 "k8s.io/api/core/v1"
+	"strings"
 )
 
 // AddOrUpdateAnnotation tries to add an annotation. Returns a new copy of updated Node and true if something was updated
@@ -67,4 +70,17 @@ func DeleteAnnotation(nodeAnnotations map[string]string, annotations map[string]
 		newAnnotations[key] = value
 	}
 	return newAnnotations, deleted
+}
+
+// GetMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
+func GetMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
+	if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
+		return nil
+	}
+	return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
+}
+
+// CreateMachinesTriggeredForDeletionAnnotValue constructs the annotation value for machineutils.TriggerDeletionByMCM from the given machine names.
+func CreateMachinesTriggeredForDeletionAnnotValue(machineNames []string) string {
+	return strings.Join(machineNames, ",")
 }

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -6,6 +6,7 @@
 package machineutils
 
 import (
+	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -49,6 +50,8 @@ const (
 	NotManagedByMCM = "node.machine.sapcloud.io/not-managed-by-mcm"
 
 	// TriggerDeletionByMCM annotation on the node would trigger the deletion of the corresponding machine object in the control cluster
+	// This annotation can also be set on the MachineDeployment and contains the machine names for which deletion should be triggered.
+	// This feature is leveraged by the CA-MCM cloud provider.
 	TriggerDeletionByMCM = "node.machine.sapcloud.io/trigger-deletion-by-mcm"
 
 	// NodeUnhealthy is a node termination reason for failed machines
@@ -86,3 +89,11 @@ const (
 // EssentialTaints are taints on node object which if added/removed, require an immediate reconcile by machine controller
 // TODO: update this when taints for ALT updation and PostCreate operations is introduced.
 var EssentialTaints = []string{TaintNodeCriticalComponentsNotReady}
+
+// IsMachineFailedOrTerminating returns true if machine is Failed or already being Terminated.
+func IsMachineFailedOrTerminating(machine *v1alpha1.Machine) bool {
+	if !machine.GetDeletionTimestamp().IsZero() || machine.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the issues noticed in live issues 6120 and 6101. 

The CA will now set the  `TriggerDeletionByMCM = "node.machine.sapcloud.io/trigger-deletion-by-mcm"`  on the `MachineDeployment` whose value denotes the machines CA wants to remove. The CA atomically updates the replica count and this annotation as one single step. Race conditions are avoided when CA scaledowns are occurring in parallel. The MCM is now updated to check this `TriggerDeletionByMCM` annotation on the `MachineDeployment`. 

The CA no longer directly sets the `MachinePriority=1` annotation on the `Machine` objects. This is now done by the MCM controller when reconciling the updated `MachineDeployment`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/autoscaler/issues/342

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix that mitigates data-races in concurrent CA scale-downs.
```


