### PR TITLE
[rel-v0.61] Skip finalizers for non-MCM nodes (#1065)

### DIFF
--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -61,6 +61,15 @@ func (c *controller) updateNode(oldObj, newObj any) {
 		return
 	}
 
+	// Do not process node updates if there is no associated machine
+	// In case of transient errors while fetching machine, do not retry
+	// as the update handler will be triggered again due to kubelet updates.
+	machine, err := c.getMachineFromNode(node.Name)
+	if err != nil {
+		klog.Errorf("unable to handle update event for node %q, couldn't fetch associated machine. Error: %v", node.Name, err)
+		return
+	}
+
 	// delete the machine if the node is deleted
 	if node.DeletionTimestamp != nil {
 		err := c.triggerMachineDeletion(context.Background(), node.Name)
@@ -69,18 +78,11 @@ func (c *controller) updateNode(oldObj, newObj any) {
 		}
 		return
 	}
-	// Check if finalizer was removed - re-add it
-	if c.hasNodeFinalizerBeenRemoved(oldNode, node, NodeFinalizerName) {
-		c.enqueueNodeAfter(node, time.Duration(machineutils.MediumRetry), fmt.Sprintf("MCM finalizer was removed from node %q, re-queuing", node.Name))
+
+	if !HasFinalizer(node, NodeFinalizerName) {
+		c.enqueueNodeAfter(node, time.Duration(machineutils.MediumRetry), fmt.Sprintf("MCM finalizer missing from node %q, re-queuing", node.Name))
 		return
 	}
-
-	machine, err := c.getMachineFromNode(node.Name)
-	if err != nil {
-		klog.Errorf("unable to handle update event for node %q, couldn't fetch associated machine. Error: %v", node.Name, err)
-		return
-	}
-
 	// to reconcile on addition/removal of essential taints in machine lifecycle, example - critical component taint
 	if addedOrRemovedEssentialTaints(oldNode, node, machineutils.EssentialTaints) {
 		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Atleast one of essential taints on node %q has changed", getNodeName(machine)))
@@ -143,6 +145,17 @@ func (c *controller) reconcileClusterNodeKey(key string) error {
 	if _, annotationPresent := node.ObjectMeta.Annotations[machineutils.NotManagedByMCM]; annotationPresent {
 		klog.Infof("ClusterNode %q: NotManagedByMCM annotation present, skipping reconciliation", key)
 		return nil
+	}
+
+	// Ignore node updates without an associated machine. Retry only for errors other than errNoMachineMatch;
+	// transient fetch errors will be eventually requeued by the update handler due to kubelet updates.
+	if _, err := c.getMachineFromNode(node.Name); err != nil {
+		if errors.Is(err, errNoMachineMatch) {
+			klog.Errorf("ClusterNode %q: No machine found matching node, skipping adding finalizers", key)
+			return nil
+		}
+		klog.Errorf("ClusterNode %q: error fetching machine for node: %v", key, err)
+		return err
 	}
 
 	if node.DeletionTimestamp != nil {
@@ -269,10 +282,6 @@ func (c *controller) updateNodeFinalizers(ctx context.Context, node *corev1.Node
 	}
 
 	return nil
-}
-
-func (c *controller) hasNodeFinalizerBeenRemoved(oldNode, newNode *corev1.Node, finalizerName string) bool {
-	return HasFinalizer(oldNode, finalizerName) && !HasFinalizer(newNode, finalizerName)
 }
 
 // HasFinalizer checks if the given object has the specified finalizer.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR cherry picks the following commit
- https://github.com/gardener/machine-controller-manager/commit/aeffe394202242e3b6c8def43f5cdf0081355591

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer github.com/gardener/machine-controller-manager #1065 @gagan16k 
Machine controller no longer adds finalizers or reconciles nodes with no associated machine
```
