### PR TITLE
fix(metrics): Rebuild Metric for Machine Current State Phase

### DIFF
--- a/pkg/util/provider/metrics/metrics.go
+++ b/pkg/util/provider/metrics/metrics.go
@@ -24,12 +24,11 @@ var (
 	MachineCountDesc = prometheus.NewDesc("mcm_machine_items_total", "Count of machines currently managed by the mcm.", nil, nil)
 
 	// MachineCSPhase Current status phase of the Machines currently managed by the mcm.
-	MachineCSPhase = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespace,
-		Subsystem: machineSubsystem,
-		Name:      "current_status_phase",
-		Help:      "Current status phase of the Machines currently managed by the mcm.",
-	}, []string{"name", "namespace"})
+	MachineCSPhase = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, machineSubsystem, "current_status_phase"),
+		"Current status phase of the Machines currently managed by the mcm.",
+		[]string{"name", "namespace"},
+		nil)
 
 	// MachineInfo Information of the Machines currently managed by the mcm.
 	MachineInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -112,7 +111,6 @@ var (
 func registerMachineSubsystemMetrics() {
 	prometheus.MustRegister(MachineInfo)
 	prometheus.MustRegister(MachineStatusCondition)
-	prometheus.MustRegister(MachineCSPhase)
 }
 
 func registerCloudAPISubsystemMetrics() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Since the metric constantly reports the current status of the machine, it also constantly updates the state of a `Terminating` Machine, even if the Machine Object is already gone. 

Therefore, this PR rebuilds the metric to a Descriptor, which is filled everytime it lists the Machine.

**Which issue(s) this PR fixes**:
No issue needed, this is a bug fix.

**Special notes for your reviewer**:
We want to do a final test on our side if the metric is still behaving the correct way:
- [x] Test
We tested this on our side.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The metric for the `machine_current_status_phase` has been fixed and is not reporting removed Machines anymore
```
