### PR TITLE
Fix incorrect machineinformer callback

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -120,7 +120,7 @@ func NewController(
 	// MachineDeployment Controller Informers
 	_, _ = machineInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: controller.updateMachineToMachineDeployment,
-		DeleteFunc: controller.deleteMachineDeployment,
+		DeleteFunc: controller.deleteMachineToMachineDeployment,
 	})
 
 	_, _ = machineSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/controller/deployment.go
+++ b/pkg/controller/deployment.go
@@ -75,7 +75,7 @@ func (dc *controller) deleteMachineDeployment(obj interface{}) {
 		}
 		d, ok = tombstone.Obj.(*v1alpha1.MachineDeployment)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a Machine Deployment %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Machine Deployment %#v", obj))
 			return
 		}
 	}
@@ -199,12 +199,12 @@ func (dc *controller) deleteMachineSetToDeployment(obj interface{}) {
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		machineSet, ok = tombstone.Obj.(*v1alpha1.MachineSet)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a MachineSet %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a MachineSet %#v", obj))
 			return
 		}
 	}
@@ -249,7 +249,8 @@ func (dc *controller) updateMachineToMachineDeployment(old, cur any) {
 }
 
 // deleteMachine will enqueue a Recreate Deployment once all of its Machines have stopped running.
-func (dc *controller) deleteMachineToMachineDeployment(ctx context.Context, obj interface{}) {
+func (dc *controller) deleteMachineToMachineDeployment(obj interface{}) {
+	ctx := context.Background()
 	machine, ok := obj.(*v1alpha1.Machine)
 
 	// When a delete is dropped, the relist will notice a Machine in the store not
@@ -259,12 +260,12 @@ func (dc *controller) deleteMachineToMachineDeployment(ctx context.Context, obj 
 	if !ok {
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
 			return
 		}
 		machine, ok = tombstone.Obj.(*v1alpha1.Machine)
 		if !ok {
-			utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a machine %#v", obj))
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a machine %#v", obj))
 			return
 		}
 	}
@@ -292,7 +293,7 @@ func (dc *controller) deleteMachineToMachineDeployment(ctx context.Context, obj 
 func (dc *controller) enqueueMachineDeployment(deployment *v1alpha1.MachineDeployment) {
 	key, err := KeyFunc(deployment)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", deployment, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", deployment, err))
 		return
 	}
 
@@ -302,7 +303,7 @@ func (dc *controller) enqueueMachineDeployment(deployment *v1alpha1.MachineDeplo
 func (dc *controller) enqueueRateLimited(deployment *v1alpha1.MachineDeployment) {
 	key, err := KeyFunc(deployment)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", deployment, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", deployment, err))
 		return
 	}
 
@@ -313,7 +314,7 @@ func (dc *controller) enqueueRateLimited(deployment *v1alpha1.MachineDeployment)
 func (dc *controller) enqueueMachineDeploymentAfter(deployment *v1alpha1.MachineDeployment, after time.Duration) {
 	key, err := KeyFunc(deployment)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", deployment, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", deployment, err))
 		return
 	}
 

--- a/pkg/controller/deployment_test.go
+++ b/pkg/controller/deployment_test.go
@@ -886,7 +886,7 @@ var _ = Describe("machineDeployment", func() {
 
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				c.deleteMachineToMachineDeployment(context.Background(), testMachine)
+				c.deleteMachineToMachineDeployment(testMachine)
 
 				waitForCacheSync(stop, c)
 				Expect(c.machineDeploymentQueue.Len()).To(Equal(queueLength))
@@ -1359,7 +1359,7 @@ var _ = Describe("machineDeployment", func() {
 
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				actualMachineSets, err := c.getMachineSetsForMachineDeployment(context.Background(), testMachineDeployment)
+				actualMachineSets, err := c.getMachineSetsForMachineDeployment(context.TODO(), testMachineDeployment)
 
 				waitForCacheSync(stop, c)
 				if expectedErr != nil {
@@ -2088,7 +2088,7 @@ var _ = Describe("machineDeployment", func() {
 
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				c.terminateMachineSets(context.Background(), testMachineSets, testMachineDeployment)
+				c.terminateMachineSets(context.TODO(), testMachineSets, testMachineDeployment)
 
 				waitForCacheSync(stop, c)
 				actualMachineSets, _ := c.controlMachineClient.MachineSets(testNamespace).List(context.Background(), metav1.ListOptions{})
@@ -2158,7 +2158,7 @@ var _ = Describe("machineDeployment", func() {
 
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				c.deleteMachineDeploymentFinalizers(context.Background(), testMachineDeployment)
+				c.deleteMachineDeploymentFinalizers(context.TODO(), testMachineDeployment)
 
 				waitForCacheSync(stop, c)
 				actualMachineDeployment, _ := c.controlMachineClient.MachineDeployments(testNamespace).Get(context.Background(), testMachineDeployment.Name, metav1.GetOptions{})

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -702,7 +702,7 @@ func (c *controller) prepareMachineForDeletion(ctx context.Context, targetMachin
 
 	machineSetKey, err := KeyFunc(machineSet)
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for %v %#v: %v", machineSet.Kind, machineSet, err))
+		utilruntime.HandleError(fmt.Errorf("couldn't get key for %v %#v: %v", machineSet.Kind, machineSet, err))
 		return
 	}
 

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -727,7 +727,7 @@ var _ = Describe("machineset", func() {
 			activeMachines := []*machinev1.Machine{testActiveMachine1, testActiveMachine2}
 
 			testMachineSet.TypeMeta = metav1.TypeMeta{}
-			Err := c.manageReplicas(context.Background(), activeMachines, testMachineSet)
+			Err := c.manageReplicas(context.TODO(), activeMachines, testMachineSet)
 			waitForCacheSync(stop, c)
 
 			Expect(Err).Should(BeNil())
@@ -747,7 +747,7 @@ var _ = Describe("machineset", func() {
 			waitForCacheSync(stop, c)
 
 			activeMachines := []*machinev1.Machine{testActiveMachine1, testActiveMachine2}
-			Expect(c.manageReplicas(context.Background(), activeMachines, testMachineSet)).NotTo(HaveOccurred())
+			Expect(c.manageReplicas(context.TODO(), activeMachines, testMachineSet)).NotTo(HaveOccurred())
 			waitForCacheSync(stop, c)
 			// TODO: Could not use Listers here, need to check more.
 			machines, err := c.controlMachineClient.Machines(testNamespace).List(context.Background(), metav1.ListOptions{})
@@ -837,7 +837,7 @@ var _ = Describe("machineset", func() {
 			Expect(len(machines.Items)).To(Equal(int(testMachineSet.Spec.Replicas + 1)))
 
 			activeMachines := []*machinev1.Machine{testActiveMachine1, testActiveMachine2, testActiveMachine3, testActiveMachine4}
-			Err := c.manageReplicas(context.Background(), activeMachines, testMachineSet)
+			Err := c.manageReplicas(context.TODO(), activeMachines, testMachineSet)
 			waitForCacheSync(stop, c)
 			machines, _ = c.controlMachineClient.Machines(testNamespace).List(context.Background(), metav1.ListOptions{})
 			Expect(len(machines.Items)).To(Equal(int(testMachineSet.Spec.Replicas)))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an incorrect machineinformer callback

**Which issue(s) this PR fixes**:
Fixes #988 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
