### PR TITLE
[GEP-28] Fix panic if provider does not support Driver.InitializeMachine

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -649,7 +649,9 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		if c.targetCoreClient == nil {
 			// persist addresses from the InitializeMachine and CreateMachine responses
 			clone := clone.DeepCopy()
-			addresses.Insert(initResponse.Addresses...)
+			if initResponse != nil {
+				addresses.Insert(initResponse.Addresses...)
+			}
 			clone.Status.Addresses = buildAddressStatus(addresses, nodeName)
 			if _, err := c.controlMachineClient.Machines(clone.Namespace).UpdateStatus(ctx, clone, metav1.UpdateOptions{}); err != nil {
 				return machineutils.ShortRetry, fmt.Errorf("failed to persist status addresses after initialization was successful: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
/kind bug

Fixes a small bug introduced in https://github.com/gardener/machine-controller-manager/pull/1012, where a panic can occur if the provider does not implement the `InitializeMachine` function. This code path can only be reached when running without a target-client (`gardenadm` scenario)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
