### PR TITLE
remove unneeded symbol in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [here](docs/documents/apis.md) for CRD API Documentation
             <td>There is a Safety Controller responsible for handling the unidentified or unknown behaviours from the cloud providers. Safety Controller:
                 <ul>
                     <li>
-                        freezes the MachineDeployment controller and MachineSet controller if the number of <code>Machine</code> objects goes beyond a certain threshold on top of <code>Spec.replicas</code>. It can be configured by the flag <code>--safety-up</code> or <code>--safety-down</code> and also <code>--machine-safety-overshooting-period`</code>.
+                        freezes the MachineDeployment controller and MachineSet controller if the number of <code>Machine</code> objects goes beyond a certain threshold on top of <code>Spec.replicas</code>. It can be configured by the flag <code>--safety-up</code> or <code>--safety-down</code> and also <code>--machine-safety-overshooting-period</code>.
                     </li>
                     <li>
                         freezes the functionality of the MCM if either of the <code>target-apiserver</code> or the <code>control-apiserver</code> is not reachable.


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes a unneeded symbol in the ReadMe.md

**Which issue(s) this PR fixes**:
Fixes #
no fixes, can actually be appended to some other PR.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
"NONE"
```
