### PR TITLE
[rel-0.57] Trigger removal of CA tainted machine without waiting for replica change

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -786,22 +786,6 @@ func (s ActiveMachines) Less(i, j int) bool {
 	return false
 }
 
-// IsMachineActive checks if machine was active
-func IsMachineActive(p *v1alpha1.Machine) bool {
-	if p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
-		return false
-	} else if p.Status.CurrentStatus.Phase == v1alpha1.MachineTerminating {
-		return false
-	}
-
-	return true
-}
-
-// IsMachineFailed checks if machine has failed
-func IsMachineFailed(p *v1alpha1.Machine) bool {
-	return p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed
-}
-
 // MachineKey is the function used to get the machine name from machine object
 // ToCheck : as machine-namespace does not matter
 func MachineKey(machine *v1alpha1.Machine) string {

--- a/pkg/controller/deployment_util.go
+++ b/pkg/controller/deployment_util.go
@@ -25,6 +25,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"reflect"
 	"sort"
 	"strconv"
@@ -921,7 +922,7 @@ func WaitForMachinesHashPopulated(c v1alpha1listers.MachineSetLister, desiredGen
 func LabelMachinesWithHash(ctx context.Context, machineList *v1alpha1.MachineList, c v1alpha1client.MachineV1alpha1Interface, machineLister v1alpha1listers.MachineLister, namespace, name, hash string) error {
 	for _, machine := range machineList.Items {
 		// Ignore inactive Machines.
-		if !IsMachineActive(&machine) {
+		if !machineutils.IsMachineActive(&machine) {
 			continue
 		}
 		// Only label the machine that doesn't already have the new hash

--- a/pkg/controller/machineset_util.go
+++ b/pkg/controller/machineset_util.go
@@ -89,7 +89,7 @@ func (c *controller) syncMachinesNodeTemplates(ctx context.Context, machineList 
 
 	for _, machine := range machineList {
 		// Ignore inactive Machines.
-		if !IsMachineActive(machine) {
+		if !machineutils.IsMachineActive(machine) {
 			continue
 		}
 
@@ -155,7 +155,7 @@ func (c *controller) syncMachinesConfig(ctx context.Context, machineList []*v1al
 
 	for _, machine := range machineList {
 		// Ignore inactive Machines.
-		if !IsMachineActive(machine) {
+		if !machineutils.IsMachineActive(machine) {
 			continue
 		}
 

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -50,9 +50,9 @@ const (
 	// NotManagedByMCM annotation helps in identifying the nodes which are not handled by MCM
 	NotManagedByMCM = "node.machine.sapcloud.io/not-managed-by-mcm"
 
-	// TriggerDeletionByMCM annotation on the node would trigger the deletion of the corresponding machine object in the control cluster
+	// TriggerDeletionByMCM annotation on the node or machine would trigger the deletion of the corresponding node and machine object in the control cluster
 	// This annotation can also be set on the MachineDeployment and contains the machine names for which deletion should be triggered.
-	// This feature is leveraged by the CA-MCM cloud provider.
+	// The latter feature is leveraged by the CA-MCM cloud provider.
 	TriggerDeletionByMCM = "node.machine.sapcloud.io/trigger-deletion-by-mcm"
 
 	// NodeUnhealthy is a node termination reason for failed machines
@@ -100,4 +100,19 @@ func IsMachineFailedOrTerminating(machine *v1alpha1.Machine) bool {
 		return true
 	}
 	return false
+}
+
+// IsMachineActive checks if machine was active
+func IsMachineActive(p *v1alpha1.Machine) bool {
+	return p.Status.CurrentStatus.Phase != v1alpha1.MachineFailed && p.Status.CurrentStatus.Phase != v1alpha1.MachineTerminating
+}
+
+// IsMachineFailed checks if machine has failed
+func IsMachineFailed(p *v1alpha1.Machine) bool {
+	return p.Status.CurrentStatus.Phase == v1alpha1.MachineFailed
+}
+
+// IsMachineTriggeredForDeletion checks if machine was triggered for deletion
+func IsMachineTriggeredForDeletion(m *v1alpha1.Machine) bool {
+	return m.Annotations[MachinePriority] == "1" || m.Annotations[TriggerDeletionByMCM] == "true"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry picks https://github.com/gardener/machine-controller-manager/pull/972

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator @elankath #972 
CA tainted node is removed as soon as possible by MachineSet controller 
```
