### PR TITLE
Log rollout events

### DIFF
--- a/pkg/controller/deployment_inplace.go
+++ b/pkg/controller/deployment_inplace.go
@@ -58,6 +58,7 @@ func (dc *controller) rolloutInPlace(ctx context.Context, d *v1alpha1.MachineDep
 		// status-rollout steps.
 		if dc.autoscalerScaleDownAnnotationDuringRollout {
 			// Annotate all the nodes under this machine-deployment, as roll-out is on-going.
+			klog.V(3).Infof("RolloutInPlace ongoing for MachineDeployment %q, annotating all nodes under it with %s", d.Name, clusterAutoscalerScaleDownAnnotations)
 			err := dc.annotateNodesBackingMachineSets(ctx, allMachineSets, clusterAutoscalerScaleDownAnnotations)
 			if err != nil {
 				klog.Errorf("failed to add annotations %s on all nodes. Error: %v", clusterAutoscalerScaleDownAnnotations, err)

--- a/pkg/controller/deployment_recreate.go
+++ b/pkg/controller/deployment_recreate.go
@@ -53,6 +53,7 @@ func (dc *controller) rolloutRecreate(ctx context.Context, d *v1alpha1.MachineDe
 		// status-rollout steps.
 		if len(oldISs) > 0 && !dc.machineSetsScaledToZero(oldISs) {
 			// Annotate all the nodes under this machine-deployment, as roll-out is on-going.
+			klog.V(3).Infof("RolloutRecreate ongoing for MachineDeployment %q, annotating all nodes under it with %s", d.Name, clusterAutoscalerScaleDownAnnotations)
 			err := dc.annotateNodesBackingMachineSets(ctx, allISs, clusterAutoscalerScaleDownAnnotations)
 			if err != nil {
 				klog.Errorf("Failed to add %s on all nodes. Error: %s", clusterAutoscalerScaleDownAnnotations, err)

--- a/pkg/controller/deployment_rolling.go
+++ b/pkg/controller/deployment_rolling.go
@@ -73,6 +73,7 @@ func (dc *controller) rolloutRolling(ctx context.Context, d *v1alpha1.MachineDep
 		// status-rollout steps.
 		if len(oldISs) > 0 && !dc.machineSetsScaledToZero(oldISs) {
 			// Annotate all the nodes under this machine-deployment, as roll-out is on-going.
+			klog.V(3).Infof("RolloutRolling ongoing for MachineDeployment %q, annotating all nodes under it with %s", d.Name, clusterAutoscalerScaleDownAnnotations)
 			err := dc.annotateNodesBackingMachineSets(ctx, allISs, clusterAutoscalerScaleDownAnnotations)
 			if err != nil {
 				klog.Errorf("Failed to add %s on all nodes. Error: %s", clusterAutoscalerScaleDownAnnotations, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces log messages to indicate when rollout operations are ongoing for MachineDeployments and when nodes are being annotated with cluster autoscaler scale-down annotations.
Changes made for InPlace, Rolling and Recreate

**Special notes for your reviewer**:
Passed unit tests

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add informational logging for MachineDeployment rollout events
```
