### PR TITLE
Avoid redundant enqueues of the machines

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -277,7 +277,7 @@ func (c *controller) reconcileClusterMachineTermination(key string) error {
 	if err != nil {
 		klog.Errorf("cannot reconcile machine %q: %s", machine.Name, err)
 		c.enqueueMachineTerminationAfter(machine, time.Duration(retry), err.Error())
-		return err
+		return nil
 	}
 
 	// Process a delete event
@@ -292,15 +292,14 @@ func (c *controller) reconcileClusterMachineTermination(key string) error {
 
 	if err != nil {
 		c.enqueueMachineTerminationAfter(machine, time.Duration(retryPeriod), err.Error())
-		return err
 	} else {
 		// If the informer loses connection to the API server it may need to resync.
 		// If a resource is deleted while the watch is down, the informer won’t get
 		// delete event because the object is already gone. To avoid this edge-case,
 		// a requeue is scheduled post machine deletion as well.
 		c.enqueueMachineTerminationAfter(machine, time.Duration(retryPeriod), "post-deletion reconcile")
-		return nil
 	}
+	return nil
 }
 
 /*


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->


**What this PR does / why we need it**:
- Fixing the `reconcileClusterMachineTermination()` flow to return back `nil` if explicit enqueue of machines are done and avoiding redundant enqueue of machines in `reconcileClusterMachineClass()`
- This PR helps in reducing the number of updates done to a `machineStatus` if the machine termination is stuck with an error which does not allow the machine to get terminated. Eg: Terminating machines with `invalidCredentials`

**Which issue(s) this PR fixes**:
Fixes #1030 

**Special notes for your reviewer**:
Reasoning for the code changes to solve the issue:
- Idea of not updating the `machineStatus` in case of same error was dropped as the errors returned by the providers were not consistent and required a lot of effort in redesigning the error handling flow. Also, the current design is well enough to avoid the issue raised.
- Idea of implementing exponential backoff was dropped as the current approach does a good job in delaying updates in case of errors(LongRetry=10mins). Also, the exponential backoff would've lead to more reconciliations in case of errors compared to explicitly specifying larger retry periods.
- The changes mentioned in the PR fixes the original issue of `Frequent redundant updates during machine termination`. Now, if error is same but the description is different, the updates will go through but the requeue of machine will happen after `LongRetry` which is a fair amount of time to wait for machine status update.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Made changes to reconcileClusterMachineTermination to avoid duplicate reconciliations
```
```bugfix operator
Updated machineclass reconciliation to avoid unnecessary machine requeues
```
