### PR TITLE
Check `providerID` instead of node label in creation flow

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -612,7 +612,7 @@ func (c *controller) triggerCreationFlow(ctx context.Context, createMachineReque
 				}
 				uninitializedMachine = true
 			} else {
-				// if node label present that means there must be a backing VM ,without need of GetMachineStatus() call
+				// if .spec.ProviderID is present that means there must be a backing VM, without need of GetMachineStatus() call
 				nodeName = machine.Labels[v1alpha1.NodeLabelKey]
 				providerID = machine.Spec.ProviderID
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
When running without a target cluster, the mcm intentionally never sets the `node` label on the `Machine` object. So this check makes no sense. It is better to check if the providerID was set in the spec. Both fields are set at the same time in `r.updateLabels()`, but only `providerID` is set in all scenarios.

**Which issue(s) this PR fixes**:
When running without a target cluster and with a provider that does not implement `GetMachineStatus()`, the controller would be in an infinite loop, because this label is never set - and without the label always calls `CreateMachine()` and returns.

Essentially a follow up to https://github.com/gardener/machine-controller-manager/pull/1004

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
