### PR TITLE
Add check for force-delete label before parsing to bool

### DIFF
--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1575,9 +1575,11 @@ func (c *controller) drainNode(ctx context.Context, deleteMachineRequest *driver
 		ReadonlyFilesystem   v1.NodeConditionType = "ReadonlyFilesystem"
 	)
 
-	forceDeleteLabelPresent, err = strconv.ParseBool(machine.Labels["force-deletion"])
-	if err != nil {
-		klog.Warningf("%q label for machine %q has invalid value: %s", "force-deletion", machine.Name, err)
+	if labelValue, exists := machine.Labels["force-deletion"]; exists {
+		forceDeleteLabelPresent, err = strconv.ParseBool(labelValue)
+		if err != nil {
+			klog.Warningf("%q label for machine %q has invalid value %q: %s", "force-deletion", machine.Name, labelValue, err)
+		}
 	}
 
 	if nodeName == "" {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR makes a minor improvement to avoid warning when `force-deletion` label is absent.
The label is parsed using [`strconv.ParseBool`](https://pkg.go.dev/strconv#ParseBool), which in case the label does not exist, returns an error due to empty values.

The change ensures that the code only attempts to parse the label if it exists, preventing warning logs for the common case where machines don't have this label.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed spurious warning logs for machines without `force-deletion` label
```
