### PR TITLE
Simplify local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.23.3 AS builder
 WORKDIR /go/src/github.com/gardener/machine-controller-manager
 COPY . .
 
-RUN .ci/build
+RUN --mount=type=cache,target="/root/.cache/go-build" .ci/build
 
 #############      base                                     #############
 FROM gcr.io/distroless/static-debian12:nonroot as base

--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,10 @@ build:
 release: build docker-image docker-login docker-push
 
 PLATFORM ?= linux/amd64
+PUSH ?= false
 .PHONY: docker-image
 docker-image:
-	@docker buildx build --platform $(PLATFORM)  -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) --rm .
+	@docker buildx build --platform $(PLATFORM) --push=$(PUSH) -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) .
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
**What this PR does / why we need it**:

/kind enhancement

This PR simplifies developing machine-controller-manager changes based on [gardener's local setup](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md).

Now, you can push an image to the local setup registry using:
```
make docker-image IMAGE_REPOSITORY=garden.local.gardener.cloud:5001/machine-controller-manager IMAGE_TAG=<optional-tag> PLATFORM=<e.g., linux/arm64> PUSH=true
```

Also, repetitive builds are much faster now (mounting a cache directory for the go build cache).

**Which issue(s) this PR fixes**:
I used this while implementing https://github.com/gardener/machine-controller-manager/issues/994

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
