### PR TITLE
Fix `mcm_machine_set_failed_machines` metric to more accurately reflect current state

### DIFF
--- a/pkg/controller/deployment_machineset_util.go
+++ b/pkg/controller/deployment_machineset_util.go
@@ -127,7 +127,7 @@ func calculateMachineSetStatus(is *v1alpha1.MachineSet, filteredMachines []*v1al
 	}
 
 	// Update the FailedMachines field when we see new failures
-	// Set the FailedMachines field to nil if there are no failed machines.
+	// Clear FailedMachines if there are no failed machines.
 	if len(failedMachines) > 0 {
 		newStatus.FailedMachines = &failedMachines
 	} else {

--- a/pkg/controller/deployment_machineset_util.go
+++ b/pkg/controller/deployment_machineset_util.go
@@ -126,13 +126,11 @@ func calculateMachineSetStatus(is *v1alpha1.MachineSet, filteredMachines []*v1al
 		}
 	}
 
-	// Update the FailedMachines field only if we see new failures
-	// Clear FailedMachines if ready replicas equals total replicas,
-	// which means the machineset doesn't have any machine objects which are in any failed state
-	// #nosec G115 -- number of machines will not exceed MaxInt32
+	// Update the FailedMachines field when we see new failures
+	// Set the FailedMachines field to nil if there are no failed machines.
 	if len(failedMachines) > 0 {
 		newStatus.FailedMachines = &failedMachines
-	} else if int32(readyReplicasCount) == is.Status.Replicas {
+	} else {
 		newStatus.FailedMachines = nil
 	}
 

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -119,6 +119,11 @@ func updateMachineSetStatusRelatedMetric(machineSet *v1alpha1.MachineSet, msMeta
 }
 
 func updateMachineSetStatusFailedMachinesMetric(machineSet *v1alpha1.MachineSet, msMeta metav1.ObjectMeta) {
+	metrics.MachineSetStatusFailedMachines.DeletePartialMatch(prometheus.Labels{
+		"name":      msMeta.Name,
+		"namespace": msMeta.Namespace,
+	})
+
 	if machineSet.Status.FailedMachines != nil {
 		for _, failedMachine := range *machineSet.Status.FailedMachines {
 			metrics.MachineSetStatusFailedMachines.With(prometheus.Labels{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds changes such that a gauge metric scraped on prometheus gets cleared and re-populated on every poll, so that it reflects the latest state of the reference slice `*machineSet.Status.FailedMachines`.
The logic to set this variable has also been updated so that it contains the current set of machines in the `Failed` state.

**Which issue(s) this PR fixes**:
Fixes #476 

**Special notes for your reviewer**:
IT for mcm-provider-aws passed

Testing was done by setting the `machineCreationTimeout` to a value lesser than the time it takes for a machine to be provisioned and move into the `Running` state (1m). The machine moves to the `Failed` state, when it can be checked against a prometheus graph to verify if it was recorded accurately

Some changes were required to ensure a `Failed` machine stays failed, like an artificial delay in the goroutine marking a machine for deletion

<img width="3450" height="1634" alt="image" src="https://github.com/user-attachments/assets/379920a6-61b5-47aa-98c5-7ba7a71646fd" />
Stacked graph reflecting number of failed machines accurately matched number in the cluster



**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` bugfix operator
Fixed metric `mcm_machine_set_failed_machines` and underlying variable `*machineSet.Status.FailedMachines` so that they reflect the current state of machines

```
