### PR TITLE
[rel-v0.59] Skip machines in `InPlaceUpdating` phase during machine set transfer to prevent update phase failures

### DIFF
--- a/pkg/controller/deployment_inplace_test.go
+++ b/pkg/controller/deployment_inplace_test.go
@@ -267,7 +267,7 @@ var _ = Describe("deployment_inplace", func() {
 				controlMachineObjects = append(controlMachineObjects, oldMachineSet, newMachineSet)
 
 				machines := []*machinev1.Machine{}
-				machines = append(machines, newMachinesFromMachineSet(int(data.setup.oldMachineSetReplicas), oldMachineSet, &machinev1.MachineStatus{}, nil, map[string]string{"key": "value"})...)
+				machines = append(machines, newMachinesFromMachineSet(int(data.setup.oldMachineSetReplicas), oldMachineSet, &machinev1.MachineStatus{CurrentStatus: machinev1.CurrentStatus{Phase: machinev1.MachineInPlaceUpdateSuccessful}}, nil, map[string]string{"key": "value"})...)
 				machines = append(machines, newMachinesFromMachineSet(int(data.setup.newMachineSetReplicas), newMachineSet, &machinev1.MachineStatus{}, nil, nil)...)
 				machinesWithUpdateSuccessful := 0
 				for i := range machines {


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of PR #1020 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator github.com/gardener/machine-controller-manager #1020 @acumino 
Fixed a bug where machines in the `InPlaceUpdating` phase were incorrectly transferred to the new machine set during inplace updates. This caused the machine controller to miss updating the phase to `InPlaceUpdateSuccessful`, resulting in machines getting stuck or marked as `InPlaceUpdateFailed`.
```
