### PR TITLE
Merge node finalizer removal and node deletion into one step

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -665,9 +665,6 @@ func (c *controller) triggerDeletionFlow(ctx context.Context, deleteMachineReque
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.InitiateVMDeletion):
 		return c.deleteVM(ctx, deleteMachineRequest)
 
-	case strings.Contains(machine.Status.LastOperation.Description, machineutils.RemoveNodeFinalizers):
-		return c.deleteNodeFinalizers(ctx, machine)
-
 	case strings.Contains(machine.Status.LastOperation.Description, machineutils.InitiateNodeDeletion):
 		return c.deleteNodeObject(ctx, machine)
 

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -3015,7 +3015,7 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					err:   fmt.Errorf("Machine deletion in process. VM deletion was successful. " + machineutils.RemoveNodeFinalizers),
+					err:   fmt.Errorf("Machine deletion in process. VM deletion was successful. " + machineutils.InitiateNodeDeletion),
 					retry: machineutils.ShortRetry,
 					machine: newMachine(
 						&v1alpha1.MachineTemplateSpec{
@@ -3034,112 +3034,7 @@ var _ = Describe("machine", func() {
 								LastUpdateTime: metav1.Now(),
 							},
 							LastOperation: v1alpha1.LastOperation{
-								Description:    fmt.Sprintf("VM deletion was successful. %s", machineutils.RemoveNodeFinalizers),
-								State:          v1alpha1.MachineStateProcessing,
-								Type:           v1alpha1.MachineOperationDelete,
-								LastUpdateTime: metav1.Now(),
-							},
-						},
-						nil,
-						map[string]string{
-							machineutils.MachinePriority: "3",
-						},
-						map[string]string{
-							v1alpha1.NodeLabelKey: "fakeID-0",
-						},
-						true,
-						metav1.Now(),
-					),
-				},
-			}),
-			Entry("Delete node finalizers successfully", &data{
-				setup: setup{
-					secrets: []*corev1.Secret{
-						{
-							ObjectMeta: *newObjectMeta(objMeta, 0),
-						},
-					},
-					machineClasses: []*v1alpha1.MachineClass{
-						{
-							ObjectMeta: *newObjectMeta(objMeta, 0),
-							SecretRef:  newSecretReference(objMeta, 0),
-						},
-					},
-					machines: newMachines(
-						1,
-						&v1alpha1.MachineTemplateSpec{
-							ObjectMeta: *newObjectMeta(objMeta, 0),
-							Spec: v1alpha1.MachineSpec{
-								Class: v1alpha1.ClassSpec{
-									Kind: "MachineClass",
-									Name: "machine-0",
-								},
-								ProviderID: "fakeID",
-							},
-						},
-						&v1alpha1.MachineStatus{
-							CurrentStatus: v1alpha1.CurrentStatus{
-								Phase:          v1alpha1.MachineTerminating,
-								LastUpdateTime: metav1.Now(),
-							},
-							LastOperation: v1alpha1.LastOperation{
-								Description:    fmt.Sprintf("VM deletion was successful. %s", machineutils.RemoveNodeFinalizers),
-								State:          v1alpha1.MachineStateProcessing,
-								Type:           v1alpha1.MachineOperationDelete,
-								LastUpdateTime: metav1.Now(),
-							},
-						},
-						nil,
-						map[string]string{
-							machineutils.MachinePriority: "3",
-						},
-						map[string]string{
-							v1alpha1.NodeLabelKey: "fakeID-0",
-						},
-						true,
-						metav1.Now(),
-					),
-					nodes: []*corev1.Node{
-						{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "fakeID-0",
-								Finalizers: []string{
-									NodeFinalizerName,
-								},
-							},
-						},
-					},
-				},
-				action: action{
-					machine: "machine-0",
-					fakeDriver: &driver.FakeDriver{
-						VMExists:   true,
-						ProviderID: "fakeID-0",
-						NodeName:   "fakeNode-0",
-						Err:        nil,
-					},
-				},
-				expect: expect{
-					err:   fmt.Errorf("machine deletion in process. Removal of finalizers from Node Object \"fakeID-0\" is successful. " + machineutils.InitiateNodeDeletion),
-					retry: machineutils.ShortRetry,
-					machine: newMachine(
-						&v1alpha1.MachineTemplateSpec{
-							ObjectMeta: *newObjectMeta(objMeta, 0),
-							Spec: v1alpha1.MachineSpec{
-								Class: v1alpha1.ClassSpec{
-									Kind: "MachineClass",
-									Name: "machine-0",
-								},
-								ProviderID: "fakeID",
-							},
-						},
-						&v1alpha1.MachineStatus{
-							CurrentStatus: v1alpha1.CurrentStatus{
-								Phase:          v1alpha1.MachineTerminating,
-								LastUpdateTime: metav1.Now(),
-							},
-							LastOperation: v1alpha1.LastOperation{
-								Description:    fmt.Sprintf("Removal of finalizers from Node Object %q is successful. %s", "fakeID-0", machineutils.InitiateNodeDeletion),
+								Description:    fmt.Sprintf("VM deletion was successful. %s", machineutils.InitiateNodeDeletion),
 								State:          v1alpha1.MachineStateProcessing,
 								Type:           v1alpha1.MachineOperationDelete,
 								LastUpdateTime: metav1.Now(),
@@ -3188,7 +3083,7 @@ var _ = Describe("machine", func() {
 								LastUpdateTime: metav1.Now(),
 							},
 							LastOperation: v1alpha1.LastOperation{
-								Description:    fmt.Sprintf("Removal of finalizers from Node Object %q is successful. %s", "fakeID-0", machineutils.InitiateNodeDeletion),
+								Description:    fmt.Sprintf("VM deletion was successful. %s", machineutils.InitiateNodeDeletion),
 								State:          v1alpha1.MachineStateProcessing,
 								Type:           v1alpha1.MachineOperationDelete,
 								LastUpdateTime: metav1.Now(),
@@ -3208,6 +3103,9 @@ var _ = Describe("machine", func() {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "fakeID-0",
+								Finalizers: []string{
+									NodeFinalizerName,
+								},
 							},
 						},
 					},
@@ -3222,7 +3120,7 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					err:         fmt.Errorf("Machine deletion in process. Deletion of node object was successful"),
+					err:         fmt.Errorf("Machine deletion in process. Deletion of Node Object %q is successful. %s", "fakeID-0", machineutils.InitiateFinalizerRemoval),
 					retry:       machineutils.ShortRetry,
 					nodeDeleted: true,
 					machine: newMachine(
@@ -3624,7 +3522,7 @@ var _ = Describe("machine", func() {
 								LastUpdateTime: metav1.Now(),
 							},
 							LastOperation: v1alpha1.LastOperation{
-								Description:    fmt.Sprintf("Label %q not present on machine %q or no associated node object found, continuing deletion flow. %s", v1alpha1.NodeLabelKey, "machine-0", machineutils.InitiateFinalizerRemoval),
+								Description:    fmt.Sprintf("Label %q not present on machine %q, continuing deletion flow. %s", v1alpha1.NodeLabelKey, "machine-0", machineutils.InitiateFinalizerRemoval),
 								State:          v1alpha1.MachineStateProcessing,
 								Type:           v1alpha1.MachineOperationDelete,
 								LastUpdateTime: metav1.Now(),

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -3502,7 +3502,7 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					err:         fmt.Errorf("machine deletion in process: no node object found"),
+					err:         fmt.Errorf("machine deletion in process: no node label found"),
 					retry:       machineutils.ShortRetry,
 					nodeDeleted: false,
 					machine: newMachine(

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -3120,7 +3120,7 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					err:         fmt.Errorf("Machine deletion in process. Deletion of Node Object %q is successful. %s", "fakeID-0", machineutils.InitiateFinalizerRemoval),
+					err:         fmt.Errorf("machine deletion in process: Deletion of Node Object %q is successful. %s", "fakeID-0", machineutils.InitiateFinalizerRemoval),
 					retry:       machineutils.ShortRetry,
 					nodeDeleted: true,
 					machine: newMachine(
@@ -3502,7 +3502,7 @@ var _ = Describe("machine", func() {
 					},
 				},
 				expect: expect{
-					err:         fmt.Errorf("Machine deletion in process. No node object found"),
+					err:         fmt.Errorf("machine deletion in process: no node object found"),
 					retry:       machineutils.ShortRetry,
 					nodeDeleted: false,
 					machine: newMachine(

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1951,7 +1951,7 @@ func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Mac
 	return c.updateStatusForNodeDeletion(ctx, machine, description, state, err)
 }
 
-func (c *controller) updateStatusForNodeDeletion(ctx context.Context, machine *v1alpha1.Machine, description string, state v1alpha1.MachineState, err error) (machineutils.RetryPeriod, error) {
+func (c *controller) updateStatusForNodeDeletion(ctx context.Context, machine *v1alpha1.Machine, description string, state v1alpha1.MachineState, retryReason error) (machineutils.RetryPeriod, error) {
 	updateRetryPeriod, updateErr := c.machineStatusUpdate(
 		ctx,
 		machine,
@@ -1972,7 +1972,7 @@ func (c *controller) updateStatusForNodeDeletion(ctx context.Context, machine *v
 		return updateRetryPeriod, updateErr
 	}
 
-	return machineutils.ShortRetry, err
+	return machineutils.ShortRetry, retryReason
 }
 
 // getEffectiveDrainTimeout returns the drainTimeout set on the machine-object, otherwise returns the timeout set using the global-flag.

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1883,60 +1883,75 @@ func (c *controller) deleteVM(ctx context.Context, deleteMachineRequest *driver.
 // deleteNodeObject attempts to remove finalizers from and delete the node object backed by the machine object
 func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Machine) (machineutils.RetryPeriod, error) {
 	var (
-		err         error
+		retryReason error
 		description string
 		state       v1alpha1.MachineState
+		node        *v1.Node
 	)
 
+	// nodeName label is expected to be present on machine object, but in case it is not present
+	// we should not block deletion of machine and should move forward with flow.
 	nodeName := machine.Labels[v1alpha1.NodeLabelKey]
-
-	if nodeName != "" {
-		var node *v1.Node
-		node, err = c.nodeLister.Get(nodeName)
-		if err != nil {
-			switch {
-			case apierrors.IsNotFound(err):
-				description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
-				klog.Warning(description)
-				state = v1alpha1.MachineStateProcessing
-			default:
-				description = fmt.Sprintf("Retrieval of Node Object %q failed due to error: %s, Retrying. %s", nodeName, err, machineutils.InitiateNodeDeletion)
-				klog.Errorf(description)
-				state = v1alpha1.MachineStateFailed
-			}
-		} else {
-			err = c.removeNodeFinalizers(ctx, node)
-			if err != nil {
-				description = fmt.Sprintf("Removal of finalizers from Node Object %q failed due to error: %s, Retrying. %s", nodeName, err, machineutils.InitiateNodeDeletion)
-				klog.Errorf(description)
-				state = v1alpha1.MachineStateFailed
-			} else {
-				// Delete node object
-				klog.V(3).Infof("Deleting node %q associated with machine %q", nodeName, machine.Name)
-				err = c.targetCoreClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-				if err != nil && !apierrors.IsNotFound(err) {
-					description = fmt.Sprintf("Deletion of Node Object %q failed due to error: %s. %s", nodeName, err, machineutils.InitiateNodeDeletion)
-					klog.Error(description)
-					state = v1alpha1.MachineStateFailed
-				} else if err == nil {
-					description = fmt.Sprintf("Deletion of Node Object %q is successful. %s", nodeName, machineutils.InitiateFinalizerRemoval)
-					klog.V(3).Info(description)
-					state = v1alpha1.MachineStateProcessing
-					err = fmt.Errorf("Machine deletion in process. %s", description)
-				} else {
-					description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
-					klog.Warning(description)
-					state = v1alpha1.MachineStateProcessing
-				}
-			}
-		}
-	} else {
+	if nodeName == "" {
 		description = fmt.Sprintf("Label %q not present on machine %q, continuing deletion flow. %s", v1alpha1.NodeLabelKey, machine.Name, machineutils.InitiateFinalizerRemoval)
 		klog.Warning(description)
 		state = v1alpha1.MachineStateProcessing
-		err = fmt.Errorf("Machine deletion in process. No node object found")
+		retryReason = errors.New("machine deletion in process: no node object found")
+
+		return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
 	}
 
+	// If node object is not found, then it could have already been deleted,
+	// therefore we should not block deletion of machine. But if error is other than NotFound,
+	// then we should retry as it could be a transient error.
+	node, retryReason = c.nodeLister.Get(nodeName)
+	if retryReason != nil {
+		switch {
+		case apierrors.IsNotFound(retryReason):
+			description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
+			klog.Warning(description)
+			state = v1alpha1.MachineStateProcessing
+		default:
+			description = fmt.Sprintf("Retrieval of Node Object %q failed due to error: %s, Retrying. %s", nodeName, retryReason, machineutils.InitiateNodeDeletion)
+			klog.Error(description)
+			state = v1alpha1.MachineStateFailed
+		}
+
+		return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
+	}
+
+	// Remove finalizers from node object before deletion.
+	klog.V(3).Infof("Removing finalizers from node %q associated with machine %q", nodeName, machine.Name)
+	retryReason = c.removeNodeFinalizers(ctx, node)
+	if retryReason != nil {
+		description = fmt.Sprintf("Removal of finalizers from Node Object %q failed due to error: %s, Retrying. %s", nodeName, retryReason, machineutils.InitiateNodeDeletion)
+		klog.Error(description)
+		state = v1alpha1.MachineStateFailed
+		return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
+	}
+
+	// Delete node object.
+	klog.V(3).Infof("Deleting node %q associated with machine %q", nodeName, machine.Name)
+	retryReason = c.targetCoreClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	switch {
+	case retryReason == nil:
+		description = fmt.Sprintf("Deletion of Node Object %q is successful. %s", nodeName, machineutils.InitiateFinalizerRemoval)
+		klog.V(3).Info(description)
+		state = v1alpha1.MachineStateProcessing
+		retryReason = fmt.Errorf("machine deletion in process: %s", description)
+	case !apierrors.IsNotFound(retryReason):
+		description = fmt.Sprintf("Deletion of Node Object %q failed due to error: %s. %s", nodeName, retryReason, machineutils.InitiateNodeDeletion)
+		klog.Error(description)
+		state = v1alpha1.MachineStateFailed
+	default:
+		description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
+		klog.Warning(description)
+		state = v1alpha1.MachineStateProcessing
+	}
+	return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
+}
+
+func (c *controller) updateStatusForNodeDeletion(ctx context.Context, machine *v1alpha1.Machine, description string, state v1alpha1.MachineState, retryReason error) (machineutils.RetryPeriod, error) {
 	updateRetryPeriod, updateErr := c.machineStatusUpdate(
 		ctx,
 		machine,
@@ -1957,7 +1972,7 @@ func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Mac
 		return updateRetryPeriod, updateErr
 	}
 
-	return machineutils.ShortRetry, err
+	return machineutils.ShortRetry, retryReason
 }
 
 // getEffectiveDrainTimeout returns the drainTimeout set on the machine-object, otherwise returns the timeout set using the global-flag.

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1832,7 +1832,7 @@ func (c *controller) deleteVM(ctx context.Context, deleteMachineRequest *driver.
 				state = v1alpha1.MachineStateFailed
 			case codes.NotFound:
 				retryRequired = machineutils.ShortRetry
-				description = fmt.Sprintf("VM not found. Continuing deletion flow. %s", machineutils.RemoveNodeFinalizers)
+				description = fmt.Sprintf("VM not found. Continuing deletion flow. %s", machineutils.InitiateNodeDeletion)
 				state = v1alpha1.MachineStateProcessing
 			default:
 				retryRequired = machineutils.LongRetry
@@ -1847,7 +1847,7 @@ func (c *controller) deleteVM(ctx context.Context, deleteMachineRequest *driver.
 
 	} else {
 		retryRequired = machineutils.ShortRetry
-		description = fmt.Sprintf("VM deletion was successful. %s", machineutils.RemoveNodeFinalizers)
+		description = fmt.Sprintf("VM deletion was successful. %s", machineutils.InitiateNodeDeletion)
 		state = v1alpha1.MachineStateProcessing
 
 		err = fmt.Errorf("Machine deletion in process. %s", description)
@@ -1880,8 +1880,8 @@ func (c *controller) deleteVM(ctx context.Context, deleteMachineRequest *driver.
 	return retryRequired, err
 }
 
-// deleteNodeFinalizers attempts to remove finalizers from the node object backed by the machine object
-func (c *controller) deleteNodeFinalizers(ctx context.Context, machine *v1alpha1.Machine) (machineutils.RetryPeriod, error) {
+// deleteNodeObject attempts to remove finalizers from and delete the node object backed by the machine object
+func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Machine) (machineutils.RetryPeriod, error) {
 	var (
 		err         error
 		description string
@@ -1893,88 +1893,51 @@ func (c *controller) deleteNodeFinalizers(ctx context.Context, machine *v1alpha1
 	if nodeName != "" {
 		var node *v1.Node
 		node, err = c.nodeLister.Get(nodeName)
+		if apierrors.IsNotFound(err) {
+			// Lister cache may be stale; confirm with API server
+			klog.V(3).Infof("Node %q not found in lister cache, attempting live fetch from API server", nodeName)
+			node, err = c.targetCoreClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+		}
 		if err != nil {
 			switch {
 			case apierrors.IsNotFound(err):
-				description = fmt.Sprintf("No node object found for %q, skipping node finalizer removal. %s", nodeName, machineutils.InitiateNodeDeletion)
+				description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
 				klog.Warning(description)
 				state = v1alpha1.MachineStateProcessing
 			default:
-				description = fmt.Sprintf("Retrieval of Node Object %q failed due to error: %s, Retrying node finalizer removal. %s", nodeName, err, machineutils.RemoveNodeFinalizers)
+				description = fmt.Sprintf("Retrieval of Node Object %q failed due to error: %s, Retrying. %s", nodeName, err, machineutils.InitiateNodeDeletion)
 				klog.Errorf(description)
 				state = v1alpha1.MachineStateFailed
 			}
 		} else {
 			err = c.removeNodeFinalizers(ctx, node)
 			if err != nil {
-				description = fmt.Sprintf("Removal of finalizers from Node Object %q failed due to error: %s, Retrying node finalizer removal. %s", nodeName, err, machineutils.RemoveNodeFinalizers)
+				description = fmt.Sprintf("Removal of finalizers from Node Object %q failed due to error: %s, Retrying. %s", nodeName, err, machineutils.InitiateNodeDeletion)
 				klog.Errorf(description)
 				state = v1alpha1.MachineStateFailed
 			} else {
-				description = fmt.Sprintf("Removal of finalizers from Node Object %q is successful. %s", nodeName, machineutils.InitiateNodeDeletion)
-				state = v1alpha1.MachineStateProcessing
-				err = fmt.Errorf("machine deletion in process. %s", description)
+				// Delete node object
+				klog.V(3).Infof("Deleting node %q associated with machine %q", nodeName, machine.Name)
+				err = c.targetCoreClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+				if err != nil && !apierrors.IsNotFound(err) {
+					description = fmt.Sprintf("Deletion of Node Object %q failed due to error: %s. %s", nodeName, err, machineutils.InitiateNodeDeletion)
+					klog.Error(description)
+					state = v1alpha1.MachineStateFailed
+				} else if err == nil {
+					description = fmt.Sprintf("Deletion of Node Object %q is successful. %s", nodeName, machineutils.InitiateFinalizerRemoval)
+					klog.V(3).Info(description)
+					state = v1alpha1.MachineStateProcessing
+					err = fmt.Errorf("Machine deletion in process. %s", description)
+				} else {
+					description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
+					klog.Warning(description)
+					state = v1alpha1.MachineStateProcessing
+				}
 			}
 		}
 	} else {
-		description = fmt.Sprintf("Label %q not present on machine %q, skipping node finalizer removal. %s", v1alpha1.NodeLabelKey, machine.Name, machineutils.InitiateNodeDeletion)
+		description = fmt.Sprintf("Label %q not present on machine %q, continuing deletion flow. %s", v1alpha1.NodeLabelKey, machine.Name, machineutils.InitiateFinalizerRemoval)
 		klog.Warning(description)
-		state = v1alpha1.MachineStateProcessing
-	}
-
-	updateRetryPeriod, updateErr := c.machineStatusUpdate(
-		ctx,
-		machine,
-		v1alpha1.LastOperation{
-			Description:    description,
-			State:          state,
-			Type:           v1alpha1.MachineOperationDelete,
-			LastUpdateTime: metav1.Now(),
-		},
-		// Let the clone.Status.CurrentStatus (LastUpdateTime) be as it was before.
-		// This helps while computing when the drain timeout to determine if force deletion is to be triggered.
-		machine.Status.CurrentStatus,
-		machine.Status.LastKnownState,
-	)
-
-	if updateErr != nil {
-		return updateRetryPeriod, updateErr
-	}
-	return machineutils.ShortRetry, err
-}
-
-// deleteNodeObject attempts to delete the node object backed by the machine object
-func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Machine) (machineutils.RetryPeriod, error) {
-	var (
-		err         error
-		description string
-		state       v1alpha1.MachineState
-	)
-
-	nodeName := machine.Labels[v1alpha1.NodeLabelKey]
-
-	if nodeName != "" {
-		// Delete node object
-		err = c.targetCoreClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
-		klog.V(3).Infof("Deleting node %q associated with machine %q", nodeName, machine.Name)
-		if err != nil && !apierrors.IsNotFound(err) {
-			// If its an error, and any other error than object not found
-			description = fmt.Sprintf("Deletion of Node Object %q failed due to error: %s. %s", nodeName, err, machineutils.InitiateNodeDeletion)
-			klog.Error(description)
-			state = v1alpha1.MachineStateFailed
-		} else if err == nil {
-			description = fmt.Sprintf("Deletion of Node Object %q is successful. %s", nodeName, machineutils.InitiateFinalizerRemoval)
-			klog.V(3).Info(description)
-			state = v1alpha1.MachineStateProcessing
-			err = fmt.Errorf("Machine deletion in process. Deletion of node object was successful")
-		} else {
-			description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
-			klog.Warning(description)
-			state = v1alpha1.MachineStateProcessing
-		}
-	} else {
-		description = fmt.Sprintf("Label %q not present on machine %q or no associated node object found, continuing deletion flow. %s", v1alpha1.NodeLabelKey, machine.Name, machineutils.InitiateFinalizerRemoval)
-		klog.Error(description)
 		state = v1alpha1.MachineStateProcessing
 		err = fmt.Errorf("Machine deletion in process. No node object found")
 	}

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1883,7 +1883,7 @@ func (c *controller) deleteVM(ctx context.Context, deleteMachineRequest *driver.
 // deleteNodeObject attempts to remove finalizers from and delete the node object backed by the machine object
 func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Machine) (machineutils.RetryPeriod, error) {
 	var (
-		retryReason error
+		err         error
 		description string
 		state       v1alpha1.MachineState
 		node        *v1.Node
@@ -1896,62 +1896,62 @@ func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Mac
 		description = fmt.Sprintf("Label %q not present on machine %q, continuing deletion flow. %s", v1alpha1.NodeLabelKey, machine.Name, machineutils.InitiateFinalizerRemoval)
 		klog.Warning(description)
 		state = v1alpha1.MachineStateProcessing
-		retryReason = errors.New("machine deletion in process: no node object found")
+		err = errors.New("machine deletion in process: no node label found")
 
-		return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
+		return c.updateStatusForNodeDeletion(ctx, machine, description, state, err)
 	}
 
-	// If node object is not found, then it could have already been deleted,
-	// therefore we should not block deletion of machine. But if error is other than NotFound,
-	// then we should retry as it could be a transient error.
-	node, retryReason = c.nodeLister.Get(nodeName)
-	if retryReason != nil {
+	node, err = c.nodeLister.Get(nodeName)
+	if err != nil {
+		// If node object is not found, then it could have already been deleted,
+		// therefore we should not block deletion of machine. But if error is other than NotFound,
+		// then we should retry as it could be a transient error.
 		switch {
-		case apierrors.IsNotFound(retryReason):
+		case apierrors.IsNotFound(err):
 			description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
 			klog.Warning(description)
 			state = v1alpha1.MachineStateProcessing
 		default:
-			description = fmt.Sprintf("Retrieval of Node Object %q failed due to error: %s, Retrying. %s", nodeName, retryReason, machineutils.InitiateNodeDeletion)
+			description = fmt.Sprintf("Retrieval of Node Object %q failed due to error: %s, Retrying. %s", nodeName, err, machineutils.InitiateNodeDeletion)
 			klog.Error(description)
 			state = v1alpha1.MachineStateFailed
 		}
 
-		return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
+		return c.updateStatusForNodeDeletion(ctx, machine, description, state, err)
 	}
 
 	// Remove finalizers from node object before deletion.
 	klog.V(3).Infof("Removing finalizers from node %q associated with machine %q", nodeName, machine.Name)
-	retryReason = c.removeNodeFinalizers(ctx, node)
-	if retryReason != nil {
-		description = fmt.Sprintf("Removal of finalizers from Node Object %q failed due to error: %s, Retrying. %s", nodeName, retryReason, machineutils.InitiateNodeDeletion)
+	err = c.removeNodeFinalizers(ctx, node)
+	if err != nil {
+		description = fmt.Sprintf("Removal of finalizers from Node Object %q failed due to error: %s, Retrying. %s", nodeName, err, machineutils.InitiateNodeDeletion)
 		klog.Error(description)
 		state = v1alpha1.MachineStateFailed
-		return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
+		return c.updateStatusForNodeDeletion(ctx, machine, description, state, err)
 	}
 
 	// Delete node object.
 	klog.V(3).Infof("Deleting node %q associated with machine %q", nodeName, machine.Name)
-	retryReason = c.targetCoreClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
+	err = c.targetCoreClient.CoreV1().Nodes().Delete(ctx, nodeName, metav1.DeleteOptions{})
 	switch {
-	case retryReason == nil:
+	case err == nil:
 		description = fmt.Sprintf("Deletion of Node Object %q is successful. %s", nodeName, machineutils.InitiateFinalizerRemoval)
 		klog.V(3).Info(description)
 		state = v1alpha1.MachineStateProcessing
-		retryReason = fmt.Errorf("machine deletion in process: %s", description)
-	case !apierrors.IsNotFound(retryReason):
-		description = fmt.Sprintf("Deletion of Node Object %q failed due to error: %s. %s", nodeName, retryReason, machineutils.InitiateNodeDeletion)
-		klog.Error(description)
-		state = v1alpha1.MachineStateFailed
-	default:
+		err = fmt.Errorf("machine deletion in process: %s", description)
+	case apierrors.IsNotFound(err):
 		description = fmt.Sprintf("No node object found for %q, continuing deletion flow. %s", nodeName, machineutils.InitiateFinalizerRemoval)
 		klog.Warning(description)
 		state = v1alpha1.MachineStateProcessing
+	default:
+		description = fmt.Sprintf("Deletion of Node Object %q failed due to error: %s. %s", nodeName, err, machineutils.InitiateNodeDeletion)
+		klog.Error(description)
+		state = v1alpha1.MachineStateFailed
 	}
-	return c.updateStatusForNodeDeletion(ctx, machine, description, state, retryReason)
+	return c.updateStatusForNodeDeletion(ctx, machine, description, state, err)
 }
 
-func (c *controller) updateStatusForNodeDeletion(ctx context.Context, machine *v1alpha1.Machine, description string, state v1alpha1.MachineState, retryReason error) (machineutils.RetryPeriod, error) {
+func (c *controller) updateStatusForNodeDeletion(ctx context.Context, machine *v1alpha1.Machine, description string, state v1alpha1.MachineState, err error) (machineutils.RetryPeriod, error) {
 	updateRetryPeriod, updateErr := c.machineStatusUpdate(
 		ctx,
 		machine,
@@ -1972,7 +1972,7 @@ func (c *controller) updateStatusForNodeDeletion(ctx context.Context, machine *v
 		return updateRetryPeriod, updateErr
 	}
 
-	return machineutils.ShortRetry, retryReason
+	return machineutils.ShortRetry, err
 }
 
 // getEffectiveDrainTimeout returns the drainTimeout set on the machine-object, otherwise returns the timeout set using the global-flag.

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -1893,11 +1893,6 @@ func (c *controller) deleteNodeObject(ctx context.Context, machine *v1alpha1.Mac
 	if nodeName != "" {
 		var node *v1.Node
 		node, err = c.nodeLister.Get(nodeName)
-		if apierrors.IsNotFound(err) {
-			// Lister cache may be stale; confirm with API server
-			klog.V(3).Infof("Node %q not found in lister cache, attempting live fetch from API server", nodeName)
-			node, err = c.targetCoreClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		}
 		if err != nil {
 			switch {
 			case apierrors.IsNotFound(err):

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -155,7 +155,8 @@ func (c *controller) reconcileClusterNodeKey(key string) error {
 
 	// Ignore node updates without an associated machine. Retry only for errors other than errNoMachineMatch;
 	// transient fetch errors will be eventually requeued by the update handler due to kubelet updates.
-	if _, err := c.getMachineFromNode(node.Name); err != nil {
+	machine, err := c.getMachineFromNode(node.Name)
+	if err != nil {
 		if errors.Is(err, errNoMachineMatch) {
 			klog.Errorf("ClusterNode %q: No machine found matching node, skipping adding finalizers", key)
 			return nil
@@ -176,11 +177,13 @@ func (c *controller) reconcileClusterNodeKey(key string) error {
 		return nil
 	}
 
-	//Add finalizers to node object if not present
-	err = c.addNodeFinalizers(ctx, node)
-	if err != nil {
-		klog.Errorf("ClusterNode %q: error adding finalizers to node: %v", key, err)
-		c.enqueueNodeAfter(node, time.Duration(machineutils.ShortRetry), err.Error())
+	if machine.DeletionTimestamp == nil { // If machine is marked for deletion, ensure node finalizers are not added
+		err = c.addNodeFinalizers(ctx, node) // Add finalizers to node object if not present
+		if err != nil {
+			klog.Errorf("ClusterNode %q: error adding finalizers to node: %v", key, err)
+			c.enqueueNodeAfter(node, time.Duration(machineutils.ShortRetry), err.Error())
+			return nil
+		}
 	}
 
 	return nil

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -99,7 +99,7 @@ func (c *controller) updateNode(oldObj, newObj any) {
 		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Conditions of node %q differ from machine status", node.Name))
 	case node.Annotations[machineutils.PreserveMachineAnnotationKey] != oldNode.Annotations[machineutils.PreserveMachineAnnotationKey]:
 		// to reconcile on change in annotations related to preservation
-		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Preserve annotations added or updated for node %q", getNodeName(machine)))
+		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Preserve annotations added or updated for node %q", node.Name))
 	}
 }
 
@@ -172,7 +172,7 @@ func (c *controller) reconcileClusterNodeKey(key string) error {
 		return nil
 	}
 
-	if machine.DeletionTimestamp == nil { // If machine is marked for deletion, ensure node finalizers are not added
+	if machine.DeletionTimestamp == nil { // Ensure node finalizers are added only for non-deleting machines
 		err = c.addNodeFinalizers(ctx, node) // Add finalizers to node object if not present
 		if err != nil {
 			klog.Errorf("ClusterNode %q: error adding finalizers to node: %v", key, err)
@@ -228,7 +228,10 @@ func (c *controller) getMachineFromNode(nodeName string) (*v1alpha1.Machine, err
 	)
 
 	selector = selector.Add(*req)
-	machines, _ := c.machineLister.List(selector)
+	machines, err := c.machineLister.List(selector)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(machines) > 1 {
 		return nil, errMultipleMachineMatch

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -77,11 +77,11 @@ func (c *controller) updateNode(oldObj, newObj any) {
 	case node.DeletionTimestamp != nil:
 		err := c.triggerMachineDeletion(context.Background(), node.Name)
 		if err != nil {
-			c.enqueueNodeAfter(node, time.Duration(machineutils.ShortRetry), fmt.Sprintf("handling node UPDATE event. Failed to trigger machine deletion for node %q, re-queuing", node.Name))
+			c.enqueueNodeAfter(node, machineutils.ShortRetry, fmt.Sprintf("handling node UPDATE event. Failed to trigger machine deletion for node %q, re-queuing", node.Name))
 		}
 		return
 	case !HasFinalizer(node, NodeFinalizerName):
-		c.enqueueNodeAfter(node, time.Duration(machineutils.MediumRetry), fmt.Sprintf("MCM finalizer missing from node %q, re-queuing", node.Name))
+		c.enqueueNodeAfter(node, machineutils.MediumRetry, fmt.Sprintf("MCM finalizer missing from node %q, re-queuing", node.Name))
 	}
 
 	isMachineCrashLooping := machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff
@@ -172,12 +172,12 @@ func (c *controller) reconcileClusterNodeKey(key string) error {
 		return nil
 	}
 
-	if machine.DeletionTimestamp == nil { // Ensure node finalizers are added only for non-deleting machines
-		err = c.addNodeFinalizers(ctx, node) // Add finalizers to node object if not present
+	// Ensure node finalizers are added only for non-deleting machines
+	if machine.DeletionTimestamp == nil {
+		err = c.addNodeFinalizers(ctx, node)
 		if err != nil {
 			klog.Errorf("ClusterNode %q: error adding finalizers to node: %v", key, err)
-			c.enqueueNodeAfter(node, time.Duration(machineutils.ShortRetry), err.Error())
-			return nil
+			return err
 		}
 	}
 	return nil
@@ -213,10 +213,10 @@ func (c *controller) enqueueNode(obj any, reason string) {
 	}
 }
 
-func (c *controller) enqueueNodeAfter(obj any, after time.Duration, reason string) {
+func (c *controller) enqueueNodeAfter(obj any, after machineutils.RetryPeriod, reason string) {
 	if key, ok := c.getKeyForObj(obj); ok {
-		klog.Infof("Adding node object to queue %q after %s, reason: %s", key, after, reason)
-		c.nodeQueue.AddAfter(key, after)
+		klog.Infof("Adding node object to queue %q after %s, reason: %s", key, time.Duration(after), reason)
+		c.nodeQueue.AddAfter(key, time.Duration(after))
 	}
 }
 

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -97,11 +97,9 @@ func (c *controller) updateNode(oldObj, newObj any) {
 	case nodeConditionsHaveChanged && !(isMachineCrashLooping || isMachineTerminating):
 		// Enqueue machine if node conditions have changed and machine is not in crashloop or terminating state
 		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Conditions of node %q differ from machine status", node.Name))
-	}
-	// to reconcile on change in annotations related to preservation
-	if node.Annotations[machineutils.PreserveMachineAnnotationKey] != oldNode.Annotations[machineutils.PreserveMachineAnnotationKey] {
+	case node.Annotations[machineutils.PreserveMachineAnnotationKey] != oldNode.Annotations[machineutils.PreserveMachineAnnotationKey]:
+		// to reconcile on change in annotations related to preservation
 		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Preserve annotations added or updated for node %q", getNodeName(machine)))
-		return
 	}
 }
 

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -10,8 +10,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/gardener/machine-controller-manager/pkg/controller/autoscaler"
 	"time"
+
+	"github.com/gardener/machine-controller-manager/pkg/controller/autoscaler"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
@@ -72,33 +73,29 @@ func (c *controller) updateNode(oldObj, newObj any) {
 	}
 
 	// delete the machine if the node is deleted
-	if node.DeletionTimestamp != nil {
+	switch {
+	case node.DeletionTimestamp != nil:
 		err := c.triggerMachineDeletion(context.Background(), node.Name)
 		if err != nil {
 			c.enqueueNodeAfter(node, time.Duration(machineutils.ShortRetry), fmt.Sprintf("handling node UPDATE event. Failed to trigger machine deletion for node %q, re-queuing", node.Name))
 		}
 		return
+	case !HasFinalizer(node, NodeFinalizerName):
+		c.enqueueNodeAfter(node, time.Duration(machineutils.MediumRetry), fmt.Sprintf("MCM finalizer missing from node %q, re-queuing", node.Name))
 	}
 
-	if !HasFinalizer(node, NodeFinalizerName) {
-		c.enqueueNodeAfter(node, time.Duration(machineutils.MediumRetry), fmt.Sprintf("MCM finalizer missing from node %q, re-queuing", node.Name))
-		return
-	}
-	// to reconcile on addition/removal of essential taints in machine lifecycle, example - critical component taint
-	if addedOrRemovedEssentialTaints(oldNode, node, machineutils.EssentialTaints) {
-		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Atleast one of essential taints on node %q has changed", getNodeName(machine)))
-		return
-	}
-	if inPlaceUpdateLabelsChanged(oldNode, node) {
-		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. in-place update label added or updated for node %q", getNodeName(machine)))
-		return
-	}
 	isMachineCrashLooping := machine.Status.CurrentStatus.Phase == v1alpha1.MachineCrashLoopBackOff
 	isMachineTerminating := machine.Status.CurrentStatus.Phase == v1alpha1.MachineTerminating
 	_, _, nodeConditionsHaveChanged := nodeConditionsHaveChanged(machine.Status.Conditions, node.Status.Conditions)
 
-	// Enqueue machine if node conditions have changed and machine is not in crashloop or terminating state
-	if nodeConditionsHaveChanged && !(isMachineCrashLooping || isMachineTerminating) {
+	// to reconcile on addition/removal of essential taints in machine lifecycle, example - critical component taint
+	switch {
+	case addedOrRemovedEssentialTaints(oldNode, node, machineutils.EssentialTaints):
+		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Atleast one of essential taints on node %q has changed", node.Name))
+	case inPlaceUpdateLabelsChanged(oldNode, node):
+		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. in-place update label added or updated for node %q", node.Name))
+	case nodeConditionsHaveChanged && !(isMachineCrashLooping || isMachineTerminating):
+		// Enqueue machine if node conditions have changed and machine is not in crashloop or terminating state
 		c.enqueueMachine(machine, fmt.Sprintf("handling node UPDATE event. Conditions of node %q differ from machine status", node.Name))
 	}
 	// to reconcile on change in annotations related to preservation
@@ -185,7 +182,6 @@ func (c *controller) reconcileClusterNodeKey(key string) error {
 			return nil
 		}
 	}
-
 	return nil
 }
 

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -38,9 +38,6 @@ const (
 	// InitiateVMDeletion specifies next step as initiate VM deletion
 	InitiateVMDeletion = "Initiate VM deletion"
 
-	//RemoveNodeFinalizers specifies next step as removing node finalizers
-	RemoveNodeFinalizers = "Remove node finalizers"
-
 	// InitiateNodeDeletion specifies next step as node object deletion
 	InitiateNodeDeletion = "Initiate node object deletion"
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Merges the separate `deleteNodeFinalizers` and `deleteNodeObject` phases into a single `deleteNodeObject` step that atomically removes the node finalizer and deletes the node object. This removes a gap in the deletion flow where the finalizer removal could be skipped while node deletion still proceeded, leaving a node stuck in terminating state.

Additionally:

- Adds a machine `DeletionTimestamp` guard in reconcileClusterNodeKey to prevent node finalizers from being re-added while the machine is being deleted.
- Refactors `updateNode` to use switch statements, removing early returns so taint/label/condition changes still trigger machine reconciliation when the finalizer is absent.

**Which issue(s) this PR fixes**:
Fixes #1080

**Special notes for your reviewer**:
<details>
<summary>IT logs</summary>

```
Random Seed: 1775816871

Will run 10 of 10 specs
------------------------------
[BeforeSuite]
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/test/integration/controller/controller_test.go:47
  > Enter [BeforeSuite] TOP-LEVEL @ 04/10/26 15:58:11.465
  STEP: Checking for the clusters if provided are available @ 04/10/26 15:58:11.465
  2026/04/10 15:58:11 Control cluster kube-config - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_control.yaml
  2026/04/10 15:58:11 Target cluster kube-config  - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_target.yaml
  STEP: Killing any existing processes @ 04/10/26 15:58:13.757
  STEP: Checking Machine-Controller-Manager repo is available at: ../../../dev/mcm @ 04/10/26 15:58:13.926
  STEP: Scaledown existing machine controllers @ 04/10/26 15:58:13.926
  STEP: Starting Machine Controller  @ 04/10/26 15:58:14.097
  STEP: Starting Machine Controller Manager @ 04/10/26 15:58:14.113
  STEP: Cleaning any old resources @ 04/10/26 15:58:14.119
  2026/04/10 15:58:14 machinedeployments.machine.sapcloud.io "test-machine-deployment" not found
  2026/04/10 15:58:14 machines.machine.sapcloud.io "test-machine" not found
  2026/04/10 15:58:14 machineclasses.machine.sapcloud.io "test-mc-v1" not found
  2026/04/10 15:58:14 machineclasses.machine.sapcloud.io "test-mc-v2" not found
  STEP: Setup MachineClass @ 04/10/26 15:58:14.798
  STEP: Looking for machineclass resource in the control cluster @ 04/10/26 15:58:15.994
  STEP: Looking for secrets refered in machineclass in the control cluster @ 04/10/26 15:58:16.181
  STEP: Initializing orphan resource tracker @ 04/10/26 15:58:16.517
  2026/04/10 15:58:20 orphan resource tracker initialized
  < Exit [BeforeSuite] TOP-LEVEL @ 04/10/26 15:58:20.46 (8.995s)
[BeforeSuite] PASSED [8.995 seconds]
------------------------------
Machine controllers test machine resource creation should not lead to any errors and add 1 more node in target cluster
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:649
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 15:58:20.46
  STEP: Checking machineController process is running @ 04/10/26 15:58:20.46
  STEP: Checking machineControllerManager process is running @ 04/10/26 15:58:20.46
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 15:58:20.46
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 15:58:21.088 (628ms)
  > Enter [It] should not lead to any errors and add 1 more node in target cluster @ 04/10/26 15:58:21.088
  STEP: Checking for errors @ 04/10/26 15:58:21.278
  STEP: Waiting until number of ready nodes is 1 more than initial nodes @ 04/10/26 15:58:21.443
  < Exit [It] should not lead to any errors and add 1 more node in target cluster @ 04/10/26 16:00:07.166 (1m46.078s)
• [106.706 seconds]
------------------------------
Machine controllers test machine resource deletion when machines available should not lead to errors and remove 1 node in target cluster
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:678
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:00:07.166
  STEP: Checking machineController process is running @ 04/10/26 16:00:07.166
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:00:07.166
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:00:07.166
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:00:07.558 (392ms)
  > Enter [It] should not lead to errors and remove 1 node in target cluster @ 04/10/26 16:00:07.558
  STEP: Checking for errors @ 04/10/26 16:00:08.389
  STEP: Waiting until test-machine machine object is deleted @ 04/10/26 16:00:08.561
  STEP: Waiting until number of ready nodes is equal to number of initial nodes @ 04/10/26 16:00:32.715
  < Exit [It] should not lead to errors and remove 1 node in target cluster @ 04/10/26 16:00:33.267 (25.709s)
• [26.101 seconds]
------------------------------
Machine controllers test machine resource deletion when machines are not available should keep nodes intact
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:717
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:00:33.267
  STEP: Checking machineController process is running @ 04/10/26 16:00:33.267
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:00:33.268
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:00:33.268
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:00:33.737 (470ms)
  > Enter [It] should keep nodes intact @ 04/10/26 16:00:33.737
  STEP: Skipping as there are machines available and this check can't be performed @ 04/10/26 16:00:34.068
  < Exit [It] should keep nodes intact @ 04/10/26 16:00:34.068 (331ms)
• [0.801 seconds]
------------------------------
Machine controllers test machine deployment resource creation with replicas=0, scale up with replicas=1 should not lead to errors and add 1 more node to target cluster
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:745
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:00:34.069
  STEP: Checking machineController process is running @ 04/10/26 16:00:34.069
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:00:34.069
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:00:34.069
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:00:34.633 (564ms)
  > Enter [It] should not lead to errors and add 1 more node to target cluster @ 04/10/26 16:00:34.633
  STEP: Checking for errors @ 04/10/26 16:00:34.818
  STEP: Waiting for Machine Set to be created @ 04/10/26 16:00:34.982
  STEP: Updating machineDeployment replicas to 1 @ 04/10/26 16:00:37.613
  STEP: Checking if machineDeployment's status has been updated with correct conditions @ 04/10/26 16:00:37.94
  STEP: Checking number of ready nodes==1 @ 04/10/26 16:02:44.31
  STEP: Fetching initial number of machineset freeze events @ 04/10/26 16:02:45.723
  < Exit [It] should not lead to errors and add 1 more node to target cluster @ 04/10/26 16:02:46.379 (2m11.743s)
• [132.308 seconds]
------------------------------
Machine controllers test machine deployment resource scale-up with replicas=6 should not lead to errors and add further 5 nodes to target cluster
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:813
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:02:46.379
  STEP: Checking machineController process is running @ 04/10/26 16:02:46.379
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:02:46.38
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:02:46.38
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:02:46.758 (379ms)
  > Enter [It] should not lead to errors and add further 5 nodes to target cluster @ 04/10/26 16:02:46.758
  STEP: Checking for errors @ 04/10/26 16:02:47.088
  STEP: Checking number of ready nodes are 6 more than initial @ 04/10/26 16:02:47.088
  < Exit [It] should not lead to errors and add further 5 nodes to target cluster @ 04/10/26 16:04:48.367 (2m1.608s)
• [121.987 seconds]
------------------------------
Machine controllers test machine deployment resource scale-down with replicas=2 should not lead to errors and remove 4 nodes from target cluster
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:843
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:04:48.367
  STEP: Checking machineController process is running @ 04/10/26 16:04:48.367
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:04:48.367
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:04:48.367
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:04:48.919 (552ms)
  > Enter [It] should not lead to errors and remove 4 nodes from target cluster @ 04/10/26 16:04:48.919
  STEP: Checking for errors @ 04/10/26 16:04:49.961
  STEP: Checking number of ready nodes are 2 more than initial @ 04/10/26 16:04:49.961
  < Exit [It] should not lead to errors and remove 4 nodes from target cluster @ 04/10/26 16:05:15.653 (26.734s)
• [27.287 seconds]
------------------------------
Machine controllers test machine deployment resource scale-down with replicas=2 should freeze and unfreeze machineset temporarily
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:872
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:05:15.654
  STEP: Checking machineController process is running @ 04/10/26 16:05:15.654
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:05:15.654
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:05:15.654
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:05:16.025 (371ms)
  > Enter [It] should freeze and unfreeze machineset temporarily @ 04/10/26 16:05:16.025
  < Exit [It] should freeze and unfreeze machineset temporarily @ 04/10/26 16:05:19.451 (3.426s)
• [3.797 seconds]
------------------------------
Machine controllers test machine deployment resource updation to v2 machine-class and replicas=4 should upgrade machines and add more nodes to target
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:881
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:05:19.451
  STEP: Checking machineController process is running @ 04/10/26 16:05:19.451
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:05:19.451
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:05:19.451
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:05:20.369 (918ms)
  > Enter [It] should upgrade machines and add more nodes to target @ 04/10/26 16:05:20.369
  STEP: Checking for errors @ 04/10/26 16:05:20.705
  STEP: UpdatedReplicas to be 4 @ 04/10/26 16:05:20.706
  STEP: AvailableReplicas to be 4 @ 04/10/26 16:05:27.431
  STEP: Number of ready nodes be 4 more @ 04/10/26 16:07:25.181
  < Exit [It] should upgrade machines and add more nodes to target @ 04/10/26 16:08:00.441 (2m40.072s)
• [160.990 seconds]
------------------------------
Machine controllers test machine deployment resource deletion When there are machine deployment(s) available in control cluster should not lead to errors and list only initial nodes
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:935
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:08:00.441
  STEP: Checking machineController process is running @ 04/10/26 16:08:00.441
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:08:00.441
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:08:00.441
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:08:00.826 (384ms)
  > Enter [It] should not lead to errors and list only initial nodes @ 04/10/26 16:08:00.826
  STEP: Checking for errors @ 04/10/26 16:08:00.986
  STEP: Waiting until number of ready nodes is equal to number of initial  nodes @ 04/10/26 16:08:01.154
  < Exit [It] should not lead to errors and list only initial nodes @ 04/10/26 16:08:32.076 (31.251s)
• [31.635 seconds]
------------------------------
Machine controllers test orphaned resources when the hyperscaler resources are queried should have been deleted
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/test/integration/common/framework.go:972
  > Enter [BeforeEach] Machine controllers test @ 04/10/26 16:08:32.076
  STEP: Checking machineController process is running @ 04/10/26 16:08:32.076
  STEP: Checking machineControllerManager process is running @ 04/10/26 16:08:32.076
  STEP: Checking nodes in target cluster are healthy @ 04/10/26 16:08:32.076
  < Exit [BeforeEach] Machine controllers test @ 04/10/26 16:08:32.465 (388ms)
  > Enter [It] should have been deleted @ 04/10/26 16:08:32.465
  STEP: Querying and comparing @ 04/10/26 16:08:32.465
The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: [vol-06c85c7307f3706f5]
NICs: [eni-047bbef8af9b80b1c]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: [vol-015a19901228e4dc1 vol-02571b17ea7739bcc vol-0163bc770ac357a04]
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []

The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
 The following resources are orphans ... trying to delete them
Virtual Machines: []
Volumes: []
NICs: [eni-0759ec8e37d1d82ce eni-017e1341458d6ed3f eni-0f52245f87975f713]
MCM Machines []
   < Exit [It] should have been deleted @ 04/10/26 16:11:17.897 (2m45.432s)
• [165.821 seconds]
------------------------------
[AfterSuite]
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/test/integration/controller/controller_test.go:49
  > Enter [AfterSuite] TOP-LEVEL @ 04/10/26 16:11:17.897
  STEP: Running Cleanup @ 04/10/26 16:11:17.897
  2026/04/10 16:11:38 machinedeployments.machine.sapcloud.io "test-machine-deployment" not found
  2026/04/10 16:11:38 machines.machine.sapcloud.io "test-machine" not found
  2026/04/10 16:11:39 deleting test-mc-v1 machineclass
  2026/04/10 16:11:39 machineclass deleted
  2026/04/10 16:11:39 deleting test-mc-v2 machineclass
  2026/04/10 16:11:40 machineclass deleted
  STEP: Killing any existing processes @ 04/10/26 16:11:40.251
  2026/04/10 16:11:40 controller_manager --control-kubeconfig=/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_control.yaml --target-kubeconfig=/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_target.yaml --namespace=shoot--i765230--demo --safety-up=2 --safety-down=1 --machine-safety-overshooting-period=300ms --leader-elect=false --v=3
  2026/04/10 16:11:40 stopMCM killed MCM process(es) with pid(s): [18738]
  2026/04/10 16:11:40 main --control-kubeconfig=/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_control.yaml --target-kubeconfig=/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_target.yaml --namespace=shoot--i765230--demo --machine-creation-timeout=20m --machine-drain-timeout=5m --machine-health-timeout=10m --machine-pv-detach-timeout=2m --machine-safety-apiserver-statuscheck-timeout=30s --machine-safety-apiserver-statuscheck-period=1m --machine-safety-orphan-vms-period=30m --leader-elect=false --v=3
  2026/04/10 16:11:40 stopMCM killed MCM process(es) with pid(s): [18743]
  2026/04/10 16:11:40 go run cmd/machine-controller/main.go --control-kubeconfig=/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_control.yaml --target-kubeconfig=/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager-provider-aws/dev/kube-configs/kubeconfig_target.yaml --namespace=shoot--i765230--demo --machine-creation-timeout=20m --machine-drain-timeout=5m --machine-health-timeout=10m --machine-pv-detach-timeout=2m --machine-safety-apiserver-statuscheck-timeout=30s --machine-safety-apiserver-statuscheck-period=1m --machine-safety-orphan-vms-period=30m --leader-elect=false --v=3
  2026/04/10 16:11:40 stopMCM killed MCM process(es) with pid(s): [18613]
  STEP: Scale back the existing machine controllers @ 04/10/26 16:11:40.424
  < Exit [AfterSuite] TOP-LEVEL @ 04/10/26 16:11:41.099 (23.202s)
[AfterSuite] PASSED [23.203 seconds]
------------------------------

Ran 10 of 10 Specs in 809.632 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 13m49.352376s
Test Suite Passed
Integration tests completed successfully
```
</details>

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Merged node finalizer removal and node object deletion into a single atomic step during machine deletion
```
