### PR TITLE
Minor fixes

### DIFF
--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -615,8 +615,8 @@ const (
 	// or deleted.
 	MachineDeploymentReplicaFailure MachineDeploymentConditionType = "ReplicaFailure"
 
-	// MachineDeploymentFrozen is added in a MachineDeployment when one of its machines fails to be created
-	// or deleted.
+	// MachineDeploymentFrozen is added in a MachineDeployment when one of its
+	// machineSet has either the "freeze" label or the "Frozen" condition on it.
 	MachineDeploymentFrozen MachineDeploymentConditionType = "Frozen"
 )
 

--- a/pkg/apis/machine/v1alpha1/machinedeployment_types.go
+++ b/pkg/apis/machine/v1alpha1/machinedeployment_types.go
@@ -249,8 +249,8 @@ const (
 	// or deleted.
 	MachineDeploymentReplicaFailure MachineDeploymentConditionType = "ReplicaFailure"
 
-	// MachineDeploymentFrozen is added in a MachineDeployment when one of its machines fails to be created
-	// or deleted.
+	// MachineDeploymentFrozen is added in a MachineDeployment when one of its
+	// machineSet has either the "freeze" label or the "Frozen" condition on it.
 	MachineDeploymentFrozen MachineDeploymentConditionType = "Frozen"
 )
 

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -849,7 +849,7 @@ var _ = Describe("machine", func() {
 						},
 					}, nil, nil, nil, true, metav1.Now()),
 					err:   status.Error(codes.ResourceExhausted, "Provider does not have capacity to create VM"),
-					retry: machineutils.MediumRetry,
+					retry: machineutils.LongRetry,
 				},
 			}),
 			Entry("Machine creation fails with Failure due to timeout", &data{

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -508,6 +508,9 @@ func (c *controller) machineCreateErrorHandler(ctx context.Context, machine *v1a
 	machineErr, ok := status.FromError(err)
 	if ok {
 		switch machineErr.Code() {
+		case codes.ResourceExhausted:
+			retryRequired = machineutils.LongRetry
+			lastKnownState = machine.Status.LastKnownState
 		case codes.Unknown, codes.DeadlineExceeded, codes.Aborted, codes.Unavailable:
 			retryRequired = machineutils.ShortRetry
 			lastKnownState = machine.Status.LastKnownState


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #977 and #961

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Resource exhaustion on machine creation results in a longer retry period
```
