### PR TITLE
Add a `nil` check before trying to adding mc annotation

### DIFF
--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -636,6 +636,9 @@ func (dc *controller) setMachinePriorityAnnotationAndUpdateTriggeredForDeletion(
 			continue
 		}
 		mcAdjust := mc.DeepCopy()
+		if mcAdjust.Annotations == nil {
+			mcAdjust.Annotations = make(map[string]string)
+		}
 		mcAdjust.Annotations[machineutils.MachinePriority] = "1"
 		_, err = dc.controlMachineClient.Machines(mcAdjust.Namespace).Update(ctx, mcAdjust, metav1.UpdateOptions{})
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug where a `nil` check was not performed before adding an annotation to a machine. 
Machines are not always guaranteed to have annotations, hence a `nil` check is required here

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
