### PR TITLE
fix: typo (occured -> occurred) in machine_util comments

### DIFF
--- a/docs/development/machine_error_codes.md
+++ b/docs/development/machine_error_codes.md
@@ -392,7 +392,7 @@ A Provider can OPTIONALLY implement this driver call. Else should return a `UNIM
 This driver call will be called by the MCM to get the `VolumeIDs` for the list of `PersistentVolumes (PVs)` supplied.
 This OPTIONAL (but recommended) driver call helps in serailzied eviction of pods with PVs while draining of machines. This implies applications backed by PVs would be evicted one by one, leading to shorter application downtimes.
 
-- On succesful returnal of a list of `Volume-IDs` for all supplied `PVSpecs`, the Provider MUST reply `0 OK`.
+- On successful returnal of a list of `Volume-IDs` for all supplied `PVSpecs`, the Provider MUST reply `0 OK`.
 - The `GetVolumeIDsResponse` is expected to return a repeated list of `strings` consisting of the `VolumeIDs` for `PVSpec` that could be extracted.
 - If for any `PV` the Provider wasn't able to identify the `Volume-ID`, the provider MAY chose to ignore it and return the `Volume-IDs` for the rest of the `PVs` for whom the `Volume-ID` was found.
 - Getting the `VolumeID` from the `PVSpec` depends on the Cloud-provider. You can extract this information by parsing the `PVSpec` based on the `ProviderType`

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -905,7 +905,7 @@ func (c *controller) getCreateFailurePhase(machine *v1alpha1.Machine) v1alpha1.M
 	timeOut := metav1.Now().Add(-timeOutDuration).Sub(machine.CreationTimestamp.Time)
 
 	if timeOut > 0 {
-		// Machine creation timeout occured while joining of machine
+		// Machine creation timeout occurred while joining of machine
 		// Machine set controller would replace this machine with a new one as phase is failed.
 		klog.V(2).Infof("Machine %q , providerID %q and backing node %q couldn't join in creation timeout of %s. Changing phase to Failed.", machine.Name, getProviderID(machine), getNodeName(machine), timeOutDuration)
 		return v1alpha1.MachineFailed
@@ -1151,7 +1151,7 @@ func (c *controller) reconcileMachineHealth(ctx context.Context, machine *v1alph
 		} else {
 			// If timeout has not occurred, re-enqueue the machine
 			// after a specified sleep time
-			klog.V(4).Infof("Creation/Health Timeout hasn't occured yet , will re-enqueue after %s", time.Duration(sleepTime))
+			klog.V(4).Infof("Creation/Health Timeout hasn't occurred yet , will re-enqueue after %s", time.Duration(sleepTime))
 			c.enqueueMachineAfter(machine, sleepTime, "re-check for creation/health timeout")
 		}
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes 'occured' -> 'occurred' typo in machine_util comments (docs/development/machine_error_codes.md and pkg/util/provider/machinecontroller/machine_util.go).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
String/comment-only change, no functional impact.

**Release note**:
```other operator
NONE
```
