### PR TITLE
[rel-v0.62] Fix bug where manageMachinePreservation uncordons nodes of Running Machines unconditionally

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -777,6 +777,14 @@ func (c *controller) manageMachinePreservation(ctx context.Context, machine *v1a
 			return
 		}
 	}
+	machinePreserved := clone.Status.CurrentStatus.PreserveExpiryTime != nil
+	machineAnnotated := clone.Annotations[machineutils.PreserveMachineAnnotationKey] != ""
+	lastApplied := clone.Annotations[machineutils.LastAppliedNodePreserveValueAnnotationKey]
+	nodeAnnotated := nodeAnnotationValue != ""
+	if !machinePreserved && !machineAnnotated && !nodeAnnotated && lastApplied == "" {
+		// Machine has no preservation state — skip the rest of the flow.
+		return
+	}
 	var effectivePreserveValue string
 	effectivePreserveValue, clone.Annotations = getEffectivePreservationAnnotations(nodeAnnotationValue, clone.Annotations)
 	if !machineutils.AllowedPreserveAnnotationValues.Has(effectivePreserveValue) {
@@ -818,11 +826,6 @@ func (c *controller) manageMachinePreservation(ctx context.Context, machine *v1a
 	}
 	if err != nil {
 		return
-	}
-	// This is to handle the case where a preserved machine recovers from Failed to Running
-	// in which case, pods should be allowed to be scheduled onto the node
-	if machineutils.IsMachineActive(clone) && nodeName != "" {
-		err = c.uncordonNodeIfCordoned(ctx, nodeName)
 	}
 	return
 }

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -4499,7 +4499,38 @@ var _ = Describe("machine", func() {
 					retry:                   machineutils.LongRetry,
 				},
 			}),
-			Entry("when preserved machine is still in Failed phase, should not uncordon node", testCase{
+			Entry("when machine is actively preserved via node annotation 'now' and node is cordoned, node should remain cordoned", testCase{
+				setup: setup{
+					nodeAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
+					laNodePreserveValue: machineutils.PreserveMachineAnnotationValueNow,
+					nodeName:            "node-1",
+					machinePhase:        v1alpha1.MachineRunning,
+					preserveExpiryTime:  &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeUnschedulable:   true,
+				},
+				expect: expect{
+					laNodePreserveValue:     machineutils.PreserveMachineAnnotationValueNow,
+					preserveExpiryTimeIsSet: true,
+					nodeUnschedulable:       true,
+					retry:                   machineutils.LongRetry,
+				},
+			}),
+			Entry("when machine is actively preserved via machine annotation 'now' and node is cordoned, node should remain cordoned", testCase{
+				setup: setup{
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueNow,
+					nodeName:               "node-1",
+					machinePhase:           v1alpha1.MachineRunning,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeUnschedulable:      true,
+				},
+				expect: expect{
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueNow,
+					preserveExpiryTimeIsSet: true,
+					nodeUnschedulable:       true,
+					retry:                   machineutils.LongRetry,
+				},
+			}),
+			Entry("when machine is actively preserved via machine annotation 'when-failed' and node is cordoned, node should remain cordoned", testCase{
 				setup: setup{
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
 					nodeName:               "node-1",
@@ -4508,12 +4539,58 @@ var _ = Describe("machine", func() {
 					nodeUnschedulable:      true,
 				},
 				expect: expect{
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueWhenFailed,
 					preserveExpiryTimeIsSet: true,
 					nodeUnschedulable:       true,
-					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueWhenFailed,
 					retry:                   machineutils.LongRetry,
 				},
 			}),
 		)
+
+		It("should not modify a non-preservation-bound machine's status, annotations, labels, spec, or backing node", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+
+			machine := &v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      "m1",
+					Labels:    map[string]string{v1alpha1.NodeLabelKey: "node-1"},
+				},
+				Status: v1alpha1.MachineStatus{
+					CurrentStatus: v1alpha1.CurrentStatus{
+						Phase:          v1alpha1.MachineRunning,
+						LastUpdateTime: metav1.Now(),
+					},
+				},
+			}
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+				Spec:       corev1.NodeSpec{Unschedulable: true},
+				Status:     corev1.NodeStatus{Conditions: []corev1.NodeCondition{}},
+			}
+
+			c, trackers := createController(stop, testNamespace, []runtime.Object{machine}, nil, []runtime.Object{node}, nil, false)
+			defer trackers.Stop()
+			waitForCacheSync(stop, c)
+
+			retry, err := c.manageMachinePreservation(context.TODO(), machine)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retry).To(Equal(machineutils.LongRetry))
+
+			updatedMachine, err := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machine.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedMachine.Annotations).To(Equal(machine.Annotations))
+			Expect(updatedMachine.Labels).To(Equal(machine.Labels))
+			Expect(updatedMachine.Spec).To(Equal(machine.Spec))
+			Expect(updatedMachine.Status).To(Equal(machine.Status))
+
+			updatedNode, err := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedNode.Annotations).To(Equal(node.Annotations))
+			Expect(updatedNode.Spec).To(Equal(node.Spec))
+			Expect(updatedNode.Status).To(Equal(node.Status))
+		})
 	})
 })

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -4101,6 +4101,7 @@ var _ = Describe("machine", func() {
 			nodeName               string
 			machinePhase           v1alpha1.MachinePhase
 			preserveExpiryTime     *metav1.Time
+			nodeUnschedulable      bool
 		}
 		type expect struct {
 			retry                   machineutils.RetryPeriod
@@ -4108,6 +4109,7 @@ var _ = Describe("machine", func() {
 			nodeCondition           *corev1.NodeCondition
 			machineAnnotationValue  string
 			laNodePreserveValue     string
+			nodeUnschedulable       bool
 			err                     error
 		}
 		type testCase struct {
@@ -4154,6 +4156,9 @@ var _ = Describe("machine", func() {
 								machineutils.PreserveMachineAnnotationKey: tc.setup.nodeAnnotationValue,
 							},
 						},
+						Spec: corev1.NodeSpec{
+							Unschedulable: tc.setup.nodeUnschedulable,
+						},
 						Status: corev1.NodeStatus{
 							Conditions: []corev1.NodeCondition{},
 						},
@@ -4198,6 +4203,7 @@ var _ = Describe("machine", func() {
 					} else {
 						Expect(found).To(BeFalse())
 					}
+					Expect(updatedNode.Spec.Unschedulable).To(Equal(tc.expect.nodeUnschedulable))
 				}
 				Expect(updatedMachine.Annotations[machineutils.PreserveMachineAnnotationKey]).To(Equal(tc.expect.machineAnnotationValue))
 				Expect(updatedMachine.Annotations[machineutils.LastAppliedNodePreserveValueAnnotationKey]).To(Equal(tc.expect.laNodePreserveValue))
@@ -4252,7 +4258,8 @@ var _ = Describe("machine", func() {
 					nodeCondition: &corev1.NodeCondition{
 						Type:   v1alpha1.NodePreserved,
 						Status: corev1.ConditionTrue},
-					retry: machineutils.LongRetry,
+					nodeUnschedulable: true,
+					retry:             machineutils.LongRetry,
 				},
 			}),
 			Entry("when node of preserved machine is annotated with preserve value 'false', should stop preservation", testCase{
@@ -4280,6 +4287,7 @@ var _ = Describe("machine", func() {
 					nodeCondition: &corev1.NodeCondition{
 						Type:   v1alpha1.NodePreserved,
 						Status: corev1.ConditionTrue},
+					nodeUnschedulable:      true,
 					retry:                  machineutils.LongRetry,
 					machineAnnotationValue: machineutils.PreserveMachineAnnotationValuePreservedByMCM,
 				},
@@ -4446,6 +4454,64 @@ var _ = Describe("machine", func() {
 					laNodePreserveValue:     "",
 					retry:                   machineutils.LongRetry,
 					err:                     nil,
+				},
+			}),
+			Entry("when preserved machine with when-failed annotation recovers to Running, should stop preservation and uncordon node", testCase{
+				setup: setup{
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					nodeName:               "node-1",
+					machinePhase:           v1alpha1.MachineRunning,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeUnschedulable:      true,
+				},
+				expect: expect{
+					preserveExpiryTimeIsSet: false,
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueWhenFailed,
+					nodeUnschedulable:       false,
+					retry:                   machineutils.LongRetry,
+				},
+			}),
+			Entry("when preserved machine with when-failed annotation expires while Running, should stop preservation, remove annotation, and uncordon node", testCase{
+				setup: setup{
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					nodeName:               "node-1",
+					machinePhase:           v1alpha1.MachineRunning,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(-1 * time.Minute)},
+					nodeUnschedulable:      true,
+				},
+				expect: expect{
+					preserveExpiryTimeIsSet: false,
+					nodeUnschedulable:       false,
+					machineAnnotationValue:  "",
+					retry:                   machineutils.LongRetry,
+				},
+			}),
+			Entry("when Running machine has no preservation annotation and node is cordoned externally, should not uncordon node", testCase{
+				setup: setup{
+					nodeName:          "node-1",
+					machinePhase:      v1alpha1.MachineRunning,
+					nodeUnschedulable: true,
+				},
+				expect: expect{
+					preserveExpiryTimeIsSet: false,
+					nodeCondition:           nil,
+					nodeUnschedulable:       true,
+					retry:                   machineutils.LongRetry,
+				},
+			}),
+			Entry("when preserved machine is still in Failed phase, should not uncordon node", testCase{
+				setup: setup{
+					machineAnnotationValue: machineutils.PreserveMachineAnnotationValueWhenFailed,
+					nodeName:               "node-1",
+					machinePhase:           v1alpha1.MachineFailed,
+					preserveExpiryTime:     &metav1.Time{Time: metav1.Now().Add(1 * time.Hour)},
+					nodeUnschedulable:      true,
+				},
+				expect: expect{
+					preserveExpiryTimeIsSet: true,
+					nodeUnschedulable:       true,
+					machineAnnotationValue:  machineutils.PreserveMachineAnnotationValueWhenFailed,
+					retry:                   machineutils.LongRetry,
 				},
 			}),
 		)

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -2444,7 +2444,7 @@ func (c *controller) stopPreservationIfActive(ctx context.Context, machine *v1al
 		return false, err
 	}
 	// Step 2: remove annotations from node
-	err = c.removePreservationRelatedAnnotationsOnNode(ctx, updatedNode, removePreservationAnnotations)
+	updatedNode, err = c.removePreservationRelatedAnnotationsOnNode(ctx, updatedNode, removePreservationAnnotations)
 	if err != nil {
 		return false, err
 	}
@@ -2455,7 +2455,15 @@ func (c *controller) stopPreservationIfActive(ctx context.Context, machine *v1al
 			return false, err
 		}
 	}
-	// Step 4: update machine status to set preserve expiry time to nil
+	// Step 4: uncordon the node when the machine has recovered to Running so pods can be scheduled again.
+	// Ordered before clearMachinePreserveExpiryTime so a failed uncordon retries next reconcile.
+	if machine.Status.CurrentStatus.Phase == v1alpha1.MachineRunning {
+		if err = c.uncordonNodeIfCordoned(ctx, updatedNode); err != nil {
+			klog.Errorf("failed to uncordon node %q of machine %q after preservation was stopped: %v", nodeName, machine.Name, err)
+			return false, err
+		}
+	}
+	// Step 5: update machine status to set preserve expiry time to nil
 	machine, err = c.clearMachinePreserveExpiryTime(ctx, machine)
 	if err != nil {
 		return false, err

--- a/pkg/util/provider/machinecontroller/machine_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_util_test.go
@@ -4624,7 +4624,7 @@ var _ = Describe("machine_util", func() {
 				c, trackers := createController(stop, testNamespace, nil, nil, targetCoreObjects, nil, false)
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
-				err := c.removePreservationRelatedAnnotationsOnNode(context.TODO(), node, tc.setup.removePreserveAnnotation)
+				_, err := c.removePreservationRelatedAnnotationsOnNode(context.TODO(), node, tc.setup.removePreserveAnnotation)
 				waitForCacheSync(stop, c)
 				updatedNode, getErr := c.targetCoreClient.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 				Expect(getErr).To(BeNil())

--- a/pkg/util/provider/machinecontroller/node.go
+++ b/pkg/util/provider/machinecontroller/node.go
@@ -352,28 +352,24 @@ func (c *controller) getNodePreserveAnnotationValue(nodeName string) (string, er
 	return node.Annotations[machineutils.PreserveMachineAnnotationKey], nil
 }
 
-func (c *controller) uncordonNodeIfCordoned(ctx context.Context, nodeName string) error {
-	node, err := c.nodeLister.Get(nodeName)
-	if err != nil {
-		return err
-	}
+func (c *controller) uncordonNodeIfCordoned(ctx context.Context, node *corev1.Node) error {
 	if !node.Spec.Unschedulable {
 		return nil
 	}
 	nodeClone := node.DeepCopy()
 	nodeClone.Spec.Unschedulable = false
-	_, err = c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeClone, metav1.UpdateOptions{})
+	_, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeClone, metav1.UpdateOptions{})
 	if err != nil {
-		klog.Errorf("error uncordoning node %q: %v", nodeName, err)
+		klog.Errorf("error uncordoning node %q: %v", node.Name, err)
 	}
 	return err
 }
 
 // removePreservationRelatedAnnotationsOnNode removes the cluster-autoscaler annotation that disables scale down of preserved node
-func (c *controller) removePreservationRelatedAnnotationsOnNode(ctx context.Context, node *corev1.Node, removePreserveAnnotation bool) error {
+func (c *controller) removePreservationRelatedAnnotationsOnNode(ctx context.Context, node *corev1.Node, removePreserveAnnotation bool) (*corev1.Node, error) {
 	// Check if annotation already absent
 	if node.Annotations == nil {
-		return nil
+		return node, nil
 	}
 	updateRequired := false
 	nodeCopy := node.DeepCopy()
@@ -389,14 +385,14 @@ func (c *controller) removePreservationRelatedAnnotationsOnNode(ctx context.Cont
 		updateRequired = true
 	}
 	if !updateRequired {
-		return nil
+		return node, nil
 	}
-	_, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeCopy, metav1.UpdateOptions{})
+	nodeCopy, err := c.targetCoreClient.CoreV1().Nodes().Update(ctx, nodeCopy, metav1.UpdateOptions{})
 	if err != nil {
 		klog.Errorf("node UPDATE failed for node %q. Retrying, error: %s", node.Name, err)
-		return err
+		return nil, err
 	}
-	return nil
+	return nodeCopy, nil
 }
 
 // addCAScaleDownDisabledAnnotationOnNode adds the cluster-autoscaler annotation to disable scale down of preserved node


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

The previous implementation called uncordonNodeIfCordoned whenever IsMachineActive returned true and a node name was present. This meant any Running machine with a cordoned backing node (cordoned for reasons unrelated to preservation, e.g: CA scale-down) would be unconditionally uncordoned on every reconcile pass. 

The PR fixes this by:
1. Introducing a check which ensures non-preservation-bound machines are not candidates for preservation-related operations
2. Performs uncordonIfCordoned only on machines for which preservation is being stopped, and the machine is in Running phase.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The following tests were added:
  - Preserved when-failed machine recovers to Running → node uncordoned, PreserveExpiryTime cleared.
  - Preserved when-failed machine expires while Running → node uncordoned, annotation removed.
  - Running machine with no preservation annotations and externally-cordoned node → node untouched.
  - Machine still in Failed phase with active preservation → node stays cordoned.
  - Actively-preserved machines (now, when-failed via node or machine annotation) with a cordoned node → node stays cordoned.
  - Non-preservation-bound machine → zero writes to machine status/annotations/labels/spec and to the backing node.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where a cordoned node backing a non-preserved Running machine would be unconditionally uncordoned on every reconcile pass through the preservation flow.
```
