### PR TITLE
Use `ToBeDeletedByClusterAutoscaler` Taint to improve load balancing during machine terminations

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -641,6 +641,9 @@ func (c *controller) triggerDeletionFlow(ctx context.Context, deleteMachineReque
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.InitiateDrain):
 		return c.drainNode(ctx, deleteMachineRequest)
 
+	case strings.Contains(machine.Status.LastOperation.Description, machineutils.SetDeletionTaint):
+		return c.taintNode(ctx, deleteMachineRequest)
+
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.DelVolumesAttachments):
 		return c.deleteNodeVolAttachments(ctx, deleteMachineRequest)
 

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -641,11 +641,11 @@ func (c *controller) triggerDeletionFlow(ctx context.Context, deleteMachineReque
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.InitiateDrain):
 		return c.drainNode(ctx, deleteMachineRequest)
 
-	case strings.Contains(machine.Status.LastOperation.Description, machineutils.SetDeletionTaint):
-		return c.taintNode(ctx, deleteMachineRequest)
-
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.DelVolumesAttachments):
 		return c.deleteNodeVolAttachments(ctx, deleteMachineRequest)
+
+	case strings.Contains(machine.Status.LastOperation.Description, machineutils.SetDeletionTaint):
+		return c.taintNode(ctx, deleteMachineRequest)
 
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.InitiateVMDeletion):
 		return c.deleteVM(ctx, deleteMachineRequest)

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -3448,7 +3448,7 @@ var _ = Describe("machine", func() {
 					),
 				},
 			}),
-			Entry("Skip ToBedeletedByClusterAutoscaler Taint if node dose not exist", &data{
+			Entry("Skip ToBedeletedByClusterAutoscaler Taint if node does not exist", &data{
 				setup: setup{
 					secrets: []*corev1.Secret{
 						{
@@ -3527,7 +3527,7 @@ var _ = Describe("machine", func() {
 								LastUpdateTime: metav1.Now(),
 							},
 							LastOperation: v1alpha1.LastOperation{
-								Description:    fmt.Sprintf("Node dose not exist. %s", machineutils.InitiateVMDeletion),
+								Description:    fmt.Sprintf("Node does not exist. %s", machineutils.InitiateVMDeletion),
 								State:          v1alpha1.MachineStateProcessing,
 								Type:           v1alpha1.MachineOperationDelete,
 								LastUpdateTime: metav1.Now(),

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1768,7 +1768,7 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 
 	if node != nil {
 		for _, taint := range node.Spec.Taints {
-			if taint.MatchTaint(&toBeDeletedTaint) {
+			if taint.Key == toBeDeletedTaint.Key {
 				taintAlreadySet = true
 				description = fmt.Sprintf("Node tainted. %s", machineutils.InitiateVMDeletion)
 			}

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1745,63 +1745,6 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 	return machineutils.ShortRetry, err
 }
 
-func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver.DeleteMachineRequest) (machineutils.RetryPeriod, error) {
-	var (
-		machine          = deleteMachineRequest.Machine
-		toBeDeletedTaint = v1.Taint{
-			Key:    machineutils.TaintToBeDeleted,
-			Value:  "gardener-machine-controller-manager",
-			Effect: v1.TaintEffectPreferNoSchedule,
-		}
-		description  = ""
-		taintUpdated = false
-		skipStep     = false
-	)
-	node, err := c.nodeLister.Get(getNodeName(machine))
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.Errorf("error occurred while trying to fetch node object - err: %v", err)
-			return machineutils.ShortRetry, err
-		}
-		skipStep = true
-		description = fmt.Sprintf("Node does not exist. %s", machineutils.InitiateVMDeletion)
-	}
-	var updatedNode *v1.Node
-	if node != nil {
-		updatedNode, taintUpdated, _ = taintutils.AddOrUpdateTaint(node, &toBeDeletedTaint)
-		if !taintUpdated {
-			description = fmt.Sprintf("Node tainted. %s", machineutils.InitiateVMDeletion)
-		}
-	}
-
-	if !taintUpdated || skipStep {
-		return c.machineStatusUpdate(
-			ctx,
-			machine,
-			v1alpha1.LastOperation{
-				Description:    description,
-				State:          v1alpha1.MachineStateProcessing,
-				Type:           v1alpha1.MachineOperationDelete,
-				LastUpdateTime: metav1.Now(),
-			},
-			// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
-			// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-			// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
-			machine.Status.CurrentStatus,
-			machine.Status.LastKnownState,
-		)
-	}
-
-	if _, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, updatedNode, metav1.UpdateOptions{}); err != nil {
-		if apierrors.IsConflict(err) {
-			return machineutils.ConflictRetry, err
-		}
-		return machineutils.ShortRetry, err
-	}
-
-	return machineutils.ShortRetry, nil
-}
-
 // deleteNodeVolAttachments deletes VolumeAttachment(s) for a node before moving to taint Node stage.
 func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachineRequest *driver.DeleteMachineRequest) (machineutils.RetryPeriod, error) {
 	var (
@@ -1864,6 +1807,63 @@ func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachine
 	}
 
 	return retryPeriod, err
+}
+
+func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver.DeleteMachineRequest) (machineutils.RetryPeriod, error) {
+	var (
+		machine          = deleteMachineRequest.Machine
+		toBeDeletedTaint = v1.Taint{
+			Key:    machineutils.TaintToBeDeleted,
+			Value:  "gardener-machine-controller-manager",
+			Effect: v1.TaintEffectPreferNoSchedule,
+		}
+		description  = ""
+		taintUpdated = false
+		skipStep     = false
+	)
+	node, err := c.nodeLister.Get(getNodeName(machine))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("error occurred while trying to fetch node object - err: %v", err)
+			return machineutils.ShortRetry, err
+		}
+		skipStep = true
+		description = fmt.Sprintf("Node does not exist. %s", machineutils.InitiateVMDeletion)
+	}
+	var updatedNode *v1.Node
+	if node != nil {
+		updatedNode, taintUpdated, _ = taintutils.AddOrUpdateTaint(node, &toBeDeletedTaint)
+		if !taintUpdated {
+			description = fmt.Sprintf("Node tainted. %s", machineutils.InitiateVMDeletion)
+		}
+	}
+
+	if !taintUpdated || skipStep {
+		return c.machineStatusUpdate(
+			ctx,
+			machine,
+			v1alpha1.LastOperation{
+				Description:    description,
+				State:          v1alpha1.MachineStateProcessing,
+				Type:           v1alpha1.MachineOperationDelete,
+				LastUpdateTime: metav1.Now(),
+			},
+			// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
+			// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
+			// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
+			machine.Status.CurrentStatus,
+			machine.Status.LastKnownState,
+		)
+	}
+
+	if _, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, updatedNode, metav1.UpdateOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			return machineutils.ConflictRetry, err
+		}
+		return machineutils.ShortRetry, err
+	}
+
+	return machineutils.ShortRetry, nil
 }
 
 // deleteVM attempts to delete the VM backed by the machine object

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1763,7 +1763,7 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 			return machineutils.ShortRetry, err
 		}
 		skipStep = true
-		description = fmt.Sprintf("Node dose not exist. %s", machineutils.InitiateVMDeletion)
+		description = fmt.Sprintf("Node does not exist. %s", machineutils.InitiateVMDeletion)
 	}
 
 	if node != nil {
@@ -1805,7 +1805,7 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 	return machineutils.ShortRetry, nil
 }
 
-// deleteNodeVolAttachments deletes VolumeAttachment(s) for a node before moving to VM deletion stage.
+// deleteNodeVolAttachments deletes VolumeAttachment(s) for a node before moving to taint Node stage.
 func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachineRequest *driver.DeleteMachineRequest) (machineutils.RetryPeriod, error) {
 	var (
 		description string
@@ -1821,11 +1821,11 @@ func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachine
 			return retryPeriod, err
 		}
 		// node not found move to vm deletion
-		description = fmt.Sprintf("Skipping deleteNodeVolAttachments due to - %s. Moving to VM Deletion. %s", err.Error(), machineutils.SetDeletionTaint)
+		description = fmt.Sprintf("Skipping deleteNodeVolAttachments due to - %s. Moving to taint Node. %s", err.Error(), machineutils.SetDeletionTaint)
 		state = v1alpha1.MachineStateProcessing
 		retryPeriod = 0
 	} else if len(node.Status.VolumesAttached) == 0 {
-		description = fmt.Sprintf("Node Volumes for node: %s are already detached. Moving to VM Deletion. %s", nodeName, machineutils.SetDeletionTaint)
+		description = fmt.Sprintf("Node Volumes for node: %s are already detached. Moving to taint Node. %s", nodeName, machineutils.SetDeletionTaint)
 		state = v1alpha1.MachineStateProcessing
 		retryPeriod = 0
 	} else {
@@ -1844,7 +1844,7 @@ func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachine
 			}
 			return retryPeriod, nil
 		}
-		description = fmt.Sprintf("No Live VolumeAttachments for node: %s. Moving to VM Deletion. %s", nodeName, machineutils.SetDeletionTaint)
+		description = fmt.Sprintf("No Live VolumeAttachments for node: %s. Moving to taint Node. %s", nodeName, machineutils.SetDeletionTaint)
 		state = v1alpha1.MachineStateProcessing
 	}
 	now := metav1.Now()

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	utilstrings "github.com/gardener/machine-controller-manager/pkg/util/strings"
+	taintutils "github.com/gardener/machine-controller-manager/pkg/util/taints"
 	utiltime "github.com/gardener/machine-controller-manager/pkg/util/time"
 
 	v1 "k8s.io/api/core/v1"
@@ -1752,9 +1753,9 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 			Value:  "gardener-machine-controller-manager",
 			Effect: v1.TaintEffectPreferNoSchedule,
 		}
-		description     = ""
-		taintAlreadySet = false
-		skipStep        = false
+		description  = ""
+		taintUpdated = false
+		skipStep     = false
 	)
 	node, err := c.nodeLister.Get(getNodeName(machine))
 	if err != nil {
@@ -1765,17 +1766,15 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 		skipStep = true
 		description = fmt.Sprintf("Node does not exist. %s", machineutils.InitiateVMDeletion)
 	}
-
+	var updatedNode *v1.Node
 	if node != nil {
-		for _, taint := range node.Spec.Taints {
-			if taint.Key == toBeDeletedTaint.Key {
-				taintAlreadySet = true
-				description = fmt.Sprintf("Node tainted. %s", machineutils.InitiateVMDeletion)
-			}
+		updatedNode, taintUpdated, _ = taintutils.AddOrUpdateTaint(node, &toBeDeletedTaint)
+		if !taintUpdated {
+			description = fmt.Sprintf("Node tainted. %s", machineutils.InitiateVMDeletion)
 		}
 	}
 
-	if taintAlreadySet || skipStep {
+	if !taintUpdated || skipStep {
 		return c.machineStatusUpdate(
 			ctx,
 			machine,
@@ -1793,9 +1792,7 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 		)
 	}
 
-	node.Spec.Taints = append(node.Spec.Taints, toBeDeletedTaint)
-
-	if _, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{}); err != nil {
+	if _, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, updatedNode, metav1.UpdateOptions{}); err != nil {
 		if apierrors.IsConflict(err) {
 			return machineutils.ConflictRetry, err
 		}

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1700,7 +1700,7 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 				if forceDeletePods {
 					description = fmt.Sprintf("Force Drain successful. %s", machineutils.DelVolumesAttachments)
 				} else { // regular drain already waits for vol detach and attach for another node.
-					description = fmt.Sprintf("Drain successful. %s", machineutils.InitiateVMDeletion)
+					description = fmt.Sprintf("Drain successful. %s", machineutils.SetDeletionTaint)
 				}
 				err = fmt.Errorf("%s", description)
 				state = v1alpha1.MachineStateProcessing
@@ -1744,6 +1744,67 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 	return machineutils.ShortRetry, err
 }
 
+func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver.DeleteMachineRequest) (machineutils.RetryPeriod, error) {
+	var (
+		machine          = deleteMachineRequest.Machine
+		toBeDeletedTaint = v1.Taint{
+			Key:    machineutils.TaintToBeDeleted,
+			Value:  "gardener-machine-controller-manager",
+			Effect: v1.TaintEffectPreferNoSchedule,
+		}
+		description     = ""
+		taintAlreadySet = false
+		skipStep        = false
+	)
+	node, err := c.nodeLister.Get(getNodeName(machine))
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.Errorf("Error occurred while trying to fetch node object - err: %s", err)
+			return machineutils.ShortRetry, err
+		}
+		skipStep = true
+		description = fmt.Sprintf("Node dose not exist. %s", machineutils.InitiateVMDeletion)
+	}
+
+	if node != nil {
+		for _, taint := range node.Spec.Taints {
+			if taint.MatchTaint(&toBeDeletedTaint) {
+				taintAlreadySet = true
+				description = fmt.Sprintf("Node tainted. %s", machineutils.InitiateVMDeletion)
+			}
+		}
+	}
+
+	if taintAlreadySet || skipStep {
+		return c.machineStatusUpdate(
+			ctx,
+			machine,
+			v1alpha1.LastOperation{
+				Description:    description,
+				State:          v1alpha1.MachineStateProcessing,
+				Type:           v1alpha1.MachineOperationDelete,
+				LastUpdateTime: metav1.Now(),
+			},
+			// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
+			// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
+			// Ref - https://github.com/gardener/machine-controller-manager/blob/rel-v0.34.0/pkg/util/provider/machinecontroller/machine_util.go#L872
+			machine.Status.CurrentStatus,
+			machine.Status.LastKnownState,
+		)
+	}
+
+	node.Spec.Taints = append(node.Spec.Taints, toBeDeletedTaint)
+
+	if _, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{}); err != nil {
+		if apierrors.IsConflict(err) {
+			return machineutils.ConflictRetry, err
+		}
+		return machineutils.ShortRetry, err
+	}
+
+	return machineutils.ShortRetry, nil
+}
+
 // deleteNodeVolAttachments deletes VolumeAttachment(s) for a node before moving to VM deletion stage.
 func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachineRequest *driver.DeleteMachineRequest) (machineutils.RetryPeriod, error) {
 	var (
@@ -1760,11 +1821,11 @@ func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachine
 			return retryPeriod, err
 		}
 		// node not found move to vm deletion
-		description = fmt.Sprintf("Skipping deleteNodeVolAttachments due to - %s. Moving to VM Deletion. %s", err.Error(), machineutils.InitiateVMDeletion)
+		description = fmt.Sprintf("Skipping deleteNodeVolAttachments due to - %s. Moving to VM Deletion. %s", err.Error(), machineutils.SetDeletionTaint)
 		state = v1alpha1.MachineStateProcessing
 		retryPeriod = 0
 	} else if len(node.Status.VolumesAttached) == 0 {
-		description = fmt.Sprintf("Node Volumes for node: %s are already detached. Moving to VM Deletion. %s", nodeName, machineutils.InitiateVMDeletion)
+		description = fmt.Sprintf("Node Volumes for node: %s are already detached. Moving to VM Deletion. %s", nodeName, machineutils.SetDeletionTaint)
 		state = v1alpha1.MachineStateProcessing
 		retryPeriod = 0
 	} else {
@@ -1783,7 +1844,7 @@ func (c *controller) deleteNodeVolAttachments(ctx context.Context, deleteMachine
 			}
 			return retryPeriod, nil
 		}
-		description = fmt.Sprintf("No Live VolumeAttachments for node: %s. Moving to VM Deletion. %s", nodeName, machineutils.InitiateVMDeletion)
+		description = fmt.Sprintf("No Live VolumeAttachments for node: %s. Moving to VM Deletion. %s", nodeName, machineutils.SetDeletionTaint)
 		state = v1alpha1.MachineStateProcessing
 	}
 	now := metav1.Now()

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -426,7 +426,7 @@ func (c *controller) updateMachineStatusAndNodeCondition(ctx context.Context, ma
 			},
 			// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
 			// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-			// Ref - https://github.com/gardener/machine-controller-manager/blob/rel-v0.34.0/pkg/util/provider/machinecontroller/machine_util.go#L872
+			// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
 			machine.Status.CurrentStatus,
 			machine.Status.LastKnownState,
 		)
@@ -1395,7 +1395,7 @@ func (c *controller) updateMachineStatusAndNodeLabel(ctx context.Context, getMac
 		},
 		// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
 		// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-		// Ref - https://github.com/gardener/machine-controller-manager/blob/rel-v0.34.0/pkg/util/provider/machinecontroller/machine_util.go#L872
+		// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
 		getMachineStatusRequest.Machine.Status.CurrentStatus,
 		getMachineStatusRequest.Machine.Status.LastKnownState,
 	)
@@ -1732,7 +1732,7 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 		},
 		// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
 		// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-		// Ref - https://github.com/gardener/machine-controller-manager/blob/rel-v0.34.0/pkg/util/provider/machinecontroller/machine_util.go#L872
+		// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
 		machine.Status.CurrentStatus,
 		machine.Status.LastKnownState,
 	)
@@ -1759,7 +1759,7 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 	node, err := c.nodeLister.Get(getNodeName(machine))
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			klog.Errorf("Error occurred while trying to fetch node object - err: %s", err)
+			klog.Errorf("error occurred while trying to fetch node object - err: %v", err)
 			return machineutils.ShortRetry, err
 		}
 		skipStep = true
@@ -1787,7 +1787,7 @@ func (c *controller) taintNode(ctx context.Context, deleteMachineRequest *driver
 			},
 			// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
 			// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-			// Ref - https://github.com/gardener/machine-controller-manager/blob/rel-v0.34.0/pkg/util/provider/machinecontroller/machine_util.go#L872
+			// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
 			machine.Status.CurrentStatus,
 			machine.Status.LastKnownState,
 		)
@@ -1928,7 +1928,7 @@ func (c *controller) deleteVM(ctx context.Context, deleteMachineRequest *driver.
 		},
 		// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
 		// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-		// Ref - https://github.com/gardener/machine-controller-manager/blob/rel-v0.34.0/pkg/util/provider/machinecontroller/machine_util.go#L872
+		// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
 		machine.Status.CurrentStatus,
 		lastKnownState,
 	)
@@ -2050,7 +2050,7 @@ func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Mac
 		},
 		// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
 		// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-		// Ref - https://github.com/gardener/machine-controller-manager/blob/rel-v0.34.0/pkg/util/provider/machinecontroller/machine_util.go#L872
+		// Ref - https://github.com/gardener/machine-controller-manager/blob/97ca0de6df297c1b53ac2b66ec28120840b6906a/pkg/util/provider/machinecontroller/machine_util.go#L1621
 		machine.Status.CurrentStatus,
 		machine.Status.LastKnownState,
 	)

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -23,6 +23,9 @@ const (
 	// InitiateDrain specifies next step as initiate node drain
 	InitiateDrain = "Initiate node drain"
 
+	// SetDeletionTaint specifies next step as set deletion taint
+	SetDeletionTaint = "Set deletion taint"
+
 	// NodeReadyForUpdate specifies next step as node ready for update.
 	NodeReadyForUpdate = "Node drain successful. Node is ready for update"
 
@@ -83,6 +86,10 @@ const (
 	// TaintNodeCriticalComponentsNotReady is the name of a gardener taint
 	// indicating that a node is not yet ready to have user workload scheduled
 	TaintNodeCriticalComponentsNotReady = "node.gardener.cloud/critical-components-not-ready"
+
+	// TaintToBeDeleted is the taint of the cluster autoscaler which is used in cloud-provider and
+	// kube-proxy to check if a node is getting deleted soon.
+	TaintToBeDeleted = "ToBeDeletedByClusterAutoscaler"
 
 	// MachineLabelKey defines the labels which contains the name of the machine of a node
 	MachineLabelKey = "node.gardener.cloud/machine-name"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

If a machine is deleted the it is possible that the load balancer do not know yet that the node is not available anymore. This results eventually in unsuccessful new connections as the node where the load balancer is forwarding the traffic is not existing anymore.

There are 2 ways a load balancer gets informed: 1. Via a reconcile of the load balancer in the `cloud-provider` package or the `kube-proxy` health check. Unfortunately the "drain" or conditions set by the MCM dose not trigger a reconcile or the health check to fail. 

The `ToBeDeletedByClusterAutoscaler` Taint is used in both [`cloud-provider`](https://github.com/kubernetes/cloud-provider/blob/080e91c4b910bf92dfd43ca79eb74f5d39dcba75/controllers/service/controller.go#L1027) and[ `kube-proxy`](https://github.com/kubernetes/kubernetes/blob/5bcb7599736327cd8c6d23e398002354a6e40f68/pkg/proxy/healthcheck/proxy_health.go#L187), therefore we want to add this Taint to improve the load balancing during machine terminations.

This is new step is added between `Initiate node drain`/`Delete Volume Attachments` and `Initiate VM deletion` with one additional `ShortRetry` (5s) to give the  `cloud-provider` and `kube-proxy` time to react before removing the server.

CC: @kon-angelo 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use `ToBeDeletedByClusterAutoscaler` Taint to improve load balancing during machine terminations.
```
