### PR TITLE
🐛 Fix machine loop block when backing node does not exist

### DIFF
--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -774,7 +774,15 @@ func (c *controller) manageMachinePreservation(ctx context.Context, machine *v1a
 	if nodeName != "" {
 		nodeAnnotationValue, err = c.getNodePreserveAnnotationValue(nodeName)
 		if err != nil {
-			return
+			// If the Node object doesn't exist in the cluster yet,
+			// it cannot have a preservation annotation. Swallow the NotFound error
+			// so the machine can continue its status transition to Pending.
+			if apierrors.IsNotFound(err) {
+				err = nil
+				nodeAnnotationValue = ""
+			} else {
+				return
+			}
 		}
 	}
 	var effectivePreserveValue string

--- a/pkg/util/provider/machinecontroller/machine.go
+++ b/pkg/util/provider/machinecontroller/machine.go
@@ -777,12 +777,11 @@ func (c *controller) manageMachinePreservation(ctx context.Context, machine *v1a
 			// If the Node object doesn't exist in the cluster yet,
 			// it cannot have a preservation annotation. Swallow the NotFound error
 			// so the machine can continue its status transition to Pending.
-			if apierrors.IsNotFound(err) {
-				err = nil
-				nodeAnnotationValue = ""
-			} else {
+			if !apierrors.IsNotFound(err) {
 				return
 			}
+			err = nil
+			nodeAnnotationValue = ""
 		}
 	}
 	var effectivePreserveValue string

--- a/pkg/util/provider/machinecontroller/machine_test.go
+++ b/pkg/util/provider/machinecontroller/machine_test.go
@@ -4448,6 +4448,20 @@ var _ = Describe("machine", func() {
 					err:                     nil,
 				},
 			}),
+			Entry("when machine has a backing node name, but node object does not exist in cluster, should swallow NotFound error and return LongRetry", testCase{
+				setup: setup{
+					nodeName:               "non-existent-node",
+					nodeAnnotationValue:    "",
+					machineAnnotationValue: "",
+					machinePhase:           v1alpha1.MachineUnknown,
+				},
+				expect: expect{
+					preserveExpiryTimeIsSet: false,
+					nodeCondition:           nil,
+					retry:                   machineutils.LongRetry,
+					err:                     nil,
+				},
+			}),
 		)
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in the machine preservation logic (`manageMachinePreservation`). Currently, the controller returns an error if the backing `Node` object does not exist yet in the cluster. 
When a machine is newly created or replacing an old instance, it takes time for the node to register. Returning an error here completely stops the machine's main update loop. This prevents the machine from changing its status phase, which causes downstream components to miss other checks.
By ignoring the `NotFound` error, the controller can assume there are no node annotations yet and continue updating the machine normally.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I added a new test case to the unit test table. It checks that when a node is missing from the cluster, the controller ignores the error and returns a normal `LongRetry` instead of failing.

**Release note**:
```
bugfix operator
Fixed a bug where a missing Node object stopped the machine controller loop from running, causing machine status phase updates to get stuck.
```
