### PR TITLE
Add delete role to the machine-controller-manager ClusterRole

### DIFF
--- a/kubernetes/deployment/out-of-tree/target-cluster-role.yaml
+++ b/kubernetes/deployment/out-of-tree/target-cluster-role.yaml
@@ -64,3 +64,4 @@ rules:
   - get
   - list
   - watch
+  - delete


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds delete role to the service account so that MCM can delete volume attachments

**Which issue(s) this PR fixes**:
Fixes #1040

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
