### PR TITLE
Trigger removal of CA tainted machine without waiting for replica change

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -786,22 +786,6 @@ func (s ActiveMachines) Less(i, j int) bool {
 	return false
 }
 
-// IsMachineActive checks if machine was active
-func IsMachineActive(p *v1alpha1.Machine) bool {
-	if p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
-		return false
-	} else if p.Status.CurrentStatus.Phase == v1alpha1.MachineTerminating {
-		return false
-	}
-
-	return true
-}
-
-// IsMachineFailed checks if machine has failed
-func IsMachineFailed(p *v1alpha1.Machine) bool {
-	return p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed
-}
-
 // MachineKey is the function used to get the machine name from machine object
 // ToCheck : as machine-namespace does not matter
 func MachineKey(machine *v1alpha1.Machine) string {

--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -25,6 +25,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"reflect"
 	"sort"
 	"strconv"
@@ -921,7 +922,7 @@ func WaitForMachinesHashPopulated(c v1alpha1listers.MachineSetLister, desiredGen
 func LabelMachinesWithHash(ctx context.Context, machineList *v1alpha1.MachineList, c v1alpha1client.MachineV1alpha1Interface, machineLister v1alpha1listers.MachineLister, namespace, name, hash string) error {
 	for _, machine := range machineList.Items {
 		// Ignore inactive Machines.
-		if !IsMachineActive(&machine) {
+		if !machineutils.IsMachineActive(&machine) {
 			continue
 		}
 		// Only label the machine that doesn't already have the new hash

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -863,8 +863,6 @@ var _ = Describe("machineset", func() {
 			waitForCacheSync(stop, c)
 
 			_, err = c.controlMachineClient.Machines(testNamespace).Get(context.Background(), staleMachine.Name, metav1.GetOptions{})
-			// MachinePriority=1 staleMachine is no longer found
-			//Expect(staleMachine).Should(BeNil())
 			Expect(err).ShouldNot(BeNil())
 			Expect(err).To(Satisfy(func(e error) bool {
 				return k8sError.IsNotFound(e)

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -861,7 +861,7 @@ var _ = Describe("machineset", func() {
 			err := c.manageReplicas(context.TODO(), beforeMachines, testMachineSet)
 			waitForCacheSync(stop, c)
 
-			staleMachine, err = c.controlMachineClient.Machines(testNamespace).Get(context.Background(), staleMachine.Name, metav1.GetOptions{})
+			_, err = c.controlMachineClient.Machines(testNamespace).Get(context.Background(), staleMachine.Name, metav1.GetOptions{})
 			// MachinePriority=1 staleMachine is no longer found
 			//Expect(staleMachine).Should(BeNil())
 			Expect(err).ShouldNot(BeNil())

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -859,7 +859,7 @@ var _ = Describe("machineset", func() {
 
 			beforeMachines := []*machinev1.Machine{staleMachine, testActiveMachine2, testActiveMachine3}
 			err := c.manageReplicas(context.TODO(), beforeMachines, testMachineSet)
-			Expect(err).ShouldNot(BeNil())
+			Expect(err).Should(BeNil())
 			waitForCacheSync(stop, c)
 
 			_, err = c.controlMachineClient.Machines(testNamespace).Get(context.Background(), staleMachine.Name, metav1.GetOptions{})

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -7,6 +7,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"sync"
 	"time"
 
@@ -608,6 +609,7 @@ var _ = Describe("machineset", func() {
 					Labels: map[string]string{
 						"test-label": "test-label",
 					},
+					Annotations: map[string]string{},
 				},
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Machine",
@@ -636,6 +638,46 @@ var _ = Describe("machineset", func() {
 				Status: machinev1.MachineStatus{
 					CurrentStatus: machinev1.CurrentStatus{
 						Phase: MachineRunning,
+					},
+				},
+			}
+
+			testActiveMachine3 = &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-3",
+					Namespace: testNamespace,
+					UID:       "12345610",
+					Labels: map[string]string{
+						"test-label": "test-label",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Machine",
+					APIVersion: "machine.sapcloud.io/v1alpha1",
+				},
+				Status: machinev1.MachineStatus{
+					CurrentStatus: machinev1.CurrentStatus{
+						Phase: MachineRunning,
+					},
+				},
+			}
+
+			testActiveMachine4 = &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-4",
+					Namespace: testNamespace,
+					UID:       "12345611",
+					Labels: map[string]string{
+						"test-label": "test-label",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Machine",
+					APIVersion: "machine.sapcloud.io/v1alpha1",
+				},
+				Status: machinev1.MachineStatus{
+					CurrentStatus: machinev1.CurrentStatus{
+						Phase: MachineFailed,
 					},
 				},
 			}
@@ -716,26 +758,6 @@ var _ = Describe("machineset", func() {
 			stop := make(chan struct{})
 			defer close(stop)
 
-			testActiveMachine3 = &machinev1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-3",
-					Namespace: testNamespace,
-					UID:       "12345610",
-					Labels: map[string]string{
-						"test-label": "test-label",
-					},
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Machine",
-					APIVersion: "machine.sapcloud.io/v1alpha1",
-				},
-				Status: machinev1.MachineStatus{
-					CurrentStatus: machinev1.CurrentStatus{
-						Phase: MachineRunning,
-					},
-				},
-			}
-
 			objects := []runtime.Object{}
 			objects = append(objects, testMachineSet, testActiveMachine1, testActiveMachine2, testActiveMachine3)
 			c, trackers := createController(stop, testNamespace, objects, nil, nil)
@@ -779,26 +801,6 @@ var _ = Describe("machineset", func() {
 				},
 			}
 
-			testActiveMachine4 = &machinev1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-4",
-					Namespace: testNamespace,
-					UID:       "12345611",
-					Labels: map[string]string{
-						"test-label": "test-label",
-					},
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Machine",
-					APIVersion: "machine.sapcloud.io/v1alpha1",
-				},
-				Status: machinev1.MachineStatus{
-					CurrentStatus: machinev1.CurrentStatus{
-						Phase: MachineFailed,
-					},
-				},
-			}
-
 			objects := []runtime.Object{}
 			objects = append(objects, testMachineSet, testActiveMachine1, testActiveMachine2, testActiveMachine3, testActiveMachine4)
 			c, trackers := createController(stop, testNamespace, objects, nil, nil)
@@ -822,46 +824,6 @@ var _ = Describe("machineset", func() {
 			stop := make(chan struct{})
 			defer close(stop)
 
-			testActiveMachine3 = &machinev1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-3",
-					Namespace: testNamespace,
-					UID:       "12345610",
-					Labels: map[string]string{
-						"test-label": "test-label",
-					},
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Machine",
-					APIVersion: "machine.sapcloud.io/v1alpha1",
-				},
-				Status: machinev1.MachineStatus{
-					CurrentStatus: machinev1.CurrentStatus{
-						Phase: MachineRunning,
-					},
-				},
-			}
-
-			testActiveMachine4 = &machinev1.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "machine-4",
-					Namespace: testNamespace,
-					UID:       "12345611",
-					Labels: map[string]string{
-						"test-label": "test-label",
-					},
-				},
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "Machine",
-					APIVersion: "machine.sapcloud.io/v1alpha1",
-				},
-				Status: machinev1.MachineStatus{
-					CurrentStatus: machinev1.CurrentStatus{
-						Phase: MachineRunning,
-					},
-				},
-			}
-
 			objects := []runtime.Object{}
 			objects = append(objects, testMachineSet, testActiveMachine1, testActiveMachine2, testActiveMachine3, testActiveMachine4)
 			c, trackers := createController(stop, testNamespace, objects, nil, nil)
@@ -879,6 +841,39 @@ var _ = Describe("machineset", func() {
 			Expect(Err).Should(BeNil())
 		})
 
+		It("should delete MachinePriority=1 machines and spawn replacement machine", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+			objects := []runtime.Object{}
+
+			staleMachine := testActiveMachine1.DeepCopy()
+			staleMachine.Annotations[machineutils.MachinePriority] = "1"
+
+			objects = append(objects, testMachineSet, staleMachine, testActiveMachine2, testActiveMachine3)
+			c, trackers := createController(stop, testNamespace, objects, nil, nil)
+			defer trackers.Stop()
+			waitForCacheSync(stop, c)
+
+			machines, _ := c.controlMachineClient.Machines(testNamespace).List(context.TODO(), metav1.ListOptions{})
+			Expect(len(machines.Items)).To(Equal(int(testMachineSet.Spec.Replicas)))
+
+			beforeMachines := []*machinev1.Machine{staleMachine, testActiveMachine2, testActiveMachine3}
+			err := c.manageReplicas(context.TODO(), beforeMachines, testMachineSet)
+			waitForCacheSync(stop, c)
+
+			staleMachine, err = c.controlMachineClient.Machines(testNamespace).Get(context.Background(), staleMachine.Name, metav1.GetOptions{})
+			// MachinePriority=1 staleMachine is no longer found
+			//Expect(staleMachine).Should(BeNil())
+			Expect(err).ShouldNot(BeNil())
+			Expect(err).To(Satisfy(func(e error) bool {
+				return k8sError.IsNotFound(e)
+			}))
+			afterMachines, err := c.controlMachineClient.Machines(testNamespace).List(context.TODO(), metav1.ListOptions{})
+			// replica count is still maintained.
+			Expect(len(afterMachines.Items)).To(Equal(int(testMachineSet.Spec.Replicas)))
+			Expect(err).Should(BeNil())
+
+		})
 	})
 
 	// TODO: This method has dependency on generic-machineclass. Implement later.

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -859,6 +859,7 @@ var _ = Describe("machineset", func() {
 
 			beforeMachines := []*machinev1.Machine{staleMachine, testActiveMachine2, testActiveMachine3}
 			err := c.manageReplicas(context.TODO(), beforeMachines, testMachineSet)
+			Expect(err).ShouldNot(BeNil())
 			waitForCacheSync(stop, c)
 
 			_, err = c.controlMachineClient.Machines(testNamespace).Get(context.Background(), staleMachine.Name, metav1.GetOptions{})

--- a/pkg/controller/machineset_util.go
+++ b/pkg/controller/machineset_util.go
@@ -89,7 +89,7 @@ func (c *controller) syncMachinesNodeTemplates(ctx context.Context, machineList 
 
 	for _, machine := range machineList {
 		// Ignore inactive Machines.
-		if !IsMachineActive(machine) {
+		if !machineutils.IsMachineActive(machine) {
 			continue
 		}
 
@@ -155,7 +155,7 @@ func (c *controller) syncMachinesConfig(ctx context.Context, machineList []*v1al
 
 	for _, machine := range machineList {
 		// Ignore inactive Machines.
-		if !IsMachineActive(machine) {
+		if !machineutils.IsMachineActive(machine) {
 			continue
 		}
 

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -101,3 +101,23 @@ func IsMachineFailedOrTerminating(machine *v1alpha1.Machine) bool {
 	}
 	return false
 }
+
+// IsMachineActive checks if machine was active
+func IsMachineActive(p *v1alpha1.Machine) bool {
+	if p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
+		return false
+	} else if p.Status.CurrentStatus.Phase == v1alpha1.MachineTerminating {
+		return false
+	}
+	return true
+}
+
+// IsMachineFailed checks if machine has failed
+func IsMachineFailed(p *v1alpha1.Machine) bool {
+	return p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed
+}
+
+// IsMachineTriggeredForDeletion checks if machine was triggered for deletion
+func IsMachineTriggeredForDeletion(m *v1alpha1.Machine) bool {
+	return m.Annotations[MachinePriority] == "1" || m.Annotations[TriggerDeletionByMCM] == "true"
+}

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -104,12 +104,7 @@ func IsMachineFailedOrTerminating(machine *v1alpha1.Machine) bool {
 
 // IsMachineActive checks if machine was active
 func IsMachineActive(p *v1alpha1.Machine) bool {
-	if p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
-		return false
-	} else if p.Status.CurrentStatus.Phase == v1alpha1.MachineTerminating {
-		return false
-	}
-	return true
+	return p.Status.CurrentStatus.Phase != v1alpha1.MachineFailed && p.Status.CurrentStatus.Phase != v1alpha1.MachineTerminating
 }
 
 // IsMachineFailed checks if machine has failed

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -50,9 +50,9 @@ const (
 	// NotManagedByMCM annotation helps in identifying the nodes which are not handled by MCM
 	NotManagedByMCM = "node.machine.sapcloud.io/not-managed-by-mcm"
 
-	// TriggerDeletionByMCM annotation on the node would trigger the deletion of the corresponding machine object in the control cluster
+	// TriggerDeletionByMCM annotation on the node or machine would trigger the deletion of the corresponding node and machine object in the control cluster
 	// This annotation can also be set on the MachineDeployment and contains the machine names for which deletion should be triggered.
-	// This feature is leveraged by the CA-MCM cloud provider.
+	// The latter feature is leveraged by the CA-MCM cloud provider.
 	TriggerDeletionByMCM = "node.machine.sapcloud.io/trigger-deletion-by-mcm"
 
 	// NodeUnhealthy is a node termination reason for failed machines


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #971

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
CA tainted node is removed as soon as possible by MachineSet controller 
```
