### PR TITLE
Fix version logging at binary startup.

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -28,11 +28,22 @@ else
   export BINARY_PATH="$(${READLINK_BIN} -f "${BINARY_PATH}")/bin"
 fi
 
-cd "${SOURCE_PATH}"
+VCS="github.com"
+ORGANIZATION="gardener"
+PROJECT="machine-controller-manager"
+REPOSITORY=${VCS}/${ORGANIZATION}/${PROJECT}
+GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD || echo "GitNotFound")}"
+
+cd "${SOURCE_PATH}" 
 
 ###############################################################################
+
+VERSION_FILE="$(${READLINK_BIN}  -f "${SOURCE_PATH}/VERSION")"
+VERSION="${VERSION:-"$(cat "${VERSION_FILE}")"}"
+GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD || echo "GitNotFound")}"
 
 CGO_ENABLED=0 GO111MODULE=on go build \
   -v \
   -o "${BINARY_PATH}/machine-controller-manager" \
+	-ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
   cmd/machine-controller-manager/controller_manager.go

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,11 @@
 TOOLS_DIR := hack/tools
 include hack/tools.mk
 
+REPOSITORY         := $(shell go list -m)
 IMAGE_REPOSITORY   := europe-docker.pkg.dev/gardener-project/public/gardener/machine-controller-manager
-IMAGE_TAG          := $(shell cat VERSION)
+VERSION            := $(shell cat VERSION)
+IMAGE_TAG          := $(VERSION)
+GIT_SHA            := $(shell git rev-parse --short HEAD || echo "GitNotFound")
 COVERPROFILE       := test/output/coverprofile.out
 
 LEADER_ELECT 	   ?= "true" # If LEADER_ELECT is not set in the environment, use the default value "true"
@@ -89,6 +92,7 @@ non-gardener-restore:
 .PHONY: start
 start:
 	@GO111MODULE=on go run \
+			-ldflags "-w -X ${REPOSITORY}/pkg/version.Version=${VERSION} -X ${REPOSITORY}/pkg/version.GitSHA=${GIT_SHA}" \
 			cmd/machine-controller-manager/controller_manager.go \
 			--control-kubeconfig=${CONTROL_KUBECONFIG} \
 			--target-kubeconfig=${TARGET_KUBECONFIG} \

--- a/cmd/machine-controller-manager/app/controllermanager.go
+++ b/cmd/machine-controller-manager/app/controllermanager.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gardener/machine-controller-manager/cmd/machine-controller-manager/app/options"
 	"github.com/gardener/machine-controller-manager/pkg/handlers"
 	"github.com/gardener/machine-controller-manager/pkg/util/configz"
+	"github.com/gardener/machine-controller-manager/pkg/version"
 	prometheus "github.com/prometheus/client_golang/prometheus/promhttp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -51,7 +52,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"
@@ -75,7 +75,7 @@ var (
 // Run runs the MCMServer.  This should never exit.
 func Run(s *options.MCMServer) error {
 	// To help debugging, immediately log version
-	klog.V(3).Infof("Version: %+v", version.Get())
+	version.LogVersionInfoWithLevel(3)
 	if err := s.Validate(); err != nil {
 		return err
 	}

--- a/pkg/util/provider/app/app.go
+++ b/pkg/util/provider/app/app.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/configz"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/app/options"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	"github.com/gardener/machine-controller-manager/pkg/version"
 	prometheus "github.com/prometheus/client_golang/prometheus/promhttp"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -53,7 +54,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/pkg/version"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/leaderelection"
@@ -73,7 +73,7 @@ var (
 // Run runs the MCServer. This should never exit.
 func Run(s *options.MCServer, driver driver.Driver) error {
 	// To help debugging, immediately log version
-	klog.V(4).Infof("Version: %+v", version.Get())
+	version.LogVersionInfoWithLevel(4)
 	if err := s.Validate(); err != nil {
 		return err
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,9 +12,9 @@ import (
 var (
 	// These variables typically come from -ldflags settings in build
 
-	// Version shows the etcd-backup-restore binary version.
+	// Version shows the machine-controller-manager binary version.
 	Version string
-	// GitSHA shows the etcd-backup-restore binary code commit SHA on git.
+	// GitSHA shows the machine-controller-manager binary code commit SHA on git.
 	GitSHA string
 )
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"k8s.io/klog/v2"
+	"runtime"
+)
+
+var (
+	// These variables typically come from -ldflags settings in build
+
+	// Version shows the etcd-backup-restore binary version.
+	Version string
+	// GitSHA shows the etcd-backup-restore binary code commit SHA on git.
+	GitSHA string
+)
+
+// LogVersionInfoWithLevel logs machine-controller-manager version and build information.
+func LogVersionInfoWithLevel(debugLevel int32) {
+	level := klog.Level(debugLevel)
+	klog.V(level).Infof("machine-controller-manager Version: %s\n", Version)
+	klog.V(level).Infof("Git SHA: %s\n", GitSHA)
+	klog.V(level).Infof("Go Version: %s\n", runtime.Version())
+	klog.V(level).Infof("Go OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Version information is not being logged at startup currently.

https://github.com/gardener/machine-controller-manager/blob/57dad3e97b4b0d18e576c8f3ec5ae3d17a062782/cmd/machine-controller-manager/app/controllermanager.go#L78

does not really print anything meaningful. Currently it prints the following:

```
I0416 03:47:56.984925       1 controllermanager.go:78] Version: v0.0.0-master+$Format:%H$
```

which is the template string present in [client-go@v0.31.0/pkg/version/base.go](https://github.com/kubernetes/client-go/blob/02a19c375c491042890be396d94a26a69da89563/pkg/version/base.go#L59). As described in the linked file a few lines above:

```
// If you are looking at these fields in the git tree, they look
// strange. They are modified on the fly by the build process. The
// in-tree values are dummy values used for "git archive", which also
// works for GitHub tar downloads.
//
// When releasing a new Kubernetes version, this file is updated by
// build/mark_new_version.sh to reflect the new version, and then a
// git annotated tag (using format vX.Y where X == Major version and Y
// == Minor version) is created to point to the commit that updates
// pkg/version/base.go
```

where the modification is not being done by the build process in this repository, and is unnecessarily complicated for what it does.

I've introduced a simple `pkg/version/version.go` where exported variables are written during linking through `ldflags` like other projects in @gardener.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
machine-controller-manager version, and build information are printed at startup.
```
