### PR TITLE
Use debian 12 distroless image as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN .ci/build
 
 #############      base                                     #############
-FROM gcr.io/distroless/static-debian11:nonroot as base
+FROM gcr.io/distroless/static-debian12:nonroot as base
 WORKDIR /
 
 #############      machine-controller-manager               #############


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR upgrades base image used from `gcr.io/distroless/static-debian11:nonroot` to `gcr.io/distroless/static-debian12:nonroot`

**Which issue(s) this PR fixes**:
Fixes partially #982 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
machine-controller-manager base image is updated to `gcr.io/distroless/static-debian12:nonroot`.
```
