### PR TITLE
Fix bug where `manageMachinePreservation` uncordons nodes of `Running` Machines unconditionally

### DIFF
--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -949,7 +949,7 @@ func (c *controller) manageAutoPreservationOfFailedMachines(ctx context.Context,
 	var others []*v1alpha1.Machine
 	for _, m := range machines {
 		// check if machine is already annotated for preservation, if yes, skip. Machine controller will take care of the rest.
-		if machineutils.IsMachineFailed(m) && !machineutils.PreventAutoPreserveAnnotationValues.Has(m.Annotations[machineutils.PreserveMachineAnnotationKey]) {
+		if machineutils.IsMachineFailed(m) && !machineutils.AllowedPreserveAnnotationValues.Has(m.Annotations[machineutils.PreserveMachineAnnotationKey]) {
 			autoPreservationCandidates = append(autoPreservationCandidates, m)
 		} else {
 			others = append(others, m)

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -248,7 +248,7 @@ func (c *controller) reconcileClusterMachine(ctx context.Context, machine *v1alp
 		}
 	}
 
-	retry, err = c.manageMachinePreservation(ctx, machine)
+	retry, err = c.reconcileMachinePreservation(ctx, machine)
 	if err != nil {
 		return retry, err
 	}
@@ -744,20 +744,9 @@ func (c *controller) isCreationProcessing(machine *v1alpha1.Machine) bool {
 	Machine Preservation operations
 */
 
-// manageMachinePreservation manages machine preservation based on the preserve annotation values on the node and machine objects.
-func (c *controller) manageMachinePreservation(ctx context.Context, machine *v1alpha1.Machine) (retry machineutils.RetryPeriod, err error) {
-	machineAnnotationsSynced := false
-	clone := machine.DeepCopy()
+// reconcileMachinePreservation manages machine preservation based on the preserve annotation values on the node and machine objects.
+func (c *controller) reconcileMachinePreservation(ctx context.Context, machine *v1alpha1.Machine) (retry machineutils.RetryPeriod, err error) {
 	defer func() {
-		// This needs to be done for cases when machine is neither preserved nor un-preserved (e.g. when preserve changes from now to when-failed on a Failed machine),
-		// but the LastAppliedNodePreserveValueAnnotation needs to be synced to the machine object.
-		// We compare annotation value in the clone with the original machine object to see if an update is required
-		if err == nil && !machineAnnotationsSynced && clone.Annotations[machineutils.LastAppliedNodePreserveValueAnnotationKey] != machine.Annotations[machineutils.LastAppliedNodePreserveValueAnnotationKey] {
-			_, err = c.controlMachineClient.Machines(clone.Namespace).Update(ctx, clone, metav1.UpdateOptions{})
-			if err != nil {
-				klog.Errorf("error updating LastAppliedNodePreserveValueAnnotation value on machine %q: %v", machine.Name, err)
-			}
-		}
 		if err != nil {
 			if apierrors.IsConflict(err) {
 				retry = machineutils.ConflictRetry
@@ -768,76 +757,151 @@ func (c *controller) manageMachinePreservation(ctx context.Context, machine *v1a
 			retry = machineutils.LongRetry
 		}
 	}()
+	var machinePreserved, nodeAnnotated, machineAnnotated bool
+	var nodeAV, machineAV, nodeName string
+	var node *corev1.Node
 
-	nodeName := clone.Labels[v1alpha1.NodeLabelKey]
-	nodeAnnotationValue := ""
+	machineAV, machineAnnotated = machine.Annotations[machineutils.PreserveMachineAnnotationKey]
+
+	if machineAnnotated && !machineutils.AllowedPreserveAnnotationValues.Has(machineAV) {
+		klog.Warningf("Preserve annotation %q=%q on machine %q is invalid", machineutils.PreserveMachineAnnotationKey, machineAV, machine.Name)
+		return
+	}
+
+	nodeName = machine.Labels[v1alpha1.NodeLabelKey]
 	if nodeName != "" {
-		nodeAnnotationValue, err = c.getNodePreserveAnnotationValue(nodeName)
+		node, err = c.nodeLister.Get(nodeName)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				err = nil
+				return
+			}
+			klog.Errorf("error fetching node %q: %v", nodeName, err)
+			return
+		}
+		nodeAV, nodeAnnotated = node.Annotations[machineutils.PreserveMachineAnnotationKey]
+		if nodeAnnotated && !machineutils.AllowedPreserveAnnotationValues.Has(nodeAV) {
+			klog.Warningf("Preserve annotation %q=%q on node %q backing machine %q is invalid", machineutils.PreserveMachineAnnotationKey, nodeAV, nodeName, machine.Name)
 			return
 		}
 	}
-	var effectivePreserveValue string
-	effectivePreserveValue, clone.Annotations = getEffectivePreservationAnnotations(nodeAnnotationValue, clone.Annotations)
-	if !machineutils.AllowedPreserveAnnotationValues.Has(effectivePreserveValue) {
-		if effectivePreserveValue == nodeAnnotationValue {
-			klog.Warningf("Preserve annotation value %q on node %q is invalid", effectivePreserveValue, nodeName)
-		} else {
-			klog.Warningf("Preserve annotation value %q on machine %q is invalid", effectivePreserveValue, clone.Name)
-		}
+	lastAppliedNodeAV := machine.Annotations[machineutils.LastAppliedNodePreserveValueAnnotationKey]
+
+	machinePreserved = machine.Status.CurrentStatus.PreserveExpiryTime != nil
+
+	// if machine/node is neither preserved, nor annotated, then this machine need not be considered in the
+	// preservation flow
+	if !machinePreserved && (!nodeAnnotated && !machineAnnotated && lastAppliedNodeAV == "") {
 		return
 	}
-	switch effectivePreserveValue {
-	case "", machineutils.PreserveMachineAnnotationValueFalse:
-		machineAnnotationsSynced, err = c.stopPreservationIfActive(ctx, clone, false)
+	effectiveAV := getEffectivePreservationAnnotations(machineAV, nodeAV, lastAppliedNodeAV)
+	preserveInfo := preserveAnnotationInfo{
+		nodeAnnotated:        nodeAnnotated,
+		machineAnnotated:     machineAnnotated,
+		lastAppliedNodeValue: lastAppliedNodeAV,
+		effectiveValue:       effectiveAV,
+		nodeValue:            nodeAV,
+		machineValue:         machineAV,
+	}
+	err = c.manageMachinePreservation(ctx, machine, &preserveInfo)
+	return
+}
+
+func (c *controller) manageMachinePreservation(ctx context.Context, machine *v1alpha1.Machine, preserveInfo *preserveAnnotationInfo) error {
+	var removeAnnotations bool
+	var updatedMachine *v1alpha1.Machine
+	var err error
+	clone := machine.DeepCopy()
+	switch preserveInfo.effectiveValue {
+	case machineutils.PreserveMachineAnnotationValueFalse, "":
+		updatedMachine, err = c.stopPreservationIfActive(ctx, clone, removeAnnotations)
 	case machineutils.PreserveMachineAnnotationValueWhenFailed:
 		// on timing out, remove preserve annotation to prevent incorrect re-preservation
 		if machineutils.IsMachinePreservationExpired(clone) {
-			machineAnnotationsSynced, err = c.stopPreservationIfActive(ctx, clone, true)
+			removeAnnotations = true
+			updatedMachine, err = c.stopPreservationIfActive(ctx, clone, removeAnnotations)
 		} else if !machineutils.IsMachineFailed(clone) {
-			machineAnnotationsSynced, err = c.stopPreservationIfActive(ctx, clone, false)
+			updatedMachine, err = c.stopPreservationIfActive(ctx, clone, removeAnnotations)
 		} else {
-			err = c.preserveMachine(ctx, clone, effectivePreserveValue)
+			updatedMachine, err = c.preserveMachine(ctx, clone, preserveInfo.effectiveValue)
 		}
 	case machineutils.PreserveMachineAnnotationValueNow:
 		if machineutils.IsMachinePreservationExpired(clone) {
 			// on timing out, remove preserve annotation to prevent incorrect re-preservation
-			machineAnnotationsSynced, err = c.stopPreservationIfActive(ctx, clone, true)
+			removeAnnotations = true
+			updatedMachine, err = c.stopPreservationIfActive(ctx, clone, removeAnnotations)
 		} else {
-			err = c.preserveMachine(ctx, clone, effectivePreserveValue)
+			updatedMachine, err = c.preserveMachine(ctx, clone, preserveInfo.effectiveValue)
 		}
 	case machineutils.PreserveMachineAnnotationValuePreservedByMCM:
 		if !machineutils.IsMachineFailed(clone) || machineutils.IsMachinePreservationExpired(clone) {
 			// To prevent incorrect re-preservation of a recovered, previously auto-preserved machine on future failures
 			// (since the autoPreserveFailedMachineCount maintained by the machineSetController, may have changed),
 			// in addition to stopping preservation, we also remove the preservation annotation on the machine.
-			machineAnnotationsSynced, err = c.stopPreservationIfActive(ctx, clone, true)
+			removeAnnotations = true
+			updatedMachine, err = c.stopPreservationIfActive(ctx, clone, removeAnnotations)
 		} else {
-			err = c.preserveMachine(ctx, clone, effectivePreserveValue)
+			updatedMachine, err = c.preserveMachine(ctx, clone, preserveInfo.effectiveValue)
 		}
 	}
 	if err != nil {
-		return
+		return err
 	}
-	// This is to handle the case where a preserved machine recovers from Failed to Running
-	// in which case, pods should be allowed to be scheduled onto the node
-	if machineutils.IsMachineActive(clone) && nodeName != "" {
-		err = c.uncordonNodeIfCordoned(ctx, nodeName)
+	if shouldAnnotationsBeUpdatedOnMachine(removeAnnotations, preserveInfo) {
+		err = c.updatePreserveAnnotationOnMachine(ctx, preserveInfo.nodeValue, updatedMachine)
 	}
-	return
+	return err
 }
 
-// getEffectivePreservationAnnotations returns the effective preservation value, and updates the machine Annotations related to preservation
-func getEffectivePreservationAnnotations(nodeAnnotationValue string, machineAnnotations map[string]string) (string, map[string]string) {
-	// If there is no active node annotation AND no previously-applied node annotation,
-	// enforce machine's preserve annotation.
-	// Otherwise, the node annotation takes precedence (even if now empty/removed).
-	if nodeAnnotationValue == "" && machineAnnotations[machineutils.LastAppliedNodePreserveValueAnnotationKey] == "" {
-		return machineAnnotations[machineutils.PreserveMachineAnnotationKey], machineAnnotations
+// shouldAnnotationsBeUpdatedOnMachine returns true when the machine's annotation tracking needs
+// to be synced after a preservation action.
+func shouldAnnotationsBeUpdatedOnMachine(removeAnnotations bool, preserveInfo *preserveAnnotationInfo) bool {
+	// annotations were already removed by stopPreservationIfActive — nothing left to sync
+	if removeAnnotations {
+		return false
 	}
-	clonedMachineAnnotations := make(map[string]string)
-	maps.Copy(clonedMachineAnnotations, machineAnnotations)
-	delete(clonedMachineAnnotations, machineutils.PreserveMachineAnnotationKey)
-	clonedMachineAnnotations[machineutils.LastAppliedNodePreserveValueAnnotationKey] = nodeAnnotationValue
-	return nodeAnnotationValue, clonedMachineAnnotations
+	// node annotation is not in control — machine annotation prevails, no sync needed
+	if !preserveInfo.nodeAnnotated && preserveInfo.lastAppliedNodeValue == "" {
+		return false
+	}
+	// node value is unchanged and machine has no annotation to clear — nothing has changed
+	if preserveInfo.nodeValue == preserveInfo.lastAppliedNodeValue && !preserveInfo.machineAnnotated {
+		return false
+	}
+	return true
+}
+
+// updatePreserveAnnotationOnMachine clears the machine's PreserveMachineAnnotationKey and sets
+// LastAppliedNodePreserveValueAnnotationKey to nodeValue.
+func (c *controller) updatePreserveAnnotationOnMachine(ctx context.Context, nodeValue string, machine *v1alpha1.Machine) error {
+	clone := machine.DeepCopy()
+	if clone.Annotations == nil {
+		clone.Annotations = make(map[string]string)
+	} else {
+		delete(clone.Annotations, machineutils.PreserveMachineAnnotationKey)
+	}
+	clone.Annotations[machineutils.LastAppliedNodePreserveValueAnnotationKey] = nodeValue
+	_, err := c.controlMachineClient.Machines(clone.Namespace).Update(ctx, clone, metav1.UpdateOptions{})
+	return err
+}
+
+// getEffectivePreservationAnnotations returns the effective preservation value.
+//
+// If there is no active node annotation AND no previously-applied node annotation,
+// enforce machine's preserve annotation.
+// Otherwise, the node annotation takes precedence (even if now empty/removed).
+//
+// This is required to handle the following scenario:
+//
+//	T1: Node and Machine both have the same annotation with the same value. (MCM is up and running).
+//	T2 (T2 > T1): MCM went down.
+//	T3 (T3 > T2): Node annotation was removed.
+//	T4 (T4 > T3): MCM came back up.
+//	At T4 it sees a Node with no preserve annotation but a Machine with a preserve annotation.
+//	It continues to preserve the machine.
+func getEffectivePreservationAnnotations(machineVal, nodeVal, lastAppliedNodeVal string) string {
+	if nodeVal == "" && lastAppliedNodeVal == "" {
+		return machineVal
+	}
+	return nodeVal
 }

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -3956,151 +3956,457 @@ var _ = Describe("machine", func() {
 		)
 	})
 	Describe("#getEffectivePreservationAnnotations", func() {
-		type setup struct {
-			nodeAnnotationValue string
-			machineAnnotations  map[string]string
-		}
-		type expect struct {
-			effectivePreserveValue string
-			machineAnnotations     map[string]string
+		type testCase struct {
+			machineVal         string
+			nodeVal            string
+			lastAppliedNodeVal string
+			expectedResult     string
 		}
 
+		DescribeTable("getEffectivePreservationAnnotations scenarios",
+			func(tc testCase) {
+				result := getEffectivePreservationAnnotations(tc.machineVal, tc.nodeVal, tc.lastAppliedNodeVal)
+				Expect(result).To(Equal(tc.expectedResult))
+			},
+			Entry("when nodeVal and lastAppliedNodeVal are empty, should return machineVal", testCase{
+				machineVal:         "now",
+				nodeVal:            "",
+				lastAppliedNodeVal: "",
+				expectedResult:     "now",
+			}),
+			Entry("when nodeVal and lastAppliedNodeVal are empty and machineVal is also empty, should return empty", testCase{
+				machineVal:         "",
+				nodeVal:            "",
+				lastAppliedNodeVal: "",
+				expectedResult:     "",
+			}),
+			Entry("when nodeVal is set, should return nodeVal regardless of machineVal", testCase{
+				machineVal:         "when-failed",
+				nodeVal:            "now",
+				lastAppliedNodeVal: "",
+				expectedResult:     "now",
+			}),
+			Entry("when nodeVal is empty but lastAppliedNodeVal is set, should return nodeVal (empty) to honour node precedence", testCase{
+				machineVal:         "now",
+				nodeVal:            "",
+				lastAppliedNodeVal: "now",
+				expectedResult:     "",
+			}),
+			Entry("when nodeVal and lastAppliedNodeVal are both set, should return nodeVal", testCase{
+				machineVal:         "when-failed",
+				nodeVal:            "now",
+				lastAppliedNodeVal: "when-failed",
+				expectedResult:     "now",
+			}),
+		)
+	})
+	Describe("#reconcilePreservation", func() {
+		type setup struct {
+			machineAnnotationValue string
+			machinePhase           v1alpha1.MachinePhase
+			preserveExpiryTime     *metav1.Time
+			nodeName               string
+			nodeUnschedulable      bool
+		}
+		type expect struct {
+			preserveExpiryTimeIsSet bool
+			nodeCondition           *corev1.NodeCondition
+			machineAnnotationValue  string
+			nodeUnschedulable       bool
+		}
 		type testCase struct {
 			setup  setup
 			expect expect
 		}
 
-		DescribeTable("getEffectivePreservationAnnotations scenarios",
+		DescribeTable("reconcilePreservation matrix scenarios",
 			func(tc testCase) {
+				stop := make(chan struct{})
+				defer close(stop)
 
-				preserveValue, updatedMachineAnnotations := getEffectivePreservationAnnotations(tc.setup.nodeAnnotationValue, tc.setup.machineAnnotations)
-				Expect(preserveValue).To(Equal(tc.expect.effectivePreserveValue))
-				Expect(updatedMachineAnnotations[machineutils.PreserveMachineAnnotationKey]).To(Equal(tc.expect.machineAnnotations[machineutils.PreserveMachineAnnotationKey]))
-				Expect(updatedMachineAnnotations[machineutils.LastAppliedNodePreserveValueAnnotationKey]).To(Equal(tc.expect.machineAnnotations[machineutils.LastAppliedNodePreserveValueAnnotationKey]))
+				machine := &v1alpha1.Machine{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      "m1",
+						Labels:    map[string]string{v1alpha1.NodeLabelKey: tc.setup.nodeName},
+						Annotations: map[string]string{
+							machineutils.PreserveMachineAnnotationKey: tc.setup.machineAnnotationValue,
+						},
+					},
+					Status: v1alpha1.MachineStatus{
+						CurrentStatus: v1alpha1.CurrentStatus{
+							Phase:              tc.setup.machinePhase,
+							LastUpdateTime:     metav1.Now(),
+							PreserveExpiryTime: tc.setup.preserveExpiryTime,
+						},
+					},
+				}
+
+				var targetCoreObjects []runtime.Object
+				if tc.setup.nodeName != "" {
+					targetCoreObjects = append(targetCoreObjects, &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{Name: tc.setup.nodeName},
+						Spec:       corev1.NodeSpec{Unschedulable: tc.setup.nodeUnschedulable},
+						Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{}},
+					})
+				}
+
+				c, trackers := createController(stop, testNamespace, []runtime.Object{machine}, nil, targetCoreObjects, nil, false)
+				defer trackers.Stop()
+				waitForCacheSync(stop, c)
+
+				preserveInfo := &preserveAnnotationInfo{
+					machineAnnotated: true,
+					machineValue:     tc.setup.machineAnnotationValue,
+					effectiveValue:   tc.setup.machineAnnotationValue,
+				}
+
+				err := c.manageMachinePreservation(context.TODO(), machine, preserveInfo)
+
+				Expect(err).ToNot(HaveOccurred())
+
+				updatedMachine, err := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				if tc.expect.preserveExpiryTimeIsSet {
+					Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeFalse())
+				} else {
+					Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeTrue())
+				}
+				Expect(updatedMachine.Annotations[machineutils.PreserveMachineAnnotationKey]).To(Equal(tc.expect.machineAnnotationValue))
+
+				if tc.setup.nodeName != "" {
+					updatedNode, err := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), tc.setup.nodeName, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedNode.Spec.Unschedulable).To(Equal(tc.expect.nodeUnschedulable))
+					found := false
+					for _, cond := range updatedNode.Status.Conditions {
+						if cond.Type == v1alpha1.NodePreserved {
+							found = true
+							Expect(cond.Status).To(Equal(tc.expect.nodeCondition.Status))
+							break
+						}
+					}
+					if tc.expect.nodeCondition != nil {
+						Expect(found).To(BeTrue())
+					} else {
+						Expect(found).To(BeFalse())
+					}
+				}
 			},
-			Entry("when node is not annotated and laNodeAnnotationValue is empty, should return machine's annotation value and empty string", testCase{
+			Entry("when machine is preserved with when-failed and transitions to Running, should stop preservation and uncordon node", testCase{
 				setup: setup{
-					nodeAnnotationValue: "",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "A",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "",
-					},
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					machinePhase:           v1alpha1.MachineRunning,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeName:               "node-1",
+					nodeUnschedulable:      true,
 				},
 				expect: expect{
-					effectivePreserveValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "A",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "",
-					},
+					preserveExpiryTimeIsSet: false,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionFalse},
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueWhenFailed,
+					nodeUnschedulable:       false,
 				},
 			}),
-			Entry("when neither node nor machine is not annotated and laNodeAnnotationValue is empty, should return two empty strings", testCase{
+			Entry("when machine is preserved with when-failed, preservation expires, and machine is Running, should stop preservation, remove annotations, and uncordon node", testCase{
 				setup: setup{
-					nodeAnnotationValue: "",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "",
-					},
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					machinePhase:           v1alpha1.MachineRunning,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(-1 * time.Minute)},
+					nodeName:               "node-1",
+					nodeUnschedulable:      true,
 				},
 				expect: expect{
-					effectivePreserveValue: "",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "",
-					},
+					preserveExpiryTimeIsSet: false,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionFalse},
+					machineAnnotationValue:  "",
+					nodeUnschedulable:       false,
 				},
 			}),
-			Entry("when neither node nor machine is annotated and laNodeAnnotationValue is \"A\", should return two empty strings", testCase{
+			Entry("when machine is not yet preserved with when-failed and is Failed, should start preservation and drain node", testCase{
 				setup: setup{
-					nodeAnnotationValue: "",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "A",
-					},
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					machinePhase:           v1alpha1.MachineFailed,
+					nodeName:               "node-1",
 				},
 				expect: expect{
-					effectivePreserveValue: "",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "",
-					},
+					preserveExpiryTimeIsSet: true,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionTrue},
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueWhenFailed,
+					nodeUnschedulable:       true,
 				},
 			}),
-			Entry("when node is annotated, laNodeAnnotationValue is empty, and machine is not annotated, should return node's annotation value as effective value and last applied value", testCase{
+			Entry("when machine is not yet preserved with auto-preserve and is Failed, should start preservation and drain node", testCase{
 				setup: setup{
-					nodeAnnotationValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "",
-					},
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValuePreservedByMCM,
+					machinePhase:           v1alpha1.MachineFailed,
+					nodeName:               "node-1",
 				},
 				expect: expect{
-					effectivePreserveValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "A",
-					},
+					preserveExpiryTimeIsSet: true,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionTrue},
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValuePreservedByMCM,
+					nodeUnschedulable:       true,
 				},
 			}),
-			Entry("when node is annotated, laNodeAnnotationValue is empty, and machine is annotated differently, should return node's annotation value as effective value and last applied value", testCase{
+			Entry("when machine is preserved with auto-preserve, preservation expires, and machine is Failed, should stop preservation and remove annotations", testCase{
 				setup: setup{
-					nodeAnnotationValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "B",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "",
-					},
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValuePreservedByMCM,
+					machinePhase:           v1alpha1.MachineFailed,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(-1 * time.Minute)},
+					nodeName:               "node-1",
+					nodeUnschedulable:      true,
 				},
 				expect: expect{
-					effectivePreserveValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "A",
-					},
+					preserveExpiryTimeIsSet: false,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionFalse},
+					machineAnnotationValue:  "",
+					nodeUnschedulable:       true,
 				},
 			}),
-			Entry("when node, machine annotation values and laNodeAnnotationValue are the same, should return node's annotation value as effective value and last applied value", testCase{
+			Entry("when machine is preserved with auto-preserve, preservation expires, and machine is Running, should stop preservation, remove annotations, and uncordon node", testCase{
 				setup: setup{
-					nodeAnnotationValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "A",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "A",
-					},
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValuePreservedByMCM,
+					machinePhase:           v1alpha1.MachineRunning,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(-1 * time.Minute)},
+					nodeName:               "node-1",
+					nodeUnschedulable:      true,
 				},
 				expect: expect{
-					effectivePreserveValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "A",
-					},
-				},
-			}),
-			Entry("when node, machine annotation values are the same and laNodeAnnotationValue differs, should return node's annotation value as effective value and last applied value", testCase{
-				setup: setup{
-					nodeAnnotationValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "A",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "B",
-					},
-				},
-				expect: expect{
-					effectivePreserveValue: "A",
-					machineAnnotations: map[string]string{
-						machineutils.PreserveMachineAnnotationKey:              "",
-						machineutils.LastAppliedNodePreserveValueAnnotationKey: "A",
-					},
+					preserveExpiryTimeIsSet: false,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionFalse},
+					machineAnnotationValue:  "",
+					nodeUnschedulable:       false,
 				},
 			}),
 		)
 
+		It("when clearMachinePreserveExpiryTime fails, node is uncordoned but PreserveExpiryTime is not cleared, and the second reconcile completes stop-preservation", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+
+			machine := &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      "m1",
+					Labels:    map[string]string{v1alpha1.NodeLabelKey: "node-1"},
+					Annotations: map[string]string{
+						machineutils.PreserveMachineAnnotationKey: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					},
+				},
+				Status: v1alpha1.MachineStatus{
+					CurrentStatus: v1alpha1.CurrentStatus{
+						Phase:              v1alpha1.MachineRunning,
+						LastUpdateTime:     metav1.Now(),
+						PreserveExpiryTime: &metav1.Time{Time: metav1.Now().Add(-1 * time.Minute)},
+					},
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+				Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{}},
+			}
+			c, trackers := createController(stop, testNamespace, []runtime.Object{machine}, nil, []runtime.Object{node}, nil, false)
+			defer trackers.Stop()
+			waitForCacheSync(stop, c)
+
+			// fail the first UpdateStatus on machine (clearMachinePreserveExpiryTime)
+			callCount := 0
+			c.controlMachineClient.(*fakemachineapi.FakeMachineV1alpha1).Fake.PrependReactor("update", "machines", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if action.(k8stesting.UpdateAction).GetSubresource() == "status" {
+					callCount++
+					if callCount == 1 {
+						return true, nil, fmt.Errorf("injected UpdateStatus failure")
+					}
+				}
+				return false, nil, nil
+			})
+
+			// first reconcile: uncordon succeeds, but PreserveExpiryTime not cleared
+			retry, err := c.reconcileMachinePreservation(context.TODO(), machine)
+			Expect(err).To(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.ShortRetry))
+
+			updatedMachine, err := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// PreserveExpiryTime still set — not cleared
+			Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeFalse())
+			updatedNode, err := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), "node-1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// node was uncordoned before the expiry-time clear failed
+			Expect(updatedNode.Spec.Unschedulable).To(BeFalse())
+
+			// second reconcile: should complete successfully
+			retry, err = c.reconcileMachinePreservation(context.TODO(), updatedMachine)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.LongRetry))
+
+			updatedMachine, err = c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeTrue())
+			updatedNode, err = c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), "node-1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// node remains uncordoned
+			Expect(updatedNode.Spec.Unschedulable).To(BeFalse())
+		})
+
+		It("when removePreserveAnnotationOnMachine fails, node should not be uncordoned and machine annotation should not be deleted, and the second reconcile should complete stop-preservation", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+
+			machine := &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      "m1",
+					Labels:    map[string]string{v1alpha1.NodeLabelKey: "node-1"},
+					Annotations: map[string]string{
+						machineutils.PreserveMachineAnnotationKey: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					},
+				},
+				Status: v1alpha1.MachineStatus{
+					CurrentStatus: v1alpha1.CurrentStatus{
+						Phase:              v1alpha1.MachineFailed,
+						LastUpdateTime:     metav1.Now(),
+						PreserveExpiryTime: &metav1.Time{Time: metav1.Now().Add(-1 * time.Minute)},
+					},
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+				Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{}},
+			}
+			c, trackers := createController(stop, testNamespace, []runtime.Object{machine}, nil, []runtime.Object{node}, nil, false)
+			defer trackers.Stop()
+			waitForCacheSync(stop, c)
+
+			// fail the first metadata Update on machine (removePreserveAnnotationOnMachine)
+			callCount := 0
+			c.controlMachineClient.(*fakemachineapi.FakeMachineV1alpha1).Fake.PrependReactor("update", "machines", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if action.(k8stesting.UpdateAction).GetSubresource() == "" {
+					callCount++
+					if callCount == 1 {
+						return true, nil, fmt.Errorf("injected Update failure")
+					}
+				}
+				return false, nil, nil
+			})
+
+			// first reconcile: NodePreserved=False written, but removePreserveAnnotationOnMachine fails
+			retry, err := c.reconcileMachinePreservation(context.TODO(), machine)
+			Expect(err).To(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.ShortRetry))
+
+			updatedMachine, err := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// annotation must not have been deleted
+			Expect(updatedMachine.Annotations[machineutils.PreserveMachineAnnotationKey]).ToNot(BeEmpty())
+			// PreserveExpiryTime still set
+			Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeFalse())
+			updatedNode, err := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), "node-1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// node must NOT have been uncordoned
+			Expect(updatedNode.Spec.Unschedulable).To(BeTrue())
+
+			// second reconcile: should complete fully
+			retry, err = c.reconcileMachinePreservation(context.TODO(), updatedMachine)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.LongRetry))
+
+			updatedMachine, err = c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedMachine.Annotations[machineutils.PreserveMachineAnnotationKey]).To(BeEmpty())
+			Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeTrue())
+			updatedNode, err = c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), "node-1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// phase is Failed — node must NOT be uncordoned
+			Expect(updatedNode.Spec.Unschedulable).To(BeTrue())
+		})
+
+		It("when AddOrUpdateConditionsOnNode fails, node should not be uncordoned and machine state should be unchanged, and the second reconcile should complete stop-preservation", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+
+			machine := &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      "m1",
+					Labels:    map[string]string{v1alpha1.NodeLabelKey: "node-1"},
+					Annotations: map[string]string{
+						machineutils.PreserveMachineAnnotationKey:              machineutils.PreserveMachineAnnotationValueNow,
+						machineutils.LastAppliedNodePreserveValueAnnotationKey: machineutils.PreserveMachineAnnotationValueNow,
+					},
+				},
+				Status: v1alpha1.MachineStatus{
+					CurrentStatus: v1alpha1.CurrentStatus{
+						Phase:              v1alpha1.MachineRunning,
+						LastUpdateTime:     metav1.Now(),
+						PreserveExpiryTime: &metav1.Time{Time: metav1.Now().Add(-1 * time.Minute)},
+					},
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+				Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{}},
+			}
+			c, trackers := createController(stop, testNamespace, []runtime.Object{machine}, nil, []runtime.Object{node}, nil, false)
+			defer trackers.Stop()
+			waitForCacheSync(stop, c)
+
+			// fail the first node UpdateStatus (AddOrUpdateConditionsOnNode)
+			callCount := 0
+			c.targetCoreClient.(*customfake.Clientset).Fake.PrependReactor("update", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				if action.(k8stesting.UpdateAction).GetSubresource() == "status" {
+					callCount++
+					if callCount == 1 {
+						return true, nil, fmt.Errorf("injected node UpdateStatus failure")
+					}
+				}
+				return false, nil, nil
+			})
+
+			// first reconcile: nothing written — all state unchanged
+			retry, err := c.reconcileMachinePreservation(context.TODO(), machine)
+			Expect(err).To(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.ShortRetry))
+
+			updatedMachine, err := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeFalse())
+			Expect(updatedMachine.Annotations[machineutils.PreserveMachineAnnotationKey]).ToNot(BeEmpty())
+			updatedNode, err := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), "node-1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedNode.Status.Conditions).To(BeEmpty())
+			// node must NOT have been uncordoned
+			Expect(updatedNode.Spec.Unschedulable).To(BeTrue())
+
+			// second reconcile: should complete fully
+			retry, err = c.reconcileMachinePreservation(context.TODO(), updatedMachine)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.LongRetry))
+
+			updatedMachine, err = c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeTrue())
+			updatedNode, err = c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), "node-1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			// Running machine — node should be uncordoned after preservation fully stopped
+			Expect(updatedNode.Spec.Unschedulable).To(BeFalse())
+		})
 	})
-	Describe("#manageMachinePreservation", func() {
+	Describe("#reconcileMachinePreservation", func() {
 		type setup struct {
+			machineAnnotated       bool
 			machineAnnotationValue string
+			nodeAnnotated          bool
 			nodeAnnotationValue    string
 			laNodePreserveValue    string
 			nodeName               string
 			machinePhase           v1alpha1.MachinePhase
 			preserveExpiryTime     *metav1.Time
+			nodeUnschedulable      bool
 		}
 		type expect struct {
 			retry                   machineutils.RetryPeriod
@@ -4109,13 +4415,14 @@ var _ = Describe("machine", func() {
 			machineAnnotationValue  string
 			laNodePreserveValue     string
 			err                     error
+			nodeUnschedulable       bool
 		}
 		type testCase struct {
 			setup  setup
 			expect expect
 		}
 
-		DescribeTable("manageMachinePreservation behavior scenarios",
+		DescribeTable("reconcileMachinePreservation behavior scenarios",
 			func(tc testCase) {
 
 				stop := make(chan struct{})
@@ -4125,6 +4432,13 @@ var _ = Describe("machine", func() {
 				var targetCoreObjects []runtime.Object
 
 				// Build machine
+				machineAnnotations := map[string]string{}
+				if tc.setup.machineAnnotated {
+					machineAnnotations[machineutils.PreserveMachineAnnotationKey] = tc.setup.machineAnnotationValue
+				}
+				if tc.setup.laNodePreserveValue != "" {
+					machineAnnotations[machineutils.LastAppliedNodePreserveValueAnnotationKey] = tc.setup.laNodePreserveValue
+				}
 				machine := &v1alpha1.Machine{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNamespace,
@@ -4132,10 +4446,7 @@ var _ = Describe("machine", func() {
 						Labels: map[string]string{
 							v1alpha1.NodeLabelKey: tc.setup.nodeName,
 						},
-						Annotations: map[string]string{
-							machineutils.PreserveMachineAnnotationKey:              tc.setup.machineAnnotationValue,
-							machineutils.LastAppliedNodePreserveValueAnnotationKey: tc.setup.laNodePreserveValue,
-						},
+						Annotations: machineAnnotations,
 					}, Status: v1alpha1.MachineStatus{
 						CurrentStatus: v1alpha1.CurrentStatus{
 							Phase:              tc.setup.machinePhase,
@@ -4147,12 +4458,17 @@ var _ = Describe("machine", func() {
 
 				controlMachineObjects = append(controlMachineObjects, machine)
 				if tc.setup.nodeName != "" && tc.setup.nodeName != "invalid" {
+					nodeAnnotations := map[string]string{}
+					if tc.setup.nodeAnnotated {
+						nodeAnnotations[machineutils.PreserveMachineAnnotationKey] = tc.setup.nodeAnnotationValue
+					}
 					node := &corev1.Node{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: tc.setup.nodeName,
-							Annotations: map[string]string{
-								machineutils.PreserveMachineAnnotationKey: tc.setup.nodeAnnotationValue,
-							},
+							Name:        tc.setup.nodeName,
+							Annotations: nodeAnnotations,
+						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: tc.setup.nodeUnschedulable,
 						},
 						Status: corev1.NodeStatus{
 							Conditions: []corev1.NodeCondition{},
@@ -4163,7 +4479,7 @@ var _ = Describe("machine", func() {
 				c, trackers := createController(stop, testNamespace, controlMachineObjects, nil, targetCoreObjects, nil, false)
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				retry, err := c.manageMachinePreservation(context.TODO(), machine)
+				retry, err := c.reconcileMachinePreservation(context.TODO(), machine)
 
 				Expect(retry).To(Equal(tc.expect.retry))
 				if tc.expect.err != nil {
@@ -4180,7 +4496,7 @@ var _ = Describe("machine", func() {
 				} else {
 					Expect(updatedMachine.Status.CurrentStatus.PreserveExpiryTime.IsZero()).To(BeTrue())
 				}
-				if tc.setup.nodeName != "" {
+				if tc.setup.nodeName != "" && tc.setup.nodeName != "invalid" {
 					updatedNode, err := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), tc.setup.nodeName, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					found := false
@@ -4198,6 +4514,7 @@ var _ = Describe("machine", func() {
 					} else {
 						Expect(found).To(BeFalse())
 					}
+					Expect(updatedNode.Spec.Unschedulable).To(Equal(tc.expect.nodeUnschedulable))
 				}
 				Expect(updatedMachine.Annotations[machineutils.PreserveMachineAnnotationKey]).To(Equal(tc.expect.machineAnnotationValue))
 				Expect(updatedMachine.Annotations[machineutils.LastAppliedNodePreserveValueAnnotationKey]).To(Equal(tc.expect.laNodePreserveValue))
@@ -4214,6 +4531,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when preserve annotation 'now' is added to node of Running machine, should successfully start preservation", testCase{
 				setup: setup{
+					nodeAnnotated:       true,
 					nodeAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
 					nodeName:            "node-1",
 					machinePhase:        v1alpha1.MachineRunning,
@@ -4229,6 +4547,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when preserve annotation 'when-failed' added to node of Running machine, should not start preservation", testCase{
 				setup: setup{
+					nodeAnnotated:       true,
 					nodeAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
 					nodeName:            "node-1",
 					machinePhase:        v1alpha1.MachineRunning,
@@ -4242,6 +4561,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when node of Failed machine has annotation `when-failed`, should start preservation", testCase{
 				setup: setup{
+					nodeAnnotated:       true,
 					nodeAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
 					nodeName:            "node-1",
 					machinePhase:        v1alpha1.MachineFailed,
@@ -4252,11 +4572,13 @@ var _ = Describe("machine", func() {
 					nodeCondition: &corev1.NodeCondition{
 						Type:   v1alpha1.NodePreserved,
 						Status: corev1.ConditionTrue},
-					retry: machineutils.LongRetry,
+					nodeUnschedulable: true,
+					retry:             machineutils.LongRetry,
 				},
 			}),
 			Entry("when node of preserved machine is annotated with preserve value 'false', should stop preservation", testCase{
 				setup: setup{
+					nodeAnnotated:       true,
 					nodeAnnotationValue: machineutils.PreserveMachineAnnotationValueFalse,
 					nodeName:            "node-1",
 					machinePhase:        v1alpha1.MachineRunning,
@@ -4271,6 +4593,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when machine is annotated for auto-preservation by MCM, should start preservation", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValuePreservedByMCM,
 					nodeName:               "node-1",
 					machinePhase:           v1alpha1.MachineFailed,
@@ -4280,12 +4603,15 @@ var _ = Describe("machine", func() {
 					nodeCondition: &corev1.NodeCondition{
 						Type:   v1alpha1.NodePreserved,
 						Status: corev1.ConditionTrue},
+					nodeUnschedulable:      true,
 					retry:                  machineutils.LongRetry,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValuePreservedByMCM,
 				},
 			}),
-			Entry("when node is annotated and preservation times out, should stop preservation", testCase{
+			Entry("when node is annotated and preservation times out, should stop preservation, and remove annotation", testCase{
 				setup: setup{
+					nodeAnnotated:       true,
+					laNodePreserveValue: machineutils.PreserveMachineAnnotationValueNow,
 					nodeAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
 					nodeName:            "node-1",
 					machinePhase:        v1alpha1.MachineRunning,
@@ -4299,6 +4625,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when machine is annotated with preserve=now and preservation times out, should stop preservation, and remove annotation", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
 					nodeName:               "node-1",
 					machinePhase:           v1alpha1.MachineRunning,
@@ -4312,6 +4639,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when machine is annotated with preserve=when-failed and preservation times out, should stop preservation, and remove annotation", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
 					nodeName:               "node-1",
 					machinePhase:           v1alpha1.MachineFailed,
@@ -4323,22 +4651,23 @@ var _ = Describe("machine", func() {
 					retry:                   machineutils.LongRetry,
 				},
 			}),
-			Entry("when invalid preserve annotation is added on node of un-preserved machine, should do nothing  ", testCase{
+			Entry("when invalid preserve annotation is added on node of un-preserved machine, should do nothing", testCase{
 				setup: setup{
+					nodeAnnotated:       true,
 					nodeAnnotationValue: "invalidValue",
 					nodeName:            "node-1",
 					machinePhase:        v1alpha1.MachineRunning,
 				},
 				expect: expect{
-					laNodePreserveValue:     "invalidValue",
 					preserveExpiryTimeIsSet: false,
 					nodeCondition:           nil,
 					retry:                   machineutils.LongRetry,
 					err:                     nil,
 				},
 			}),
-			Entry("when invalid preserve annotation is added on machine of un-preserved machine, and node is not annotated should do nothing  ", testCase{
+			Entry("when invalid preserve annotation is added on machine of un-preserved machine, and node is not annotated should do nothing", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: "invalidValue",
 					nodeName:               "node-1",
 					machinePhase:           v1alpha1.MachineRunning,
@@ -4353,8 +4682,8 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when a machine is annotated with preserve=now, but has no backing node, should start preservation", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
-					nodeAnnotationValue:    "",
 					nodeName:               "",
 					machinePhase:           v1alpha1.MachineUnknown,
 				},
@@ -4368,6 +4697,7 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when preservation times out for a machine annotated with preserve=now, but has no backing node, should stop preservation", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
 					nodeName:               "",
 					machinePhase:           v1alpha1.MachineUnknown,
@@ -4380,10 +4710,10 @@ var _ = Describe("machine", func() {
 					err:                     nil,
 				},
 			}),
-			Entry("when a machine has a backing node, but node retrieval fails", testCase{
+			Entry("when a machine has a backing node, but node retrieval fails with not found, should return LongRetry", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
-					nodeAnnotationValue:    "",
 					nodeName:               "invalid",
 					machinePhase:           v1alpha1.MachineUnknown,
 				},
@@ -4391,12 +4721,13 @@ var _ = Describe("machine", func() {
 					preserveExpiryTimeIsSet: false,
 					nodeCondition:           nil,
 					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueNow,
-					retry:                   machineutils.ShortRetry,
-					err:                     fmt.Errorf("node %q not found", "invalid"),
+					retry:                   machineutils.LongRetry,
+					err:                     nil,
 				},
 			}),
 			Entry("when auto-preserved machine moves to Running, should stop preservation and remove auto-preserve annotation", testCase{
 				setup: setup{
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValuePreservedByMCM,
 					nodeName:               "node-1",
 					machinePhase:           v1alpha1.MachineRunning,
@@ -4412,9 +4743,10 @@ var _ = Describe("machine", func() {
 			}),
 			Entry("when node is annotated with 'now' and machine is annotated with 'when-failed', should start preservation and remove preserve annotation from machine", testCase{
 				setup: setup{
+					nodeAnnotated:          true,
 					nodeAnnotationValue:    machineutils.PreserveMachineAnnotationValueNow,
+					machineAnnotated:       true,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
-					laNodePreserveValue:    "",
 					nodeName:               "node-1",
 					machinePhase:           v1alpha1.MachineRunning,
 				},
@@ -4430,11 +4762,11 @@ var _ = Describe("machine", func() {
 				},
 			}),
 			// case possible when MCM goes down and node annotation value is cleared and machine is annotated
-			Entry("when node and machine are found to be annotated with \"\", and 'now', respectively and last applied node preserve value is 'now', should stop preservation", testCase{
+			Entry("when node annotation was removed and last applied node preserve value is 'now', should stop preservation", testCase{
 				setup: setup{
-					nodeAnnotationValue:    "",
-					laNodePreserveValue:    "now",
-					machineAnnotationValue: "now",
+					laNodePreserveValue:    machineutils.PreserveMachineAnnotationValueNow,
+					machineAnnotated:       true,
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
 					nodeName:               "node-1",
 					machinePhase:           v1alpha1.MachineRunning,
 					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
@@ -4448,6 +4780,118 @@ var _ = Describe("machine", func() {
 					err:                     nil,
 				},
 			}),
+			Entry("when machine has no preserve annotations but backing node is cordoned, node should remain cordoned", testCase{
+				setup: setup{
+					nodeName:          "node-1",
+					machinePhase:      v1alpha1.MachineRunning,
+					nodeUnschedulable: true,
+				},
+				expect: expect{
+					preserveExpiryTimeIsSet: false,
+					nodeCondition:           nil,
+					nodeUnschedulable:       true,
+					retry:                   machineutils.LongRetry,
+					err:                     nil,
+				},
+			}),
+			Entry("when machine is actively preserved via node annotation 'now' and node is cordoned, node should remain cordoned", testCase{
+				setup: setup{
+					nodeAnnotated:       true,
+					nodeAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
+					laNodePreserveValue: machineutils.PreserveMachineAnnotationValueNow,
+					nodeName:            "node-1",
+					machinePhase:        v1alpha1.MachineRunning,
+					preserveExpiryTime:  &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeUnschedulable:   true,
+				},
+				expect: expect{
+					laNodePreserveValue:     machineutils.PreserveMachineAnnotationValueNow,
+					preserveExpiryTimeIsSet: true,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionTrue},
+					nodeUnschedulable:       true,
+					retry:                   machineutils.LongRetry,
+				},
+			}),
+			Entry("when machine is actively preserved via machine annotation 'now' and node is cordoned, node should remain cordoned", testCase{
+				setup: setup{
+					machineAnnotated:       true,
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
+					nodeName:               "node-1",
+					machinePhase:           v1alpha1.MachineRunning,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeUnschedulable:      true,
+				},
+				expect: expect{
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueNow,
+					preserveExpiryTimeIsSet: true,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionTrue},
+					nodeUnschedulable:       true,
+					retry:                   machineutils.LongRetry,
+				},
+			}),
+			Entry("when machine is actively preserved via machine annotation 'when-failed' and node is cordoned, node should remain cordoned", testCase{
+				setup: setup{
+					machineAnnotated:       true,
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					nodeName:               "node-1",
+					machinePhase:           v1alpha1.MachineFailed,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeUnschedulable:      true,
+				},
+				expect: expect{
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueWhenFailed,
+					preserveExpiryTimeIsSet: true,
+					nodeCondition:           &corev1.NodeCondition{Type: v1alpha1.NodePreserved, Status: corev1.ConditionTrue},
+					nodeUnschedulable:       true,
+					retry:                   machineutils.LongRetry,
+				},
+			}),
 		)
+
+		It("should not modify a machine with no preservation annotations and no PreserveExpiryTime set", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+
+			machine := &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      "m1",
+					Labels:    map[string]string{v1alpha1.NodeLabelKey: "node-1"},
+				},
+				Status: v1alpha1.MachineStatus{
+					CurrentStatus: v1alpha1.CurrentStatus{
+						Phase:          v1alpha1.MachineRunning,
+						LastUpdateTime: metav1.Now(),
+					},
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       corev1.NodeSpec{Unschedulable: false},
+				Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{}},
+			}
+
+			c, trackers := createController(stop, testNamespace, []runtime.Object{machine}, nil, []runtime.Object{node}, nil, false)
+			defer trackers.Stop()
+			waitForCacheSync(stop, c)
+
+			retry, err := c.reconcileMachinePreservation(context.TODO(), machine)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.LongRetry))
+
+			updatedMachine, err := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedMachine.Annotations).To(Equal(machine.Annotations))
+			Expect(updatedMachine.Labels).To(Equal(machine.Labels))
+			Expect(updatedMachine.Spec).To(Equal(machine.Spec))
+			Expect(updatedMachine.Status).To(Equal(machine.Status))
+
+			updatedNode, err := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedNode.Annotations).To(Equal(node.Annotations))
+			Expect(updatedNode.Spec).To(Equal(node.Spec))
+			Expect(updatedNode.Status).To(Equal(node.Status))
+		})
 	})
 })

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -75,6 +75,18 @@ const (
 	cacheUpdateTimeout = 1 * time.Second
 )
 
+// preserveAnnotationInfo encapsulates the preservation annotation values found
+// on the machine and node objects, along with the effective preservation value for the machine
+// and the last applied node preserve value by MCM.
+type preserveAnnotationInfo struct {
+	nodeAnnotated        bool
+	machineAnnotated     bool
+	nodeValue            string
+	machineValue         string
+	lastAppliedNodeValue string
+	effectiveValue       string
+}
+
 // ValidateMachineClass validates the machine class.
 func (c *controller) ValidateMachineClass(_ context.Context, classSpec *v1alpha1.ClassSpec) (*v1alpha1.MachineClass, map[string][]byte, machineutils.RetryPeriod, error) {
 	var (
@@ -2333,7 +2345,7 @@ Utility Functions for Machine Preservation
 */
 
 // preserveMachine contains logic to start the preservation of a machine and node.
-func (c *controller) preserveMachine(ctx context.Context, machine *v1alpha1.Machine, preserveValue string) error {
+func (c *controller) preserveMachine(ctx context.Context, machine *v1alpha1.Machine, preserveValue string) (*v1alpha1.Machine, error) {
 	var err error
 	nodeName := machine.Labels[v1alpha1.NodeLabelKey]
 	if machine.Status.CurrentStatus.PreserveExpiryTime == nil {
@@ -2341,29 +2353,29 @@ func (c *controller) preserveMachine(ctx context.Context, machine *v1alpha1.Mach
 		// Step 1: Add preserveExpiryTime to machine status
 		machine, err = c.setPreserveExpiryTimeOnMachine(ctx, machine)
 		if err != nil {
-			return err
+			return machine, err
 		}
 	}
 	if nodeName == "" {
 		// Machine has no backing node, preservation is complete
 		klog.V(2).Infof("Machine %q without backing node is preserved successfully till %v.", machine.Name, machine.Status.CurrentStatus.PreserveExpiryTime)
-		return nil
+		return machine, nil
 	}
 	// Machine has a backing node
 	node, err := c.nodeLister.Get(nodeName)
 	if err != nil {
 		klog.Errorf("error trying to get node %q of machine %q: %v. Retrying.", nodeName, machine.Name, err)
-		return err
+		return machine, err
 	}
 	existingNodePreservedCondition := nodeops.GetCondition(node, v1alpha1.NodePreserved)
 	// checks if preservation is already complete
 	if existingNodePreservedCondition != nil && existingNodePreservedCondition.Status == v1.ConditionTrue {
-		return nil
+		return machine, nil
 	}
 	// Step 2: Add annotations to prevent scale down of node by CA
 	updatedNode, err := c.addCAScaleDownDisabledAnnotationOnNode(ctx, node)
 	if err != nil {
-		return err
+		return machine, err
 	}
 	var drainErr error
 	if shouldPreservedNodeBeDrained(existingNodePreservedCondition, machine.Status.CurrentStatus.Phase) {
@@ -2376,62 +2388,59 @@ func (c *controller) preserveMachine(ctx context.Context, machine *v1alpha1.Mach
 		_, err = nodeops.AddOrUpdateConditionsOnNode(ctx, c.targetCoreClient, updatedNode.Name, *newCond)
 		if drainErr != nil {
 			klog.Errorf("error draining preserved node %q for machine %q : %v", nodeName, machine.Name, drainErr)
-			return drainErr
+			return machine, drainErr
 		}
 		if err != nil {
 			klog.Errorf("error trying to update node preserved condition for node %q of machine %q : %v", nodeName, machine.Name, err)
-			return err
+			return machine, err
 		}
 	}
 	klog.V(2).Infof("Machine %q and backing node preserved successfully till %v.", machine.Name, machine.Status.CurrentStatus.PreserveExpiryTime)
-	return nil
+	return machine, nil
 }
 
-// stopPreservationIfActive stops the preservation of the machine and node, if preserved, and returns true if machine object has been updated
-func (c *controller) stopPreservationIfActive(ctx context.Context, machine *v1alpha1.Machine, removePreservationAnnotations bool) (bool, error) {
-	// removal of preserveExpiryTime is the last step of stopping preservation
-	// therefore, if preserveExpiryTime is not set, machine is not preserved
-	nodeName := machine.Labels[v1alpha1.NodeLabelKey]
+// stopPreservationIfActive stops the preservation of the machine and node, if preserved.
+func (c *controller) stopPreservationIfActive(ctx context.Context, machine *v1alpha1.Machine, removePreservationAnnotations bool) (*v1alpha1.Machine, error) {
+	// clearMachinePreserveExpiryTime is the last step, so a nil PreserveExpiryTime means nothing to do.
 	if machine.Status.CurrentStatus.PreserveExpiryTime == nil {
-		return false, nil
+		return machine, nil
 	}
-	// if there is no backing node
+	nodeName := machine.Labels[v1alpha1.NodeLabelKey]
 	if nodeName == "" {
-		// remove annotation from machine if needed
-		if removePreservationAnnotations {
-			var err error
-			machine, err = c.removePreserveAnnotationOnMachine(ctx, machine)
-			if err != nil {
-				return false, err
-			}
-		}
-		machine, err := c.clearMachinePreserveExpiryTime(ctx, machine)
-		if err != nil {
-			return false, err
-		}
-		klog.V(2).Infof("Preservation of machine %q with no backing node has stopped.", machine.Name)
-		return true, nil
+		return c.stopPreservationOnMachineOnly(ctx, machine, removePreservationAnnotations)
 	}
-
-	// Machine has a backing node
 	node, err := c.nodeLister.Get(nodeName)
 	if err != nil {
-		// if node is not found and error is simply returned, then preservation will never be stopped on machine
-		// therefore, this error is handled specifically
 		if apierrors.IsNotFound(err) {
-			// Node not found, proceed to clear preserveExpiryTime on machine
-			klog.Warningf("Node %q of machine %q not found. Proceeding to clear PreserveExpiryTime on machine.", nodeName, machine.Name)
-			_, err := c.clearMachinePreserveExpiryTime(ctx, machine)
-			if err != nil {
-				return false, err
-			}
-			klog.V(2).Infof("Preservation of machine %q has stopped.", machine.Name)
-			return true, nil
+			klog.Warningf("Node %q of machine %q not found. Proceeding to stop preservation on machine.", nodeName, machine.Name)
+			return c.stopPreservationOnMachineOnly(ctx, machine, removePreservationAnnotations)
 		}
 		klog.Errorf("error trying to get node %q of machine %q: %v. Retrying.", nodeName, machine.Name, err)
-		return false, err
+		return machine, err
 	}
-	// prepare NodeCondition to set preservation as stopped
+	return c.stopPreservationWithNode(ctx, machine, node, removePreservationAnnotations)
+}
+
+// stopPreservationOnMachineOnly stops preservation when there is no backing node.
+func (c *controller) stopPreservationOnMachineOnly(ctx context.Context, machine *v1alpha1.Machine, removePreservationAnnotations bool) (*v1alpha1.Machine, error) {
+	var err error
+	if removePreservationAnnotations {
+		machine, err = c.removePreserveAnnotationOnMachine(ctx, machine)
+		if err != nil {
+			return machine, err
+		}
+	}
+	machine, err = c.clearMachinePreserveExpiryTime(ctx, machine)
+	if err != nil {
+		return machine, err
+	}
+	klog.V(2).Infof("Preservation of machine %q has stopped.", machine.Name)
+	return machine, nil
+}
+
+// stopPreservationWithNode stops preservation for a machine that has a backing node.
+func (c *controller) stopPreservationWithNode(ctx context.Context, machine *v1alpha1.Machine, node *v1.Node, removePreservationAnnotations bool) (*v1alpha1.Machine, error) {
+	nodeName := node.Name
 	preservedConditionFalse := v1.NodeCondition{
 		Type:               v1alpha1.NodePreserved,
 		Status:             v1.ConditionFalse,
@@ -2439,29 +2448,36 @@ func (c *controller) stopPreservationIfActive(ctx context.Context, machine *v1al
 		Reason:             v1alpha1.PreservationStopped,
 	}
 	// Step 1: change node condition to reflect that preservation has stopped
-	updatedNode, err := nodeops.AddOrUpdateConditionsOnNode(ctx, c.targetCoreClient, node.Name, preservedConditionFalse)
+	updatedNode, err := nodeops.AddOrUpdateConditionsOnNode(ctx, c.targetCoreClient, nodeName, preservedConditionFalse)
 	if err != nil {
-		return false, err
+		return machine, err
 	}
 	// Step 2: remove annotations from node
-	err = c.removePreservationRelatedAnnotationsOnNode(ctx, updatedNode, removePreservationAnnotations)
-	if err != nil {
-		return false, err
+	if updatedNode, err = c.removePreservationRelatedAnnotationsOnNode(ctx, updatedNode, removePreservationAnnotations); err != nil {
+		return machine, err
 	}
 	// Step 3: remove annotation from machine if needed
 	if removePreservationAnnotations {
 		machine, err = c.removePreserveAnnotationOnMachine(ctx, machine)
 		if err != nil {
-			return false, err
+			return machine, err
 		}
 	}
-	// Step 4: update machine status to set preserve expiry time to nil
+	// Step 4: uncordon the node if the machine has recovered to Running, so pods can be scheduled again.
+	// Done before clearing PreserveExpiryTime so a failure here retries with PreserveExpiryTime still set.
+	if machine.Status.CurrentStatus.Phase == v1alpha1.MachineRunning {
+		if err = c.uncordonNodeIfCordoned(ctx, updatedNode, machine.Name); err != nil {
+			klog.Errorf("failed to uncordon node %q of machine %q after preservation was stopped: %v", nodeName, machine.Name, err)
+			return machine, err
+		}
+	}
+	// Step 5: clear preserve expiry time on machine
 	machine, err = c.clearMachinePreserveExpiryTime(ctx, machine)
 	if err != nil {
-		return false, err
+		return machine, err
 	}
 	klog.V(2).Infof("Preservation of machine %q with backing node %q has stopped.", machine.Name, nodeName)
-	return true, nil
+	return machine, nil
 }
 
 // setPreserveExpiryTimeOnMachine sets the PreserveExpiryTime on the machine object's Status.CurrentStatus to now + preserve timeout
@@ -2543,7 +2559,7 @@ func (c *controller) clearMachinePreserveExpiryTime(ctx context.Context, machine
 	machine.Status.CurrentStatus.LastUpdateTime = metav1.Now()
 	updatedMachine, err := c.controlMachineClient.Machines(machine.Namespace).UpdateStatus(ctx, machine, metav1.UpdateOptions{})
 	if err != nil {
-		klog.Errorf("machine/status UPDATE failed for machine %q. Retrying, error: %s", machine.Name, err)
+		klog.Errorf("could not clear PreserveExpiryTime. Machine/status UPDATE failed for machine %q. Retrying, error: %s", machine.Name, err)
 		return nil, err
 	}
 	return updatedMachine, nil
@@ -2610,9 +2626,9 @@ func (c *controller) drainPreservedNode(ctx context.Context, machine *v1alpha1.M
 		printLogInitError(message, &err, &description, machine, true)
 	}
 
-	// TODO@thiyyakat: how to calculate timeout? In the case of preserve=now, PreserveExpiryTime will not coincide with time of failure in which case pods will get force
-	// drained.
-	// current solution: since we want to know when machine transitioned to Failed, the code uses LastUpdateTime.
+	// LastUpdateTime marks when the machine last transitioned to its current phase (e.g. Failed).
+	// For preserve=now, PreserveExpiryTime reflects the preservation start, not the failure time,
+	// so LastUpdateTime is used to measure how long the machine has been in the Failed phase.
 	timeOutOccurred = utiltime.HasTimeOutOccurred(machine.Status.CurrentStatus.LastUpdateTime, timeOutDuration)
 	if forceDrainLabelPresent || timeOutOccurred {
 		forceDeletePods = true

--- a/pkg/util/provider/machinecontroller/machine_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_util_test.go
@@ -4024,7 +4024,7 @@ var _ = Describe("machine_util", func() {
 				c, trackers := createController(stop, testNamespace, controlMachineObjects, nil, targetCoreObjects, nil, false)
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				err := c.preserveMachine(context.TODO(), machine, tc.setup.preserveValue)
+				_, err := c.preserveMachine(context.TODO(), machine, tc.setup.preserveValue)
 				if tc.expect.err == nil {
 					Expect(err).To(BeNil())
 				} else {

--- a/pkg/util/provider/machinecontroller/machine_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_util_test.go
@@ -4624,7 +4624,7 @@ var _ = Describe("machine_util", func() {
 				c, trackers := createController(stop, testNamespace, nil, nil, targetCoreObjects, nil, false)
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				err := c.removePreservationRelatedAnnotationsOnNode(context.TODO(), node, tc.setup.removePreserveAnnotation)
+				_, err := c.removePreservationRelatedAnnotationsOnNode(context.TODO(), node, tc.setup.removePreserveAnnotation)
 				waitForCacheSync(stop, c)
 				updatedNode, getErr := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 				Expect(getErr).To(BeNil())

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -370,10 +370,10 @@ func (c *controller) uncordonNodeIfCordoned(ctx context.Context, nodeName string
 }
 
 // removePreservationRelatedAnnotationsOnNode removes the cluster-autoscaler annotation that disables scale down of preserved node
-func (c *controller) removePreservationRelatedAnnotationsOnNode(ctx context.Context, node *corev1.Node, removePreserveAnnotation bool) error {
+func (c *controller) removePreservationRelatedAnnotationsOnNode(ctx context.Context, node *corev1.Node, removePreserveAnnotation bool) (*corev1.Node, error) {
 	// Check if annotation already absent
 	if node.Annotations == nil {
-		return nil
+		return node, nil
 	}
 	updateRequired := false
 	nodeCopy := node.DeepCopy()
@@ -389,14 +389,14 @@ func (c *controller) removePreservationRelatedAnnotationsOnNode(ctx context.Cont
 		updateRequired = true
 	}
 	if !updateRequired {
-		return nil
+		return node, nil
 	}
-	_, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeCopy, metav1.UpdateOptions{})
+	nodeCopy, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeCopy, metav1.UpdateOptions{})
 	if err != nil {
 		klog.Errorf("node UPDATE failed for node %q. Retrying, error: %s", node.Name, err)
-		return err
+		return nil, err
 	}
-	return nil
+	return nodeCopy, nil
 }
 
 // addCAScaleDownDisabledAnnotationOnNode adds the cluster-autoscaler annotation to disable scale down of preserved node

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -340,33 +340,19 @@ func addedOrRemovedEssentialTaints(oldNode, node *corev1.Node, taintKeys []strin
 	return false
 }
 
-func (c *controller) getNodePreserveAnnotationValue(nodeName string) (string, error) {
-	node, err := c.nodeLister.Get(nodeName)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return "", nil
-		}
-		klog.Errorf("error fetching node %q: %v", nodeName, err)
-		return "", err
-	}
-	return node.Annotations[machineutils.PreserveMachineAnnotationKey], nil
-}
-
-func (c *controller) uncordonNodeIfCordoned(ctx context.Context, nodeName string) error {
-	node, err := c.nodeLister.Get(nodeName)
-	if err != nil {
-		return err
-	}
+func (c *controller) uncordonNodeIfCordoned(ctx context.Context, node *corev1.Node, machineName string) error {
 	if !node.Spec.Unschedulable {
 		return nil
 	}
 	nodeClone := node.DeepCopy()
 	nodeClone.Spec.Unschedulable = false
-	_, err = c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeClone, metav1.UpdateOptions{})
+	_, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeClone, metav1.UpdateOptions{})
 	if err != nil {
-		klog.Errorf("error uncordoning node %q: %v", nodeName, err)
+		klog.Errorf("error uncordoning node %q backing machine %q: %v", node.Name, machineName, err)
+		return err
 	}
-	return err
+	klog.V(2).Infof("Node %q backing machine %q has been uncordoned.", node.Name, machineName)
+	return nil
 }
 
 // removePreservationRelatedAnnotationsOnNode removes the cluster-autoscaler annotation that disables scale down of preserved node

--- a/pkg/util/provider/machineutils/utils.go
+++ b/pkg/util/provider/machineutils/utils.go
@@ -120,7 +120,7 @@ const (
 )
 
 // AllowedPreserveAnnotationValues contains the allowed values for the preserve annotation
-var AllowedPreserveAnnotationValues = sets.New(PreserveMachineAnnotationValueNow, PreserveMachineAnnotationValueWhenFailed, PreserveMachineAnnotationValuePreservedByMCM, PreserveMachineAnnotationValueFalse, "")
+var AllowedPreserveAnnotationValues = sets.New(PreserveMachineAnnotationValueNow, PreserveMachineAnnotationValueWhenFailed, PreserveMachineAnnotationValuePreservedByMCM, PreserveMachineAnnotationValueFalse)
 
 // PreventAutoPreserveAnnotationValues contains the values to check if a machine is already annotated for preservation,
 // in which case it should not be auto-preserved.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR does the following:

- Fixes a bug where MCM unconditionally uncordoned the backing node of any active machine on every preservation reconcile pass, even when the node had been cordoned externally (e.g. by CA or an operator) for reasons unrelated to preservation.
- Moves the uncordon into `stopPreservationWithNode`, gated on `phase == MachineRunning`, so it only fires when preservation is actively being stopped and the machine has recovered.
- Orders the uncordon before `clearMachinePreserveExpiryTime`, so a failed uncordon is retried on the next reconcile instead of being silently dropped.
- Splits `manageMachinePreservation` into a gathering phase (`reconcileMachinePreservation`) and a transition phase (`manageMachinePreservation`).
- Adds an early exit for machines with no preservation state.
- Simplifies `getEffectivePreservationAnnotations` into a pure function.
- Removes `""` as a valid preservation annotation value.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

IT run with `machine-controller-manager-provider-aws`

The key behavioral change: uncordoning is gated on preservation being stopped in the current reconcile iteration AND phase == MachineRunning. Machines that are actively preserved, or unrelated to preservation, will never have their node uncordoned by this flow.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where a cordoned node backing a non-preserved Running machine would be unconditionally uncordoned on every reconcile pass through the preservation flow.
```
