### PR TITLE
[rel-v0.60] Fix panic if provider does not support Driver.InitializeMachine (#1032)

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -654,7 +654,9 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 		if c.targetCoreClient == nil {
 			// persist addresses from the InitializeMachine and CreateMachine responses
 			clone := clone.DeepCopy()
-			addresses.Insert(initResponse.Addresses...)
+			if initResponse != nil {
+				addresses.Insert(initResponse.Addresses...)
+			}
 			clone.Status.Addresses = buildAddressStatus(addresses, nodeName)
 			if _, err := c.controlMachineClient.Machines(clone.Namespace).UpdateStatus(ctx, clone, metav1.UpdateOptions{}); err != nil {
 				return machineutils.ShortRetry, fmt.Errorf("failed to persist status addresses after initialization was successful: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry picks the following commit

- https://github.com/gardener/machine-controller-manager/commit/52f840ee2277347d9da066957f8745916f93c062

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator github.com/gardener/machine-controller-manager #1032 @maboehm 
Fix panic if provider does not support Driver.InitializeMachine
```
