### PR TITLE
Exclude terminating machines when managing machineset replicas

### DIFF
--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -359,6 +359,9 @@ func (c *controller) manageReplicas(ctx context.Context, allMachines []*v1alpha1
 	// are machines that require removal.
 	machinesWithoutUpdateSuccessfulLabelDiff := len(machinesWithoutUpdateSuccessfulLabel) - int(machineSet.Spec.Replicas)
 
+	// During in-place updates, ScaleUps are disabled in the oldMachineSet and the newMachineSet's
+	// ReplicaCount would never increase before a machine from oldMachineSet is moved.
+	// So no need for any special case during in-place updates when checking if machines need to be created.
 	if nonTerminatingMachinesDiff < 0 {
 		// If MachineSet is frozen and no deletion timestamp, don't process it
 		if machineSet.Labels["freeze"] == "True" && machineSet.DeletionTimestamp == nil {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Excludes considering terminating machines in machineset controller when 
computing the necessary machines that need to be created/removed.

A machine will only move to terminating state once the machine set has been scaled-down
hence if a machine is already in terminating state, it should be excluded from the list
of machines that are being considered when computing the active replicas of a machine set.

The only other scenario where a machine moves to terminating is when its in `Failed` state 
and the MCS controller proceeds to consider it as a stale machine and marks it
for removal. In this case, by excluding the terminating machine from diff computation,
we ensure that a replacement machine is spawned for the failed machine.

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Exclude terminating machines when managing machineset replicas to allow for faster replacement of a failed machine.
```
