### PR TITLE
[GEP-31] Introduce Constants needed for Conditons and Status for InPlace update 

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -221,6 +221,15 @@ const (
 
 	// MachineCrashLoopBackOff means creation or deletion of the machine is failing. It means that machine object is present but there is no corresponding VM.
 	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
+
+	// MachineInPlaceUpdating means machine is being updated in-place
+	MachineInPlaceUpdating MachinePhase = "InPlaceUpdating"
+
+	// MachineInPlaceUpdateSuccessful means machine in-place update was successful
+	MachineInPlaceUpdateSuccessful MachinePhase = "InPlaceUpdateSuccessful"
+
+	// MachineInPlaceUpdateFailed means machine in-place update failed
+	MachineInPlaceUpdateFailed MachinePhase = "InPlaceUpdateFailed"
 )
 
 // MachineState is a label for the state of a machines at the current time.
@@ -249,6 +258,12 @@ const (
 	// MachineOperationUpdate indicates that the operation was an update
 	MachineOperationUpdate MachineOperationType = "Update"
 
+	// MachineOperationInPlaceUpdate indicates that the operation was an in-place update
+	MachineOperationInPlaceUpdate MachineOperationType = "InPlaceUpdate"
+
+	// MachineOperationDrainNode indicates that the operation was a drain node
+	MachineOperationDrainNode MachineOperationType = "DrainNode"
+
 	// MachineOperationHealthCheck indicates that the operation was a create
 	MachineOperationHealthCheck MachineOperationType = "HealthCheck"
 
@@ -269,6 +284,29 @@ const (
 	ConditionTrue    ConditionStatus = "True"
 	ConditionFalse   ConditionStatus = "False"
 	ConditionUnknown ConditionStatus = "Unknown"
+)
+
+const (
+	// NodeInPlaceUpdate is a node condition type for in-place update
+	NodeInPlaceUpdate corev1.NodeConditionType = "InPlaceUpdate"
+
+	// UpdateCandidate is a constant for reason in condition that indicates node is candidate for update
+	UpdateCandidate string = "UpdateCandidate"
+
+	// SelectedForUpdate is a constant for reason in condition that indicates node is selected for update
+	SelectedForUpdate string = "SelectedForUpdate"
+
+	// DrainSuccessful is a constant for reason in condition that indicates node drain is successful
+	DrainSuccessful string = "DrainSuccessful"
+
+	// ReadyForUpdate is a constant for reason in condition that indicates node is ready for update
+	ReadyForUpdate string = "ReadyForUpdate"
+
+	// UpdateSuccessful is a constant for reason in condition that indicates update succeeded
+	UpdateSuccessful string = "UpdateSuccessful"
+
+	// UpdateFailed is a constant for reason in condition that indicates update failed
+	UpdateFailed string = "UpdateFailed"
 )
 
 /********************** MachineSet APIs ***************/

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -290,8 +290,8 @@ const (
 	// NodeInPlaceUpdate is a node condition type for in-place update
 	NodeInPlaceUpdate corev1.NodeConditionType = "InPlaceUpdate"
 
-	// UpdateCandidate is a constant for reason in condition that indicates node is candidate for update
-	UpdateCandidate string = "UpdateCandidate"
+	// CandidateForUpdate is a constant for reason in condition that indicates node is candidate for update
+	CandidateForUpdate string = "CandidateForUpdate"
 
 	// SelectedForUpdate is a constant for reason in condition that indicates node is selected for update
 	SelectedForUpdate string = "SelectedForUpdate"

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -220,17 +220,17 @@ const (
 	// NodeInPlaceUpdate is a node condition type for in-place update
 	NodeInPlaceUpdate corev1.NodeConditionType = "InPlaceUpdate"
 
-	// UpdateCandidate is a constant for reason in condition that indicates node is candidate for update
-	UpdateCandidate string = "UpdateCandidate"
+	// CandidateForUpdate is a constant for reason in condition that indicates node is candidate for update
+	CandidateForUpdate string = "CandidateForUpdate"
 
 	// SelectedForUpdate is a constant for reason in condition that indicates node is selected for update
 	SelectedForUpdate string = "SelectedForUpdate"
 
-	// DrainSuccessful is a constant for reason in condition that indicates node drain is successful
-	DrainSuccessful string = "DrainSuccessful"
-
 	// ReadyForUpdate is a constant for reason in condition that indicates node is ready for update
 	ReadyForUpdate string = "ReadyForUpdate"
+
+	// DrainSuccessful is a constant for reason in condition that indicates node drain is successful
+	DrainSuccessful string = "DrainSuccessful"
 
 	// UpdateSuccessful is a constant for reason in condition that indicates update succeeded
 	UpdateSuccessful string = "UpdateSuccessful"

--- a/pkg/apis/machine/v1alpha1/machine_types.go
+++ b/pkg/apis/machine/v1alpha1/machine_types.go
@@ -151,6 +151,15 @@ const (
 
 	// MachineCrashLoopBackOff means machine creation is failing. It means that machine object is present but there is no corresponding VM.
 	MachineCrashLoopBackOff MachinePhase = "CrashLoopBackOff"
+
+	// MachineInPlaceUpdating means machine is being updated in-place
+	MachineInPlaceUpdating MachinePhase = "InPlaceUpdating"
+
+	// MachineInPlaceUpdateSuccessful means machine in-place update was successful
+	MachineInPlaceUpdateSuccessful MachinePhase = "InPlaceUpdateSuccessful"
+
+	// MachineInPlaceUpdateFailed means machine in-place update failed
+	MachineInPlaceUpdateFailed MachinePhase = "InPlaceUpdateFailed"
 )
 
 // MachineState is a current state of the operation.
@@ -179,6 +188,12 @@ const (
 	// MachineOperationUpdate indicates that the operation was an update
 	MachineOperationUpdate MachineOperationType = "Update"
 
+	// MachineOperationInPlaceUpdate indicates that the operation was an in-place update
+	MachineOperationInPlaceUpdate MachineOperationType = "InPlaceUpdate"
+
+	// MachineOperationDrainNode indicates that the operation was a drain node
+	MachineOperationDrainNode MachineOperationType = "DrainNode"
+
 	// MachineOperationHealthCheck indicates that the operation was a health check of node object
 	MachineOperationHealthCheck MachineOperationType = "HealthCheck"
 
@@ -199,6 +214,29 @@ const (
 	ConditionTrue    ConditionStatus = "True"
 	ConditionFalse   ConditionStatus = "False"
 	ConditionUnknown ConditionStatus = "Unknown"
+)
+
+const (
+	// NodeInPlaceUpdate is a node condition type for in-place update
+	NodeInPlaceUpdate corev1.NodeConditionType = "InPlaceUpdate"
+
+	// UpdateCandidate is a constant for reason in condition that indicates node is candidate for update
+	UpdateCandidate string = "UpdateCandidate"
+
+	// SelectedForUpdate is a constant for reason in condition that indicates node is selected for update
+	SelectedForUpdate string = "SelectedForUpdate"
+
+	// DrainSuccessful is a constant for reason in condition that indicates node drain is successful
+	DrainSuccessful string = "DrainSuccessful"
+
+	// ReadyForUpdate is a constant for reason in condition that indicates node is ready for update
+	ReadyForUpdate string = "ReadyForUpdate"
+
+	// UpdateSuccessful is a constant for reason in condition that indicates update succeeded
+	UpdateSuccessful string = "UpdateSuccessful"
+
+	// UpdateFailed is a constant for reason in condition that indicates update failed
+	UpdateFailed string = "UpdateFailed"
 )
 
 // CurrentStatus contains information about the current status of Machine.

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -23,6 +23,9 @@ const (
 	// InitiateDrain specifies next step as initiate node drain
 	InitiateDrain = "Initiate node drain"
 
+	// NodeReadyForUpdate specifies next step as node ready for update.
+	NodeReadyForUpdate = "Node drain successful. Node is ready for update"
+
 	// DelVolumesAttachments specifies next step as deleting volume attachments
 	DelVolumesAttachments = "Delete Volume Attachments"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces constants for Conditions and Status for InPlace update scenarios.
 
**Which issue(s) this PR fixes**:
Part of #944 
Part of https://github.com/gardener/gardener/issues/10219

**Special notes for your reviewer**:
This change was part of https://github.com/gardener/machine-controller-manager/pull/973. However, these constants are urgently required in the gardener/gardener PRs. Hence, we request an MCM patch release with these changes.

/invite @aaronfern @elankath @unmarshall

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
