### PR TITLE
[rel-v0.56] Add a nil check before trying to adding mc annotation (#966)

### DIFF
--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -636,6 +636,9 @@ func (dc *controller) setMachinePriorityAnnotationAndUpdateTriggeredForDeletion(
 			continue
 		}
 		mcAdjust := mc.DeepCopy()
+		if mcAdjust.Annotations == nil {
+			mcAdjust.Annotations = make(map[string]string)
+		}
 		mcAdjust.Annotations[machineutils.MachinePriority] = "1"
 		_, err = dc.controlMachineClient.Machines(mcAdjust.Namespace).Update(ctx, mcAdjust, metav1.UpdateOptions{})
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry picks the following PR: https://github.com/gardener/machine-controller-manager/pull/966

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug was fixed where MCM panics when trying to add an annotation to a nil map
```
