### PR TITLE
Add `node_name` label to the `mcm_machine_info` metric

### DIFF
--- a/pkg/util/provider/machinecontroller/metrics.go
+++ b/pkg/util/provider/machinecontroller/metrics.go
@@ -120,5 +120,6 @@ func updateMachineInfoMetric(mMeta metav1.ObjectMeta, mSpec v1alpha1.MachineSpec
 		"spec_provider_id":     mSpec.ProviderID,
 		"spec_class_api_group": mSpec.Class.APIGroup,
 		"spec_class_kind":      mSpec.Class.Kind,
-		"spec_class_name":      mSpec.Class.Name}).Set(float64(1))
+		"spec_class_name":      mSpec.Class.Name,
+		"node_name":            mMeta.Labels[v1alpha1.NodeLabelKey]}).Set(float64(1))
 }

--- a/pkg/util/provider/metrics/metrics.go
+++ b/pkg/util/provider/metrics/metrics.go
@@ -38,7 +38,7 @@ var (
 		Name:      "info",
 		Help:      "Information of the Machines currently managed by the mcm.",
 	}, []string{"name", "namespace", "createdAt",
-		"spec_provider_id", "spec_class_api_group", "spec_class_kind", "spec_class_name"})
+		"spec_provider_id", "spec_class_api_group", "spec_class_kind", "spec_class_name", "node_name"})
 
 	// MachineStatusCondition Information of the mcm managed Machines' status conditions
 	MachineStatusCondition = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new label `node_name` to the `mcm_machine_info` metric

**Which issue(s) this PR fixes**:
Fixes #992

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
add new label `node_name` to the `mcm_machine_info` metric
```
