### PR TITLE
Add integration tests for machine preservation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1206,7 +1206,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				}
 				patchBytes, err := json.Marshal(patch)
 				gomega.Expect(err).To(gomega.BeNil())
-				c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for this machine to now be deleted")
 				gomega.Eventually(
@@ -1249,7 +1250,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				}
 				patchBytes, err := json.Marshal(patch)
 				gomega.Expect(err).To(gomega.BeNil())
-				c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for this machine")

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	appsV1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -34,6 +35,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/test/integration/common/helpers"
 	"github.com/gardener/machine-controller-manager/pkg/test/utils/matchers"
+	mc_utils "github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 )
 
 const (
@@ -978,6 +980,371 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					Should(gomega.BeEquivalentTo(false))
 
+			})
+		})
+	})
+
+	// Testcase #04 | Auto Machine preservation
+	ginkgo.Describe("Auto Machine Preservation", func() {
+		ginkgo.Context("Auto-Preserve Failed machine", func() {
+			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
+				ginkgo.By("Creating a MCD with preservation fields populated")
+				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				//Update the standard mcd to have preservation fields with values needed for this test
+				mcd.Spec.AutoPreserveFailedMachineMax = 1
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+						gomega.Expect(err).To(gomega.BeNil())
+						mcd.ResourceVersion = existingMCD.ResourceVersion
+						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+						return updateErr
+					})
+					gomega.Expect(retryErr).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+
+				ginkgo.By("wait for machine to be created")
+				var machineList *v1alpha1.MachineList
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
+
+				ginkgo.By("wait for machine to start running")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				// Simulate kubelet failure for the node
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				machineList = c.ControlCluster.GetMachineList(ctx)
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("remove VAP and VAPB to simulate kubelet restart")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+
+				ginkgo.By("wait for node to recover and move to Running phase")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+			})
+		})
+
+		ginkgo.Context("Ensure that AutoPreserveFailedMachineMax is honoured", func() {
+			ginkgo.It("when number of failed machines cross the threshold, only AutoPreserveFailedMachineMax number of machines are preserved. The rest are terminated", func() {
+				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=1
+				ginkgo.By("Creating a MCD with preservation fields populated")
+				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 2)
+				//Update the standard mcd to have preservation fields with values needed for this test
+				mcd.Spec.AutoPreserveFailedMachineMax = 1
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+						gomega.Expect(err).To(gomega.BeNil())
+						mcd.ResourceVersion = existingMCD.ResourceVersion
+						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+						return updateErr
+					})
+					gomega.Expect(retryErr).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+
+				ginkgo.By("wait for machines to be created")
+				var machineList *v1alpha1.MachineList
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(2)))
+
+				ginkgo.By("wait for machines to start running")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
+					Should(gomega.BeTrue())
+
+				// Get list of running machines
+				machineList = c.ControlCluster.GetMachineList(ctx)
+
+				preservedMachine := machineList.Items[0]
+				nonPreservedMachine := machineList.Items[1]
+
+				// Simulate kubelet failure for one node. We expect this node to be preserved
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for one machine")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{preservedMachine.Name}).
+					Should(gomega.BeTrue())
+
+				// Simulate kubelet failure for the other node too. This node is expected to fail, but is not expected to be preserved
+				// because autoPreserveFailedMachineMax=1 and one machine is already preserved
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for other machine as well")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels["node"], nonPreservedMachine.ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for the other machine to be deleted")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineDeleted,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, nonPreservedMachine.Name).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("cleanup")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+
+			})
+		})
+
+		ginkgo.Context("Should honour presense/absense of lablels", func() {
+			var (
+				machineList *v1alpha1.MachineList
+			)
+			ginkgo.It("preserved machine should stop being preserved when node.machine.sapcloud.io/preserve=false annotation is added", func() {
+				// Create an mcd with replica=1, and AutoPreserveFailedMachineMax=1
+				ginkgo.By("Creating a MCD with preservation fields populated")
+				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				//Update the standard mcd to have preservation fields with values needed for this test
+				mcd.Spec.AutoPreserveFailedMachineMax = 1
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+						gomega.Expect(err).To(gomega.BeNil())
+						mcd.ResourceVersion = existingMCD.ResourceVersion
+						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+						return updateErr
+					})
+					gomega.Expect(retryErr).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+
+				ginkgo.By("wait for machine to be created")
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
+
+				ginkgo.By("wait for machine to start running")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				// Get list of running machines
+				machineList = c.ControlCluster.GetMachineList(ctx)
+
+				// Simulate kubelet failure for the node so that it can be preserved
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the preserved machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueFalse,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+
+				ginkgo.By("Waiting for this machine to now be deleted")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineDeleted,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, machineList.Items[0].Name).
+					Should(gomega.BeTrue())
+
+			})
+			ginkgo.It("running machine with the node.machine.sapcloud.io/preserve=false annotation should not be preserved", func() {
+				ginkgo.By("wait for a new machine to be created")
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
+
+				ginkgo.By("wait for the replacement machine to start running")
+				machineList = c.ControlCluster.GetMachineList(ctx)
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				machineList = c.ControlCluster.GetMachineList(ctx)
+
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation from the running machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueFalse,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+
+				// Simulate kubelet for the node so that it can be preserved
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for this machine")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to be deleted")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineDeleted,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, machineList.Items[0].Name).
+					Should(gomega.BeTrue())
+
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+			})
+		})
+
+		ginkgo.Context("Ensure that machinePreserveTimeout is honoured", func() {
+			ginkgo.It("when number of failed machines cross the threshold, only AutoPreserveFailedMachineMax number of machines are preserved. The rest are terminated", func() {
+				var machineList *v1alpha1.MachineList
+				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
+				ginkgo.By("Create a MCD with preservation fields populated")
+				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				//Update the standard mcd to have preservation fields
+				mcd.Spec.AutoPreserveFailedMachineMax = 1
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout:   &metav1.Duration{Duration: 15 * time.Second},
+					MachinePreserveTimeout: &metav1.Duration{Duration: 1 * time.Minute},
+				}
+
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+						gomega.Expect(err).To(gomega.BeNil())
+						mcd.ResourceVersion = existingMCD.ResourceVersion
+						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+						return updateErr
+					})
+					gomega.Expect(retryErr).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+
+				ginkgo.By("wait for machine to be created")
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
+
+				ginkgo.By("wait for machine to start running")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				// Get list of running machines
+				machineList = c.ControlCluster.GetMachineList(ctx)
+
+				// Simulate kubelet for the node so that it can be preserved
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("Ensure that machine stays preserved for one minute")
+				gomega.Consistently(
+					c.ControlCluster.IsFailingMachinePreserved,
+					1*time.Minute,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("Waiting for machine to be deleted")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineDeleted,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, machineList.Items[0].Name).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("cleanup")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 	})

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -41,8 +41,6 @@ import (
 
 const (
 	dwdIgnoreScalingAnnotation = "dependency-watchdog.gardener.cloud/ignore-scaling"
-	// testMachineDeploymentName  = "test-machine-deployment"
-	// testMachineName            = "test-machine"
 )
 
 var (
@@ -1000,6 +998,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		ginkgo.Context("Auto-Preserve Failed machine", func() {
 			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
 				ginkgo.By("Creating a MCD with preservation fields populated")
+				// mcd replicas for the auto preservation tests are intentionally set to 3. This is done so that we pay the cost of
+				// creating new machines only once and subsequent tests can be run without waiting for new machines to be created.
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
@@ -1110,7 +1110,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 			ginkgo.It("when AutoPreserveFailedMachineMax is reduced, the number of auto-preserved failed machines also gets reduced to honour the new max", func() {
-				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=2
+				// Create an mcd with replica=3, and AutoPreserveFailedMachineMax=2
 				ginkgo.By("Creating a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				// Update the standard mcd to have preservation fields with values needed for this test
@@ -1172,7 +1172,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 		ginkgo.Context("Should honour presence/absence of annotations", func() {
 			ginkgo.It("preserved machine should stop being preserved when node.machine.sapcloud.io/preserve=false annotation is added", func() {
-				// Create an mcd with replica=1, and AutoPreserveFailedMachineMax=1
+				// Create an mcd with replica=3, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields with values needed for this test
@@ -1279,7 +1279,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 		ginkgo.Context("Ensure that machinePreserveTimeout is honoured", func() {
 			ginkgo.It("a preserved machine is terminated once its machinePreserveTimeout expires", func() {
-				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
+				// Create an mcd with replica=3, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
 				ginkgo.By("Create a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields
@@ -1364,7 +1364,9 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		ginkgo.Context("Manual-Preserve Failed machine", func() {
 			ginkgo.It("Should preserve machine when annotated with `preserve=when-failed` on failure and let it join the cluster again when it recovers before preservation timeout", func() {
 				ginkgo.By("Create an MCD with AutoPreserveFailedMachineMax set to 0")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				// mcd replicas for the auto preservation tests are intentionally set to 2. This is done so that we pay the cost of
+				// creating new machines only once and subsequent tests can be run without waiting for new machines to be created.
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 0
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1387,6 +1389,18 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine to ensure it is preserved when it fails
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine")
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved machine")
+					patch := map[string]any{
+						"metadata": map[string]any{
+							"annotations": nil,
+						},
+					}
+					patchBytes, err := json.Marshal(patch)
+					gomega.Expect(err).To(gomega.BeNil())
+					_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+				})
 				patch := map[string]any{
 					"metadata": map[string]any{
 						"annotations": map[string]any{
@@ -1401,6 +1415,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for the node
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
@@ -1424,7 +1443,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			})
 			ginkgo.It("Should preserve machine on failure when it's corresponding node is manually annotated", func() {
 				ginkgo.By("Create a MCD with AutoPreserveFailedMachineMax set to 0")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 0
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1450,6 +1469,18 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				nodeName := runningMachines[0].ObjectMeta.Labels["node"]
 				gomega.Expect(len(nodeName)).Should(gomega.BeNumerically(">", 0))
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running node")
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved node")
+					patch := map[string]any{
+						"metadata": map[string]any{
+							"annotations": nil,
+						},
+					}
+					patchBytes, err := json.Marshal(patch)
+					gomega.Expect(err).To(gomega.BeNil())
+					_, err = c.TargetCluster.Clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+				})
 				patch := map[string]any{
 					"metadata": map[string]any{
 						"annotations": map[string]any{
@@ -1464,6 +1495,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for the node
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
@@ -1489,7 +1525,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		ginkgo.Context("Ensure that machines annotated with `when-failed` are preserved", func() {
 			ginkgo.It("Should ensure that a machine marked for preservation using `when-failed` is preserved even if `autoPreserveFailedMachineMax` number of machines are already preserved", func() {
 				ginkgo.By("Create a MCD with with AutoPreserveFailedMachineMax set to 1")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1512,6 +1548,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for one node so that it can be auto preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for one node")
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be auto-preserved")
@@ -1524,6 +1565,18 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the second machine that is running to ensure it is preserved when it fails
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the other running machine")
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved machine")
+					patch := map[string]any{
+						"metadata": map[string]any{
+							"annotations": nil,
+						},
+					}
+					patchBytes, err := json.Marshal(patch)
+					gomega.Expect(err).To(gomega.BeNil())
+					_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[1].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+				})
 				patch := map[string]any{
 					"metadata": map[string]any{
 						"annotations": map[string]any{
@@ -1549,15 +1602,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name, runningMachines[1].Name}).
 					Should(gomega.BeTrue())
-
-				ginkgo.By("cleanup deployed VAP and VAPB")
-				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 		ginkgo.Context("Ensure preserved machines are deleted when preserve annotation is removed", func() {
 			ginkgo.It("Should ensure that a manually preserved failed machine is deleted if the preservation annotation is removed", func() {
 				ginkgo.By("Create a MCD with no preservation fields populated")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to a low machine health timeout to speed up tests
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
 					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
@@ -1593,6 +1643,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for the node
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
@@ -1621,9 +1676,6 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					WithArguments(ctx, runningMachines[0].Name, controlClusterNamespace).
 					Should(gomega.BeTrue())
-
-				ginkgo.By("cleanup deployed VAP and VAPB")
-				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 	})
@@ -1742,7 +1794,7 @@ func (c *IntegrationTestFramework) cleanTestResources(ctx context.Context, timeo
 	}
 
 	// Check and delete any VAP or VAPB
-	if err := c.ControlCluster.DeleteVAPToRestartKubeletUpdates(ctx); err != nil {
+	if err := c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx); err != nil {
 		log.Println(err.Error())
 	}
 }

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1032,6 +1032,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
 				machineList = c.ControlCluster.GetMachineList(ctx)
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1107,6 +1112,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Simulate kubelet failure for one node. We expect this node to be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for one machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1128,10 +1138,6 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					WithArguments(ctx, nonPreservedMachine.Name).
 					Should(gomega.BeTrue())
-
-				ginkgo.By("cleanup")
-				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
-
 			})
 			ginkgo.It("when AutoPreserveFailedMachineMax is reduced, the number of auto-preserved failed machines also gets reduced to honour the new max", func() {
 				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=2
@@ -1182,6 +1188,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Simulate kubelet failure for both the nodes.
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for both nodes")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"], machineList.Items[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 
 				ginkgo.By("Wait for both machines to fail and be preserved")
 				gomega.Eventually(
@@ -1208,9 +1219,6 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 					return isOnlyMachine0Deleted != isOnlyMachine1Deleted
 				}, c.timeout, c.pollingInterval).Should(gomega.BeTrue())
-
-				ginkgo.By("cleanup")
-				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 
@@ -1266,6 +1274,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1335,6 +1348,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for this machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 
 				ginkgo.By("Waiting for machine to be deleted")
 				gomega.Eventually(
@@ -1343,8 +1361,6 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					WithArguments(ctx, machineList.Items[0].Name).
 					Should(gomega.BeTrue())
-
-				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 
@@ -1399,6 +1415,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
+				ginkgo.DeferCleanup(func() {
+					ginkgo.By("cleanup deployed VAP/VAPB")
+					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+				})
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1423,9 +1444,6 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					WithArguments(ctx, machineList.Items[0].Name).
 					Should(gomega.BeTrue())
-
-				ginkgo.By("cleanup")
-				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 	})
@@ -1525,6 +1543,11 @@ func (c *IntegrationTestFramework) cleanTestResources(ctx context.Context, timeo
 		if err := c.cleanMachineClass(ctx, machineClassName, timeout); err != nil {
 			log.Println(err.Error())
 		}
+	}
+
+	// Check and delete any VAP or VAPB
+	if err := c.ControlCluster.DeleteVAPToRestartKubeletUpdates(ctx); err != nil {
+		log.Println(err.Error())
 	}
 }
 

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1004,7 +1004,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd
@@ -1059,7 +1059,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd
@@ -1116,7 +1116,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 2
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd
@@ -1178,7 +1178,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd
@@ -1285,8 +1285,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				//Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout:   &metav1.Duration{Duration: 15 * time.Second},
-					MachinePreserveTimeout: &metav1.Duration{Duration: 1 * time.Minute},
+					MachineHealthTimeout:   &metav1.Duration{Duration: 5 * time.Second},
+					MachinePreserveTimeout: &metav1.Duration{Duration: 15 * time.Second},
 				}
 
 				// Create mcd
@@ -1320,10 +1320,10 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
 					Should(gomega.BeTrue())
 
-				ginkgo.By("Ensure that machine stays preserved for one minute")
+				ginkgo.By("Ensure that machine stays preserved for MachinePreserveTimeout duration")
 				gomega.Consistently(
 					c.ControlCluster.AreMachinesFailedAndPreserved,
-					1*time.Minute,
+					mcd.Spec.Template.Spec.MachineConfiguration.MachinePreserveTimeout.Duration,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
 					Should(gomega.BeTrue())
@@ -1370,7 +1370,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 0
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd
@@ -1447,7 +1447,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 0
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd
@@ -1529,7 +1529,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd
@@ -1610,7 +1610,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to a low machine health timeout to speed up tests
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
-					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+					MachineHealthTimeout: &metav1.Duration{Duration: 5 * time.Second},
 				}
 
 				// Create mcd

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -976,7 +976,27 @@ func (c *IntegrationTestFramework) ControllerTests() {
 	})
 
 	// Testcase #03 | Auto Preservation of Machines
-	ginkgo.Describe("Auto Machine Preservation", func() {
+	ginkgo.Describe("Auto Machine Preservation", ginkgo.Ordered, func() {
+		ginkgo.AfterAll(func() {
+			ginkgo.By("Delete mcd after auto preservation tests")
+			gomega.Expect(
+				c.ControlCluster.McmClient.
+					MachineV1alpha1().
+					MachineDeployments(controlClusterNamespace).
+					Delete(
+						ctx,
+						testMachineDeploymentName,
+						metav1.DeleteOptions{},
+					)).
+				Should(gomega.BeNil())
+
+			gomega.Eventually(
+				c.ControlCluster.IsMachineDeploymentDeleted,
+				c.timeout,
+				c.pollingInterval).
+				WithArguments(ctx, helpers.McdName, controlClusterNamespace).
+				Should(gomega.BeTrue())
+		})
 		ginkgo.Context("Auto-Preserve Failed machine", func() {
 			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
 				ginkgo.By("Creating a MCD with preservation fields populated")
@@ -1319,7 +1339,299 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 	})
 
-	// Testcase #04 | Orphaned Resources
+	// Testcase #04 | Manual Machine preservation
+	ginkgo.Describe("Manual Machine Preservation", ginkgo.Ordered, func() {
+		ginkgo.AfterAll(func() {
+			ginkgo.By("Delete mcd after manual preservation tests")
+			gomega.Expect(
+				c.ControlCluster.McmClient.
+					MachineV1alpha1().
+					MachineDeployments(controlClusterNamespace).
+					Delete(
+						ctx,
+						testMachineDeploymentName,
+						metav1.DeleteOptions{},
+					)).
+				Should(gomega.BeNil())
+
+			gomega.Eventually(
+				c.ControlCluster.IsMachineDeploymentDeleted,
+				c.timeout,
+				c.pollingInterval).
+				WithArguments(ctx, helpers.McdName, controlClusterNamespace).
+				Should(gomega.BeTrue())
+		})
+		ginkgo.Context("Manual-Preserve Failed machine", func() {
+			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
+				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
+				ginkgo.By("Create a MCD with no preservation fields populated")
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				// Update the standard mcd to have preservation fields
+				mcd.Spec.AutoPreserveFailedMachineMax = 0
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("wait for atleast one machine to start running")
+				var runningMachines []v1alpha1.Machine
+				gomega.Eventually(
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
+					},
+					c.timeout,
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
+
+				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine to ensure it is preserved when it fails
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				// Simulate kubelet failure for the node
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.AreFailingMachinesPreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("remove VAP and VAPB to simulate kubelet restart")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+
+				ginkgo.By("wait for machine to recover and move to Running phase")
+				gomega.Eventually(
+					c.ControlCluster.AreMachinesRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{runningMachines[0].Name}, controlClusterNamespace).
+					Should(gomega.BeTrue())
+			})
+			ginkgo.It("Should preserve machine on failure when it's corresponding node is manually annotated", func() {
+				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
+				ginkgo.By("Create a MCD with no preservation fields populated")
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				// Update the standard mcd to have preservation fields
+				mcd.Spec.AutoPreserveFailedMachineMax = 0
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("wait for atleast one machine to start running")
+				var runningMachines []v1alpha1.Machine
+				gomega.Eventually(
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
+					},
+					c.timeout,
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
+
+				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running node to ensure its corresponding machine is preserved when it fails
+				ginkgo.By("get node name from machine")
+				nodeName := runningMachines[0].ObjectMeta.Labels["node"]
+				gomega.Expect(len(nodeName)).Should(gomega.BeNumerically(">", 0))
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running node")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				//_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				_, err = c.TargetCluster.Clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				// Simulate kubelet failure for the node
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.AreFailingMachinesPreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("remove VAP and VAPB to simulate kubelet restart")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+
+				ginkgo.By("wait for machine to recover and move to Running phase")
+				gomega.Eventually(
+					c.ControlCluster.AreMachinesRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{runningMachines[0].Name}, controlClusterNamespace).
+					Should(gomega.BeTrue())
+			})
+		})
+		ginkgo.Context("Ensure that machine annotated with `when-failed` are preserved", func() {
+			ginkgo.It("Should ensure that a machine marked for preservation using `when-failed` is preserved even if `autoPreserveFailedMachineMax` number of machines are already preserved", func() {
+				ginkgo.By("Create a MCD with no preservation fields populated")
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				// Update the standard mcd to have preservation fields
+				mcd.Spec.AutoPreserveFailedMachineMax = 1
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("wait for atleast two machine to start running")
+				var runningMachines []v1alpha1.Machine
+				gomega.Eventually(
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
+					},
+					c.timeout,
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 2))
+
+				// Simulate kubelet failure for one node so that it can be auto preserved
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for one node")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be auto-preserved")
+				gomega.Eventually(
+					c.ControlCluster.AreFailingMachinesPreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
+					Should(gomega.BeTrue())
+
+				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the second machine that is running to ensure it is preserved when it fails
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the other running machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[1].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				// Simulate kubelet failure for the second node.
+				// The first node is already auto-preserved and counts AutoPreserveFailedMachineMax.
+				// We expect this machine to be preserved as well since it is explicitely marked
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the second machine")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"], runningMachines[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for second machine to fail and be preserved while ensurint that the first machine remains preserved")
+				gomega.Eventually(
+					c.ControlCluster.AreFailingMachinesPreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name, runningMachines[1].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("cleanup deployed VAP and VAPB")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+			})
+		})
+		ginkgo.Context("Ensure preserved machines are deleted when preserve annotated is removed", func() {
+			ginkgo.It("Should ensure that a manually preserved machine is deleted if the preservation annotation is removed", func() {
+				ginkgo.By("Create a MCD with no preservation fields populated")
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
+				// Update the standard mcd to a low machine health timeout to speed up tests
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("wait for atleast one machine to start running")
+				var runningMachines []v1alpha1.Machine
+				gomega.Eventually(
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
+					},
+					c.timeout,
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
+
+				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine to ensure it is preserved when it fails
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				// Simulate kubelet failure for the node
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.AreFailingMachinesPreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved machine")
+				patch = map[string]any{
+					"metadata": map[string]any{
+						"annotations": nil,
+					},
+				}
+				patchBytes, err = json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("wait for machine to be deleted")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineDeleted,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, runningMachines[0].Name, controlClusterNamespace).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("cleanup deployed VAP and VAPB")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+			})
+		})
+	})
+
+	// Testcase #05 | Orphaned Resources
 	ginkgo.Describe("orphaned resources", func() {
 		ginkgo.Context("when the hyperscaler resources are queried", func() {
 			ginkgo.It("should have been deleted", func() {

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -26,7 +26,8 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	appsV1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -696,6 +697,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 							c.ControlCluster.IsTestMachineDeleted,
 							c.timeout,
 							c.pollingInterval).
+							WithArguments(ctx, controlClusterNamespace).
 							Should(gomega.BeTrue())
 
 						ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes")
@@ -962,6 +964,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 							c.timeout,
 							c.pollingInterval).
 							Should(gomega.BeNumerically("==", initialNodes))
+
+						gomega.Eventually(func() error {
+							_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+							return err
+						}, c.timeout, c.pollingInterval).Should(gomega.Satisfy(apierrors.IsNotFound))
 					}
 				})
 			})
@@ -989,49 +996,30 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		ginkgo.Context("Auto-Preserve Failed machine", func() {
 			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
 					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
 				}
-				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
-				if errors.IsAlreadyExists(err) {
-					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
-						gomega.Expect(err).To(gomega.BeNil())
-						mcd.ResourceVersion = existingMCD.ResourceVersion
-						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
-						return updateErr
-					})
-					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else {
-					gomega.Expect(err).To(gomega.BeNil())
-				}
 
-				ginkgo.By("wait for machine to be created")
-				var machineList *v1alpha1.MachineList
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("wait for atleast one machine to start running")
+				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
-					func() *v1alpha1.MachineList {
-						machineList = c.ControlCluster.GetMachineList(ctx)
-						return machineList
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
 					},
 					c.timeout,
-					c.pollingInterval).
-					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
-
-				ginkgo.By("wait for machine to start running")
-				gomega.Eventually(
-					c.ControlCluster.AreMachinesRunning,
-					c.timeout,
-					c.pollingInterval).
-					WithArguments(ctx, []string{machineList.Items[0].Name}).
-					Should(gomega.BeTrue())
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
 
 				// Simulate kubelet failure for the node
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
-				machineList = c.ControlCluster.GetMachineList(ctx)
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
@@ -1043,7 +1031,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("remove VAP and VAPB to simulate kubelet restart")
@@ -1054,7 +1042,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.AreMachinesRunning,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, []string{runningMachines[0].Name}, controlClusterNamespace).
 					Should(gomega.BeTrue())
 			})
 		})
@@ -1063,51 +1051,29 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			ginkgo.It("when number of failed machines cross the threshold, only AutoPreserveFailedMachineMax number of machines are preserved. The rest are terminated", func() {
 				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
 					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
 				}
 
-				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
-				if errors.IsAlreadyExists(err) {
-					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
-						gomega.Expect(err).To(gomega.BeNil())
-						mcd.ResourceVersion = existingMCD.ResourceVersion
-						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
-						return updateErr
-					})
-					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else {
-					gomega.Expect(err).To(gomega.BeNil())
-				}
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
 
-				ginkgo.By("wait for machines to be created")
-				var machineList *v1alpha1.MachineList
+				ginkgo.By("wait for two machine to start running")
+				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
-					func() *v1alpha1.MachineList {
-						machineList = c.ControlCluster.GetMachineList(ctx)
-						return machineList
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
 					},
 					c.timeout,
-					c.pollingInterval).
-					Should(gomega.HaveField("Items", gomega.HaveLen(2)))
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 2))
 
-				ginkgo.By("wait for machines to start running")
-				gomega.Eventually(
-					c.ControlCluster.AreMachinesRunning,
-					c.timeout,
-					c.pollingInterval).
-					WithArguments(ctx, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
-					Should(gomega.BeTrue())
-
-				// Get list of running machines
-				machineList = c.ControlCluster.GetMachineList(ctx)
-
-				preservedMachine := machineList.Items[0]
-				nonPreservedMachine := machineList.Items[1]
+				preservedMachine := runningMachines[0]
+				nonPreservedMachine := runningMachines[1]
 
 				// Simulate kubelet failure for one node. We expect this node to be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for one machine")
@@ -1136,58 +1102,36 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsMachineDeleted,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, nonPreservedMachine.Name).
+					WithArguments(ctx, nonPreservedMachine.Name, controlClusterNamespace).
 					Should(gomega.BeTrue())
 			})
 			ginkgo.It("when AutoPreserveFailedMachineMax is reduced, the number of auto-preserved failed machines also gets reduced to honour the new max", func() {
 				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=2
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				// Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 2
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
 					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
 				}
 
-				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
-				if errors.IsAlreadyExists(err) {
-					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
-						gomega.Expect(err).To(gomega.BeNil())
-						mcd.ResourceVersion = existingMCD.ResourceVersion
-						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
-						return updateErr
-					})
-					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else {
-					gomega.Expect(err).To(gomega.BeNil())
-				}
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
 
-				ginkgo.By("wait for machines to be created")
-				var machineList *v1alpha1.MachineList
+				ginkgo.By("wait for two machine to start running")
+				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
-					func() *v1alpha1.MachineList {
-						machineList = c.ControlCluster.GetMachineList(ctx)
-						return machineList
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
 					},
 					c.timeout,
-					c.pollingInterval).
-					Should(gomega.HaveField("Items", gomega.HaveLen(2)))
-
-				ginkgo.By("wait for machines to start running")
-				gomega.Eventually(
-					c.ControlCluster.AreMachinesRunning,
-					c.timeout,
-					c.pollingInterval).
-					WithArguments(ctx, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
-					Should(gomega.BeTrue())
-
-				// Get list of running machines
-				machineList = c.ControlCluster.GetMachineList(ctx)
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 2))
 
 				// Simulate kubelet failure for both the nodes.
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for both nodes")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"], machineList.Items[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"], runningMachines[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
@@ -1199,7 +1143,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name, runningMachines[1].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Reduce mcd.AutoPreserveFailedMachineMax to 1")
@@ -1214,8 +1158,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("wait for only one machine to be deleted while the other one stays preserved")
 				gomega.Eventually(func() bool {
-					isOnlyMachine0Deleted := c.ControlCluster.IsMachineDeleted(ctx, machineList.Items[0].Name) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{machineList.Items[1].Name})
-					isOnlyMachine1Deleted := c.ControlCluster.IsMachineDeleted(ctx, machineList.Items[1].Name) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{machineList.Items[0].Name})
+					isOnlyMachine0Deleted := c.ControlCluster.IsMachineDeleted(ctx, runningMachines[0].Name, controlClusterNamespace) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{runningMachines[1].Name})
+					isOnlyMachine1Deleted := c.ControlCluster.IsMachineDeleted(ctx, runningMachines[1].Name, controlClusterNamespace) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{runningMachines[0].Name})
 
 					return isOnlyMachine0Deleted != isOnlyMachine1Deleted
 				}, c.timeout, c.pollingInterval).Should(gomega.BeTrue())
@@ -1223,57 +1167,33 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 
 		ginkgo.Context("Should honour presence/absence of labels", func() {
-			var (
-				machineList *v1alpha1.MachineList
-			)
 			ginkgo.It("preserved machine should stop being preserved when node.machine.sapcloud.io/preserve=false annotation is added", func() {
 				// Create an mcd with replica=1, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
 					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
 				}
 
-				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
-				if errors.IsAlreadyExists(err) {
-					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
-						gomega.Expect(err).To(gomega.BeNil())
-						mcd.ResourceVersion = existingMCD.ResourceVersion
-						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
-						return updateErr
-					})
-					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else {
-					gomega.Expect(err).To(gomega.BeNil())
-				}
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
 
-				ginkgo.By("wait for machine to be created")
+				ginkgo.By("wait for atleast one machine to start running")
+				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
-					func() *v1alpha1.MachineList {
-						machineList = c.ControlCluster.GetMachineList(ctx)
-						return machineList
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
 					},
 					c.timeout,
-					c.pollingInterval).
-					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
-
-				ginkgo.By("wait for machine to start running")
-				gomega.Eventually(
-					c.ControlCluster.AreMachinesRunning,
-					c.timeout,
-					c.pollingInterval).
-					WithArguments(ctx, []string{machineList.Items[0].Name}).
-					Should(gomega.BeTrue())
-
-				// Get list of running machines
-				machineList = c.ControlCluster.GetMachineList(ctx)
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
 
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
@@ -1285,7 +1205,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the preserved machine")
@@ -1298,7 +1218,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				}
 				patchBytes, err := json.Marshal(patch)
 				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for this machine to now be deleted")
@@ -1306,31 +1226,20 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsMachineDeleted,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, machineList.Items[0].Name).
+					WithArguments(ctx, runningMachines[0].Name, controlClusterNamespace).
 					Should(gomega.BeTrue())
 
 			})
 			ginkgo.It("running machine with the node.machine.sapcloud.io/preserve=false annotation should not be auto-preserved", func() {
-				ginkgo.By("wait for a new machine to be created")
+				ginkgo.By("wait for atleast one machine to start running")
+				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
-					func() *v1alpha1.MachineList {
-						machineList = c.ControlCluster.GetMachineList(ctx)
-						return machineList
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
 					},
 					c.timeout,
-					c.pollingInterval).
-					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
-
-				ginkgo.By("wait for machine to start running")
-				machineList = c.ControlCluster.GetMachineList(ctx)
-				gomega.Eventually(
-					c.ControlCluster.AreMachinesRunning,
-					c.timeout,
-					c.pollingInterval).
-					WithArguments(ctx, []string{machineList.Items[0].Name}).
-					Should(gomega.BeTrue())
-
-				machineList = c.ControlCluster.GetMachineList(ctx)
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
 
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the running machine")
 				patch := map[string]any{
@@ -1342,12 +1251,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				}
 				patchBytes, err := json.Marshal(patch)
 				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for this machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
@@ -1359,17 +1268,16 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsMachineDeleted,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, machineList.Items[0].Name).
+					WithArguments(ctx, runningMachines[0].Name, controlClusterNamespace).
 					Should(gomega.BeTrue())
 			})
 		})
 
 		ginkgo.Context("Ensure that machinePreserveTimeout is honoured", func() {
 			ginkgo.It("a preserved machine is terminated once its machinePreserveTimeout expires", func() {
-				var machineList *v1alpha1.MachineList
 				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
 				ginkgo.By("Create a MCD with preservation fields populated")
-				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1377,44 +1285,23 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					MachinePreserveTimeout: &metav1.Duration{Duration: 1 * time.Minute},
 				}
 
-				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
-				if errors.IsAlreadyExists(err) {
-					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
-						gomega.Expect(err).To(gomega.BeNil())
-						mcd.ResourceVersion = existingMCD.ResourceVersion
-						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
-						return updateErr
-					})
-					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else {
-					gomega.Expect(err).To(gomega.BeNil())
-				}
+				// Create mcd
+				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
+				gomega.Expect(err).To(gomega.BeNil())
 
-				ginkgo.By("wait for machine to be created")
+				ginkgo.By("wait for atleast one machine to start running")
+				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
-					func() *v1alpha1.MachineList {
-						machineList = c.ControlCluster.GetMachineList(ctx)
-						return machineList
+					func() int {
+						runningMachines, _ = c.ControlCluster.GetRunningMachineList(ctx, controlClusterNamespace)
+						return len(runningMachines)
 					},
 					c.timeout,
-					c.pollingInterval).
-					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
-
-				ginkgo.By("wait for machine to start running")
-				gomega.Eventually(
-					c.ControlCluster.AreMachinesRunning,
-					c.timeout,
-					c.pollingInterval).
-					WithArguments(ctx, []string{machineList.Items[0].Name}).
-					Should(gomega.BeTrue())
-
-				// Get list of running machines
-				machineList = c.ControlCluster.GetMachineList(ctx)
+					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
 
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
@@ -1426,7 +1313,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Ensure that machine stays preserved for one minute")
@@ -1434,7 +1321,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.AreFailingMachinesPreserved,
 					1*time.Minute,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Waiting for machine to be deleted")
@@ -1442,7 +1329,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsMachineDeleted,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, machineList.Items[0].Name).
+					WithArguments(ctx, runningMachines[0].Name, controlClusterNamespace).
 					Should(gomega.BeTrue())
 			})
 		})

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1170,7 +1170,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			})
 		})
 
-		ginkgo.Context("Should honour presence/absence of labels", func() {
+		ginkgo.Context("Should honour presence/absence of annotations", func() {
 			ginkgo.It("preserved machine should stop being preserved when node.machine.sapcloud.io/preserve=false annotation is added", func() {
 				// Create an mcd with replica=1, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
@@ -1362,9 +1362,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				Should(gomega.BeTrue())
 		})
 		ginkgo.Context("Manual-Preserve Failed machine", func() {
-			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
-				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
-				ginkgo.By("Create a MCD with no preservation fields populated")
+			ginkgo.It("Should preserve machine when annotated with `preserve=when-failed` on failure and let it join the cluster again when it recovers before preservation timeout", func() {
+				ginkgo.By("Create an MCD with AutoPreserveFailedMachineMax set to 0")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 0
@@ -1424,8 +1423,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 			ginkgo.It("Should preserve machine on failure when it's corresponding node is manually annotated", func() {
-				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
-				ginkgo.By("Create a MCD with no preservation fields populated")
+				ginkgo.By("Create a MCD with AutoPreserveFailedMachineMax set to 0")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 0
@@ -1461,7 +1459,6 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				}
 				patchBytes, err := json.Marshal(patch)
 				gomega.Expect(err).To(gomega.BeNil())
-				//_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 				_, err = c.TargetCluster.Clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 				gomega.Expect(err).To(gomega.BeNil())
 
@@ -1489,9 +1486,9 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 		})
-		ginkgo.Context("Ensure that machine annotated with `when-failed` are preserved", func() {
+		ginkgo.Context("Ensure that machines annotated with `when-failed` are preserved", func() {
 			ginkgo.It("Should ensure that a machine marked for preservation using `when-failed` is preserved even if `autoPreserveFailedMachineMax` number of machines are already preserved", func() {
-				ginkgo.By("Create a MCD with no preservation fields populated")
+				ginkgo.By("Create a MCD with with AutoPreserveFailedMachineMax set to 1")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
@@ -1540,12 +1537,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet failure for the second node.
-				// The first node is already auto-preserved and counts AutoPreserveFailedMachineMax.
+				// The first node is already auto-preserved and counts towards AutoPreserveFailedMachineMax.
 				// We expect this machine to be preserved as well since it is explicitely marked
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the second machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"], runningMachines[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
-				ginkgo.By("Waiting for second machine to fail and be preserved while ensurint that the first machine remains preserved")
+				ginkgo.By("Waiting for second machine to fail and be preserved while ensuring that the first machine remains preserved")
 				gomega.Eventually(
 					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
@@ -1557,8 +1554,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
-		ginkgo.Context("Ensure preserved machines are deleted when preserve annotated is removed", func() {
-			ginkgo.It("Should ensure that a manually preserved machine is deleted if the preservation annotation is removed", func() {
+		ginkgo.Context("Ensure preserved machines are deleted when preserve annotation is removed", func() {
+			ginkgo.It("Should ensure that a manually preserved failed machine is deleted if the preservation annotation is removed", func() {
 				ginkgo.By("Create a MCD with no preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				// Update the standard mcd to a low machine health timeout to speed up tests

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -984,7 +984,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 	})
 
-	// Testcase #04 | Auto Machine preservation
+	// Testcase #04 | Auto Preservation of Machines
 	ginkgo.Describe("Auto Machine Preservation", func() {
 		ginkgo.Context("Auto-Preserve Failed machine", func() {
 			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
@@ -1005,7 +1005,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 						return updateErr
 					})
 					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else if !errors.IsAlreadyExists(err) {
+				} else {
 					gomega.Expect(err).To(gomega.BeNil())
 				}
 
@@ -1075,7 +1075,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 						return updateErr
 					})
 					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else if !errors.IsAlreadyExists(err) {
+				} else {
 					gomega.Expect(err).To(gomega.BeNil())
 				}
 
@@ -1133,11 +1133,11 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 
 			})
-			ginkgo.It("when AutoPreserveFailedMachineMax is reduced, number of preserved failed machines also get reduced", func() {
+			ginkgo.It("when AutoPreserveFailedMachineMax is reduced, the number of auto-preserved failed machines also gets reduced to honour the new max", func() {
 				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=2
 				ginkgo.By("Creating a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
-				//Update the standard mcd to have preservation fields with values needed for this test
+				// Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 2
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
 					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
@@ -1153,7 +1153,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 						return updateErr
 					})
 					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else if !errors.IsAlreadyExists(err) {
+				} else {
 					gomega.Expect(err).To(gomega.BeNil())
 				}
 
@@ -1238,7 +1238,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 						return updateErr
 					})
 					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else if !errors.IsAlreadyExists(err) {
+				} else {
 					gomega.Expect(err).To(gomega.BeNil())
 				}
 
@@ -1371,7 +1371,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 						return updateErr
 					})
 					gomega.Expect(retryErr).To(gomega.BeNil())
-				} else if !errors.IsAlreadyExists(err) {
+				} else {
 					gomega.Expect(err).To(gomega.BeNil())
 				}
 

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1003,12 +1003,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for the node
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1061,12 +1061,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for one node. We expect this node to be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for one machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1115,12 +1115,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for both the nodes.
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for both nodes")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"], runningMachines[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"], runningMachines[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Wait for both machines to fail and be preserved")
 				gomega.Eventually(
@@ -1177,12 +1177,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1240,12 +1240,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for this machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to be deleted")
 				gomega.Eventually(
@@ -1285,12 +1285,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 				// Defer VAP/VAPB cleanup to ensure that they are removed even if test fails
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -989,7 +989,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		ginkgo.Context("Auto-Preserve Failed machine", func() {
 			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 1)
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1022,7 +1022,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("wait for machine to start running")
 				gomega.Eventually(
-					c.ControlCluster.IsMachineRunning,
+					c.ControlCluster.AreMachinesRunning,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, []string{machineList.Items[0].Name}).
@@ -1038,15 +1038,15 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsFailingMachinePreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("remove VAP and VAPB to simulate kubelet restart")
 				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 
-				ginkgo.By("wait for node to recover and move to Running phase")
+				ginkgo.By("wait for machine to recover and move to Running phase")
 				gomega.Eventually(
-					c.ControlCluster.IsMachineRunning,
+					c.ControlCluster.AreMachinesRunning,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, []string{machineList.Items[0].Name}).
@@ -1058,7 +1058,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			ginkgo.It("when number of failed machines cross the threshold, only AutoPreserveFailedMachineMax number of machines are preserved. The rest are terminated", func() {
 				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 2)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1092,7 +1092,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("wait for machines to start running")
 				gomega.Eventually(
-					c.ControlCluster.IsMachineRunning,
+					c.ControlCluster.AreMachinesRunning,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
@@ -1113,7 +1113,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsFailingMachinePreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{preservedMachine.Name}).
+					WithArguments(ctx, controlClusterNamespace, preservedMachine.Name).
 					Should(gomega.BeTrue())
 
 				// Simulate kubelet failure for the other node too. This node is expected to fail, but is not expected to be preserved
@@ -1142,7 +1142,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			ginkgo.It("preserved machine should stop being preserved when node.machine.sapcloud.io/preserve=false annotation is added", func() {
 				// Create an mcd with replica=1, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 1)
 				//Update the standard mcd to have preservation fields with values needed for this test
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1175,7 +1175,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("wait for machine to start running")
 				gomega.Eventually(
-					c.ControlCluster.IsMachineRunning,
+					c.ControlCluster.AreMachinesRunning,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, []string{machineList.Items[0].Name}).
@@ -1193,7 +1193,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsFailingMachinePreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the preserved machine")
@@ -1218,7 +1218,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 
 			})
-			ginkgo.It("running machine with the node.machine.sapcloud.io/preserve=false annotation should not be preserved", func() {
+			ginkgo.It("running machine with the node.machine.sapcloud.io/preserve=false annotation should not be auto-preserved", func() {
 				ginkgo.By("wait for a new machine to be created")
 				gomega.Eventually(
 					func() *v1alpha1.MachineList {
@@ -1229,10 +1229,10 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
 
-				ginkgo.By("wait for the replacement machine to start running")
+				ginkgo.By("wait for machine to start running")
 				machineList = c.ControlCluster.GetMachineList(ctx)
 				gomega.Eventually(
-					c.ControlCluster.IsMachineRunning,
+					c.ControlCluster.AreMachinesRunning,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, []string{machineList.Items[0].Name}).
@@ -1274,7 +1274,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				var machineList *v1alpha1.MachineList
 				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
 				ginkgo.By("Create a MCD with preservation fields populated")
-				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 1)
 				//Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
@@ -1308,7 +1308,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("wait for machine to start running")
 				gomega.Eventually(
-					c.ControlCluster.IsMachineRunning,
+					c.ControlCluster.AreMachinesRunning,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, []string{machineList.Items[0].Name}).
@@ -1326,7 +1326,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsFailingMachinePreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Ensure that machine stays preserved for one minute")
@@ -1334,7 +1334,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.ControlCluster.IsFailingMachinePreserved,
 					1*time.Minute,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Waiting for machine to be deleted")

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1135,7 +1135,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			})
 		})
 
-		ginkgo.Context("Should honour presense/absense of lablels", func() {
+		ginkgo.Context("Should honour presence/absence of labels", func() {
 			var (
 				machineList *v1alpha1.MachineList
 			)
@@ -1240,7 +1240,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				machineList = c.ControlCluster.GetMachineList(ctx)
 
-				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation from the running machine")
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the running machine")
 				patch := map[string]any{
 					"metadata": map[string]any{
 						"annotations": map[string]any{
@@ -1253,7 +1253,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 				gomega.Expect(err).To(gomega.BeNil())
 
-				// Simulate kubelet for the node so that it can be preserved
+				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for this machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 
@@ -1270,7 +1270,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 
 		ginkgo.Context("Ensure that machinePreserveTimeout is honoured", func() {
-			ginkgo.It("when number of failed machines cross the threshold, only AutoPreserveFailedMachineMax number of machines are preserved. The rest are terminated", func() {
+			ginkgo.It("a preserved machine is terminated once its machinePreserveTimeout expires", func() {
 				var machineList *v1alpha1.MachineList
 				// Create an mcd with replica=1, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
 				ginkgo.By("Create a MCD with preservation fields populated")
@@ -1317,7 +1317,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Get list of running machines
 				machineList = c.ControlCluster.GetMachineList(ctx)
 
-				// Simulate kubelet for the node so that it can be preserved
+				// Simulate kubelet failure for the node so that it can be preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
 

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -41,8 +41,8 @@ import (
 
 const (
 	dwdIgnoreScalingAnnotation = "dependency-watchdog.gardener.cloud/ignore-scaling"
-	testMachineDeploymentName  = "test-machine-deployment"
-	testMachineName            = "test-machine"
+	// testMachineDeploymentName  = "test-machine-deployment"
+	// testMachineName            = "test-machine"
 )
 
 var (
@@ -689,15 +689,15 @@ func (c *IntegrationTestFramework) ControllerTests() {
 							c.ControlCluster.McmClient.
 								MachineV1alpha1().
 								Machines(controlClusterNamespace).
-								Delete(ctx, testMachineName, metav1.DeleteOptions{})).
+								Delete(ctx, helpers.McName, metav1.DeleteOptions{})).
 							Should(gomega.BeNil(), "No Errors while deleting machine")
 
 						ginkgo.By("Waiting until test-machine machine object is deleted")
 						gomega.Eventually(
-							c.ControlCluster.IsTestMachineDeleted,
+							c.ControlCluster.IsMachineDeleted,
 							c.timeout,
 							c.pollingInterval).
-							WithArguments(ctx, controlClusterNamespace).
+							WithArguments(ctx, helpers.McName, controlClusterNamespace).
 							Should(gomega.BeTrue())
 
 						ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes")
@@ -762,7 +762,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					machineDeployment, _ = c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					machineDeployment.Spec.Replicas = 1
 					_, updateErr := c.ControlCluster.McmClient.
 						MachineV1alpha1().
@@ -779,7 +779,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					machineDeployment, err = c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					if len(machineDeployment.Status.Conditions) != 2 {
 						return false
@@ -819,7 +819,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					machineDployment, _ := c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					machineDployment.Spec.Replicas = 6
 					_, updateErr := c.ControlCluster.McmClient.
 						MachineV1alpha1().
@@ -849,7 +849,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					machineDployment, _ := c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					machineDployment.Spec.Replicas = 2
 					_, updateErr := c.ControlCluster.McmClient.
 						MachineV1alpha1().
@@ -887,7 +887,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					machineDployment, _ := c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					machineDployment.Spec.Template.Spec.Class.Name = testMachineClassResources[1]
 					machineDployment.Spec.Replicas = 4
 					_, updateErr := c.ControlCluster.McmClient.
@@ -903,7 +903,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					machineDeployment, err := c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					if err != nil {
 						log.Println("Failed to get machinedeployment object")
 					}
@@ -914,7 +914,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					machineDeployment, err := c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					if err != nil {
 						log.Println("Failed to get machinedeployment object")
 					}
@@ -940,7 +940,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					_, err := c.ControlCluster.McmClient.
 						MachineV1alpha1().
 						MachineDeployments(controlClusterNamespace).
-						Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+						Get(ctx, helpers.McdName, metav1.GetOptions{})
 					if err == nil {
 						ginkgo.By("Checking for errors")
 						gomega.Expect(
@@ -949,7 +949,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 								MachineDeployments(controlClusterNamespace).
 								Delete(
 									ctx,
-									testMachineDeploymentName,
+									helpers.McdName,
 									metav1.DeleteOptions{},
 								)).
 							Should(gomega.BeNil())
@@ -966,7 +966,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 							Should(gomega.BeNumerically("==", initialNodes))
 
 						gomega.Eventually(func() error {
-							_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(ctx, testMachineDeploymentName, metav1.GetOptions{})
+							_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(ctx, helpers.McdName, metav1.GetOptions{})
 							return err
 						}, c.timeout, c.pollingInterval).Should(gomega.Satisfy(apierrors.IsNotFound))
 					}
@@ -985,7 +985,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					MachineDeployments(controlClusterNamespace).
 					Delete(
 						ctx,
-						testMachineDeploymentName,
+						helpers.McdName,
 						metav1.DeleteOptions{},
 					)).
 				Should(gomega.BeNil())
@@ -1032,7 +1032,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1090,7 +1090,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{preservedMachine.Name}).
@@ -1144,7 +1144,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Wait for both machines to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name, runningMachines[1].Name}).
@@ -1162,8 +1162,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("wait for only one machine to be deleted while the other one stays preserved")
 				gomega.Eventually(func() bool {
-					isOnlyMachine0Deleted := c.ControlCluster.IsMachineDeleted(ctx, runningMachines[0].Name, controlClusterNamespace) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{runningMachines[1].Name})
-					isOnlyMachine1Deleted := c.ControlCluster.IsMachineDeleted(ctx, runningMachines[1].Name, controlClusterNamespace) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{runningMachines[0].Name})
+					isOnlyMachine0Deleted := c.ControlCluster.IsMachineDeleted(ctx, runningMachines[0].Name, controlClusterNamespace) && c.ControlCluster.AreMachinesFailedAndPreserved(ctx, controlClusterNamespace, []string{runningMachines[1].Name})
+					isOnlyMachine1Deleted := c.ControlCluster.IsMachineDeleted(ctx, runningMachines[1].Name, controlClusterNamespace) && c.ControlCluster.AreMachinesFailedAndPreserved(ctx, controlClusterNamespace, []string{runningMachines[0].Name})
 
 					return isOnlyMachine0Deleted != isOnlyMachine1Deleted
 				}, c.timeout, c.pollingInterval).Should(gomega.BeTrue())
@@ -1206,7 +1206,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1314,7 +1314,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1322,7 +1322,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Ensure that machine stays preserved for one minute")
 				gomega.Consistently(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					1*time.Minute,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1349,7 +1349,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					MachineDeployments(controlClusterNamespace).
 					Delete(
 						ctx,
-						testMachineDeploymentName,
+						helpers.McdName,
 						metav1.DeleteOptions{},
 					)).
 				Should(gomega.BeNil())
@@ -1406,7 +1406,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1471,7 +1471,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1519,7 +1519,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be auto-preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1547,7 +1547,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for second machine to fail and be preserved while ensurint that the first machine remains preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name, runningMachines[1].Name}).
@@ -1600,7 +1600,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.AreFailingMachinesPreserved,
+					c.ControlCluster.AreMachinesFailedAndPreserved,
 					c.timeout,
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
@@ -1729,11 +1729,11 @@ func (c *IntegrationTestFramework) Cleanup() {
 
 func (c *IntegrationTestFramework) cleanTestResources(ctx context.Context, timeout int64) {
 	// Check and delete machinedeployment resource
-	if err := c.cleanMachineDeployment(ctx, testMachineDeploymentName, timeout); err != nil {
+	if err := c.cleanMachineDeployment(ctx, helpers.McdName, timeout); err != nil {
 		log.Println(err.Error())
 	}
 	// Check and delete machine resource
-	if err := c.cleanMachine(ctx, testMachineName, timeout); err != nil {
+	if err := c.cleanMachine(ctx, helpers.McName, timeout); err != nil {
 		log.Println(err.Error())
 	}
 
@@ -1923,7 +1923,7 @@ func (c *IntegrationTestFramework) getTestMachineSets(ctx context.Context, names
 	testMachineSets := []string{}
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	for _, machineSet := range machineSets.Items {
-		if machineSet.OwnerReferences[0].Name == testMachineDeploymentName {
+		if machineSet.OwnerReferences[0].Name == helpers.McdName {
 			testMachineSets = append(testMachineSets, machineSet.Name)
 		}
 	}

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -976,7 +976,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 	// Testcase #03 | Preservation of Machines
 	ginkgo.Describe("Machine Preservation", ginkgo.Ordered, func() {
 		ginkgo.AfterAll(func() {
-			ginkgo.By("Delete mcd after auto preservation tests")
+			ginkgo.By("Delete mcd after preservation tests")
 			gomega.Expect(
 				c.ControlCluster.McmClient.
 					MachineV1alpha1().
@@ -998,7 +998,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		ginkgo.Context("Should auto-preserve a failed machine", func() {
 			ginkgo.It("When it fails and the machine should re-join the cluster if it recovers before the preservation timeout", func() {
 				ginkgo.By("Creating a MCD with preservation fields populated")
-				// mcd replicas for the auto preservation tests are intentionally set to 3. This is done so that we pay the cost of
+				// mcd replicas for the preservation tests are intentionally set to 3. This is done so that we pay the cost of
 				// creating new machines only once and subsequent tests can be run without waiting for new machines to be created.
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
 				//Update the standard mcd to have preservation fields with values needed for this test
@@ -1268,7 +1268,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Create an mcd with replica=3, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
 				ginkgo.By("Create a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
-				//Update the standard mcd to have preservation fields
+				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
 				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
 					MachineHealthTimeout:   &metav1.Duration{Duration: 5 * time.Second},
@@ -1307,7 +1307,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Ensure that machine stays preserved for MachinePreserveTimeout duration")
-				// Duration of check reduced by a small amount to account for any pollible flakes arrising due to delays in this running this check
+				// Duration of check reduced by a small amount to account for any possible flakes arising due to delays in running this check
 				gomega.Consistently(
 					c.ControlCluster.AreMachinesFailedAndPreserved,
 					mcd.Spec.Template.Spec.MachineConfiguration.MachinePreserveTimeout.Duration-(2*c.pollingInterval),
@@ -1587,7 +1587,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 	})
 
-	// Testcase #05 | Orphaned Resources
+	// Testcase #04 | Orphaned Resources
 	ginkgo.Describe("orphaned resources", func() {
 		ginkgo.Context("when the hyperscaler resources are queried", func() {
 			ginkgo.It("should have been deleted", func() {

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -975,23 +975,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 	})
 
-	// Testcase #03 | Orphaned Resources
-	ginkgo.Describe("orphaned resources", func() {
-		ginkgo.Context("when the hyperscaler resources are queried", func() {
-			ginkgo.It("should have been deleted", func() {
-				// if available, should delete orphaned resources in the cloud provider
-				ginkgo.By("Querying and comparing")
-				gomega.Eventually(
-					c.resourcesTracker.IsOrphanedResourcesAvailable,
-					c.timeout,
-					c.pollingInterval).
-					Should(gomega.BeEquivalentTo(false))
-
-			})
-		})
-	})
-
-	// Testcase #04 | Auto Preservation of Machines
+	// Testcase #03 | Auto Preservation of Machines
 	ginkgo.Describe("Auto Machine Preservation", func() {
 		ginkgo.Context("Auto-Preserve Failed machine", func() {
 			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
@@ -1331,6 +1315,22 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					WithArguments(ctx, runningMachines[0].Name, controlClusterNamespace).
 					Should(gomega.BeTrue())
+			})
+		})
+	})
+
+	// Testcase #04 | Orphaned Resources
+	ginkgo.Describe("orphaned resources", func() {
+		ginkgo.Context("when the hyperscaler resources are queried", func() {
+			ginkgo.It("should have been deleted", func() {
+				// if available, should delete orphaned resources in the cloud provider
+				ginkgo.By("Querying and comparing")
+				gomega.Eventually(
+					c.resourcesTracker.IsOrphanedResourcesAvailable,
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.BeEquivalentTo(false))
+
 			})
 		})
 	})

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1035,10 +1035,10 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.IsFailingMachinePreserved,
+					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("remove VAP and VAPB to simulate kubelet restart")
@@ -1110,10 +1110,10 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.IsFailingMachinePreserved,
+					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, preservedMachine.Name).
+					WithArguments(ctx, controlClusterNamespace, []string{preservedMachine.Name}).
 					Should(gomega.BeTrue())
 
 				// Simulate kubelet failure for the other node too. This node is expected to fail, but is not expected to be preserved
@@ -1132,6 +1132,85 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				ginkgo.By("cleanup")
 				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 
+			})
+			ginkgo.It("when AutoPreserveFailedMachineMax is reduced, number of preserved failed machines also get reduced", func() {
+				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=2
+				ginkgo.By("Creating a MCD with preservation fields populated")
+				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
+				//Update the standard mcd to have preservation fields with values needed for this test
+				mcd.Spec.AutoPreserveFailedMachineMax = 2
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+						gomega.Expect(err).To(gomega.BeNil())
+						mcd.ResourceVersion = existingMCD.ResourceVersion
+						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+						return updateErr
+					})
+					gomega.Expect(retryErr).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+
+				ginkgo.By("wait for machines to be created")
+				var machineList *v1alpha1.MachineList
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(2)))
+
+				ginkgo.By("wait for machines to start running")
+				gomega.Eventually(
+					c.ControlCluster.AreMachinesRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
+					Should(gomega.BeTrue())
+
+				// Get list of running machines
+				machineList = c.ControlCluster.GetMachineList(ctx)
+
+				// Simulate kubelet failure for both the nodes.
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for both nodes")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"], machineList.Items[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Wait for both machines to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.AreFailingMachinesPreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("Reduce mcd.AutoPreserveFailedMachineMax to 1")
+				retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+					existingMCD.Spec.AutoPreserveFailedMachineMax = 1
+					_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), existingMCD, metav1.UpdateOptions{})
+					return updateErr
+				})
+				gomega.Expect(retryErr).To(gomega.BeNil())
+
+				ginkgo.By("wait for only one machine to be deleted while the other one stays preserved")
+				gomega.Eventually(func() bool {
+					isOnlyMachine0Deleted := c.ControlCluster.IsMachineDeleted(ctx, machineList.Items[0].Name) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{machineList.Items[1].Name})
+					isOnlyMachine1Deleted := c.ControlCluster.IsMachineDeleted(ctx, machineList.Items[1].Name) && c.ControlCluster.AreFailingMachinesPreserved(ctx, controlClusterNamespace, []string{machineList.Items[0].Name})
+
+					return isOnlyMachine0Deleted != isOnlyMachine1Deleted
+				}, c.timeout, c.pollingInterval).Should(gomega.BeTrue())
+
+				ginkgo.By("cleanup")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 
@@ -1190,10 +1269,10 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.IsFailingMachinePreserved,
+					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the preserved machine")
@@ -1323,18 +1402,18 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
-					c.ControlCluster.IsFailingMachinePreserved,
+					c.ControlCluster.AreFailingMachinesPreserved,
 					c.timeout,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Ensure that machine stays preserved for one minute")
 				gomega.Consistently(
-					c.ControlCluster.IsFailingMachinePreserved,
+					c.ControlCluster.AreFailingMachinesPreserved,
 					1*time.Minute,
 					c.pollingInterval).
-					WithArguments(ctx, controlClusterNamespace, machineList.Items[0].Name).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Waiting for machine to be deleted")

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -973,8 +973,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 	})
 
-	// Testcase #03 | Auto Preservation of Machines
-	ginkgo.Describe("Auto Machine Preservation", ginkgo.Ordered, func() {
+	// Testcase #03 | Preservation of Machines
+	ginkgo.Describe("Machine Preservation", ginkgo.Ordered, func() {
 		ginkgo.AfterAll(func() {
 			ginkgo.By("Delete mcd after auto preservation tests")
 			gomega.Expect(
@@ -1066,7 +1066,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
 				gomega.Expect(err).To(gomega.BeNil())
 
-				ginkgo.By("wait for two machine to start running")
+				ginkgo.By("wait for two machines to start running")
 				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
 					func() int {
@@ -1123,7 +1123,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				err := c.ControlCluster.CreateOrUpdateMcd(ctx, mcd, controlClusterNamespace)
 				gomega.Expect(err).To(gomega.BeNil())
 
-				ginkgo.By("wait for two machine to start running")
+				ginkgo.By("wait for two machines to start running")
 				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
 					func() int {
@@ -1170,7 +1170,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			})
 		})
 
-		ginkgo.Context("Should honour presence/absence of annotations", func() {
+		ginkgo.Context("Should honour presence/absence of annotations during auto-preservation", func() {
 			ginkgo.It("Such that machine preservation should stop when the node.machine.sapcloud.io/preserve=false annotation is added", func() {
 				// Create an mcd with replica=3, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
@@ -1213,16 +1213,9 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the preserved machine")
-				patch := map[string]any{
-					"metadata": map[string]any{
-						"annotations": map[string]any{
-							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueFalse,
-						},
-					},
-				}
-				patchBytes, err := json.Marshal(patch)
-				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, map[string]any{
+					mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueFalse,
+				})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for this machine to now be deleted")
@@ -1246,16 +1239,9 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).Should(gomega.BeNumerically(">=", 1))
 
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=false annotation to the running machine")
-				patch := map[string]any{
-					"metadata": map[string]any{
-						"annotations": map[string]any{
-							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueFalse,
-						},
-					},
-				}
-				patchBytes, err := json.Marshal(patch)
-				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				err := c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, map[string]any{
+					mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueFalse,
+				})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet failure for the node so that it can be preserved
@@ -1321,9 +1307,10 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 
 				ginkgo.By("Ensure that machine stays preserved for MachinePreserveTimeout duration")
+				// Duration of check reduced by a small amount to account for any pollible flakes arrising due to delays in this running this check
 				gomega.Consistently(
 					c.ControlCluster.AreMachinesFailedAndPreserved,
-					mcd.Spec.Template.Spec.MachineConfiguration.MachinePreserveTimeout.Duration,
+					mcd.Spec.Template.Spec.MachineConfiguration.MachinePreserveTimeout.Duration-(2*c.pollingInterval),
 					c.pollingInterval).
 					WithArguments(ctx, controlClusterNamespace, []string{runningMachines[0].Name}).
 					Should(gomega.BeTrue())
@@ -1337,34 +1324,10 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 		})
-	})
-
-	// Testcase #04 | Manual Machine preservation
-	ginkgo.Describe("Manual Machine Preservation", ginkgo.Ordered, func() {
-		ginkgo.AfterAll(func() {
-			ginkgo.By("Delete mcd after manual preservation tests")
-			gomega.Expect(
-				c.ControlCluster.McmClient.
-					MachineV1alpha1().
-					MachineDeployments(controlClusterNamespace).
-					Delete(
-						ctx,
-						helpers.McdName,
-						metav1.DeleteOptions{},
-					)).
-				Should(gomega.BeNil())
-
-			gomega.Eventually(
-				c.ControlCluster.IsMachineDeploymentDeleted,
-				c.timeout,
-				c.pollingInterval).
-				WithArguments(ctx, helpers.McdName, controlClusterNamespace).
-				Should(gomega.BeTrue())
-		})
 		ginkgo.Context("Should manually preserve a failed machine", func() {
 			ginkgo.It("When a machine is annotated with `preserve=when-failed`. It should be preserved on failure and should re-join the cluster if it recovers before preservation timeout", func() {
 				ginkgo.By("Create an MCD with AutoPreserveFailedMachineMax set to 0")
-				// mcd replicas for the auto preservation tests are intentionally set to 2. This is done so that we pay the cost of
+				// mcd replicas for the manual preservation tests are intentionally set to 2. This is done so that we pay the cost of
 				// creating new machines only once and subsequent tests can be run without waiting for new machines to be created.
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to have preservation fields
@@ -1391,26 +1354,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine")
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved machine")
-					patch := map[string]any{
-						"metadata": map[string]any{
-							"annotations": nil,
-						},
-					}
-					patchBytes, err := json.Marshal(patch)
-					gomega.Expect(err).To(gomega.BeNil())
-					_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+					err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, nil)
 					gomega.Expect(err).To(gomega.BeNil())
 				})
-				patch := map[string]any{
-					"metadata": map[string]any{
-						"annotations": map[string]any{
-							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
-						},
-					},
-				}
-				patchBytes, err := json.Marshal(patch)
-				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, map[string]any{
+					mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+				})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet failure for the node
@@ -1471,26 +1420,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running node")
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved node")
-					patch := map[string]any{
-						"metadata": map[string]any{
-							"annotations": nil,
-						},
-					}
-					patchBytes, err := json.Marshal(patch)
-					gomega.Expect(err).To(gomega.BeNil())
-					_, err = c.TargetCluster.Clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+					err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, nil)
 					gomega.Expect(err).To(gomega.BeNil())
 				})
-				patch := map[string]any{
-					"metadata": map[string]any{
-						"annotations": map[string]any{
-							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
-						},
-					},
-				}
-				patchBytes, err := json.Marshal(patch)
-				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.TargetCluster.Clientset.CoreV1().Nodes().Patch(ctx, nodeName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, map[string]any{
+					mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+				})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet failure for the node
@@ -1522,9 +1457,9 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 		})
-		ginkgo.Context("Should ensure that machines annotated with `when-failed` are preserved", func() {
+		ginkgo.Context("Should ensure that machines manually annotated with `when-failed` are preserved", func() {
 			ginkgo.It("Such that these manually annotated machines are preserved even if `autoPreserveFailedMachineMax` number of machines have already preserved", func() {
-				ginkgo.By("Create a MCD with with AutoPreserveFailedMachineMax set to 1")
+				ginkgo.By("Create a MCD with AutoPreserveFailedMachineMax set to 1")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to have preservation fields
 				mcd.Spec.AutoPreserveFailedMachineMax = 1
@@ -1567,31 +1502,17 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the other running machine")
 				ginkgo.DeferCleanup(func() {
 					ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved machine")
-					patch := map[string]any{
-						"metadata": map[string]any{
-							"annotations": nil,
-						},
-					}
-					patchBytes, err := json.Marshal(patch)
-					gomega.Expect(err).To(gomega.BeNil())
-					_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[1].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+					err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, nil)
 					gomega.Expect(err).To(gomega.BeNil())
 				})
-				patch := map[string]any{
-					"metadata": map[string]any{
-						"annotations": map[string]any{
-							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
-						},
-					},
-				}
-				patchBytes, err := json.Marshal(patch)
-				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[1].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, map[string]any{
+					mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+				})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet failure for the second node.
 				// The first node is already auto-preserved and counts towards AutoPreserveFailedMachineMax.
-				// We expect this machine to be preserved as well since it is explicitely marked
+				// We expect this machine to be preserved as well since it is explicitly marked
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the second machine")
 				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey], runningMachines[1].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
@@ -1604,7 +1525,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 		})
-		ginkgo.Context("Should ensure preserved machines are deleted when preserve annotation is removed", func() {
+		ginkgo.Context("Should ensure manually preserved machines are deleted when preserve annotation is removed", func() {
 			ginkgo.It("When the preservation annotation is removed, a manually preserved failed machine should be deleted", func() {
 				ginkgo.By("Create a MCD with no preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
@@ -1629,16 +1550,9 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine to ensure it is preserved when it fails
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine")
-				patch := map[string]any{
-					"metadata": map[string]any{
-						"annotations": map[string]any{
-							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
-						},
-					},
-				}
-				patchBytes, err := json.Marshal(patch)
-				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, map[string]any{
+					mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+				})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				// Simulate kubelet failure for the node
@@ -1659,14 +1573,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 
 				ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved machine")
-				patch = map[string]any{
-					"metadata": map[string]any{
-						"annotations": nil,
-					},
-				}
-				patchBytes, err = json.Marshal(patch)
-				gomega.Expect(err).To(gomega.BeNil())
-				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, runningMachines[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				err = c.ControlCluster.PatchMachineAnnotations(ctx, runningMachines[0].Name, controlClusterNamespace, nil)
 				gomega.Expect(err).To(gomega.BeNil())
 
 				ginkgo.By("wait for machine to be deleted")

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -995,8 +995,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				WithArguments(ctx, helpers.McdName, controlClusterNamespace).
 				Should(gomega.BeTrue())
 		})
-		ginkgo.Context("Auto-Preserve Failed machine", func() {
-			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
+		ginkgo.Context("Should auto-preserve a failed machine", func() {
+			ginkgo.It("When it fails and the machine should re-join the cluster if it recovers before the preservation timeout", func() {
 				ginkgo.By("Creating a MCD with preservation fields populated")
 				// mcd replicas for the auto preservation tests are intentionally set to 3. This is done so that we pay the cost of
 				// creating new machines only once and subsequent tests can be run without waiting for new machines to be created.
@@ -1051,8 +1051,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			})
 		})
 
-		ginkgo.Context("Ensure that AutoPreserveFailedMachineMax is honoured", func() {
-			ginkgo.It("when number of failed machines cross the threshold, only AutoPreserveFailedMachineMax number of machines are preserved. The rest are terminated", func() {
+		ginkgo.Context("Should ensure AutoPreserveFailedMachineMax is honoured", func() {
+			ginkgo.It("Such that when number of failed machines cross the threshold, only AutoPreserveFailedMachineMax number of machines are preserved. The rest should be terminated", func() {
 				// Create an mcd with replica=2, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
@@ -1109,7 +1109,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					WithArguments(ctx, nonPreservedMachine.Name, controlClusterNamespace).
 					Should(gomega.BeTrue())
 			})
-			ginkgo.It("when AutoPreserveFailedMachineMax is reduced, the number of auto-preserved failed machines also gets reduced to honour the new max", func() {
+			ginkgo.It("Such that when AutoPreserveFailedMachineMax is reduced, the number of auto-preserved failed machines also gets reduced to honour the new max", func() {
 				// Create an mcd with replica=3, and AutoPreserveFailedMachineMax=2
 				ginkgo.By("Creating a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
@@ -1171,7 +1171,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 		})
 
 		ginkgo.Context("Should honour presence/absence of annotations", func() {
-			ginkgo.It("preserved machine should stop being preserved when node.machine.sapcloud.io/preserve=false annotation is added", func() {
+			ginkgo.It("Such that machine preservation should stop when the node.machine.sapcloud.io/preserve=false annotation is added", func() {
 				// Create an mcd with replica=3, and AutoPreserveFailedMachineMax=1
 				ginkgo.By("Creating a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
@@ -1234,7 +1234,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 
 			})
-			ginkgo.It("running machine with the node.machine.sapcloud.io/preserve=false annotation should not be auto-preserved", func() {
+			ginkgo.It("When a running machine has the node.machine.sapcloud.io/preserve=false annotation it should not be auto-preserved", func() {
 				ginkgo.By("wait for atleast one machine to start running")
 				var runningMachines []v1alpha1.Machine
 				gomega.Eventually(
@@ -1277,8 +1277,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			})
 		})
 
-		ginkgo.Context("Ensure that machinePreserveTimeout is honoured", func() {
-			ginkgo.It("a preserved machine is terminated once its machinePreserveTimeout expires", func() {
+		ginkgo.Context("Should ensure that machinePreserveTimeout is honoured", func() {
+			ginkgo.It("Such that a preserved machine is deleted once its PreserveExpiryTime expires", func() {
 				// Create an mcd with replica=3, AutoPreserveFailedMachineMax=1, and with a very small machinePreserveTimeout
 				ginkgo.By("Create a MCD with preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 3)
@@ -1361,8 +1361,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				WithArguments(ctx, helpers.McdName, controlClusterNamespace).
 				Should(gomega.BeTrue())
 		})
-		ginkgo.Context("Manual-Preserve Failed machine", func() {
-			ginkgo.It("Should preserve machine when annotated with `preserve=when-failed` on failure and let it join the cluster again when it recovers before preservation timeout", func() {
+		ginkgo.Context("Should manually preserve a failed machine", func() {
+			ginkgo.It("When a machine is annotated with `preserve=when-failed`. It should be preserved on failure and should re-join the cluster if it recovers before preservation timeout", func() {
 				ginkgo.By("Create an MCD with AutoPreserveFailedMachineMax set to 0")
 				// mcd replicas for the auto preservation tests are intentionally set to 2. This is done so that we pay the cost of
 				// creating new machines only once and subsequent tests can be run without waiting for new machines to be created.
@@ -1441,7 +1441,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					WithArguments(ctx, []string{runningMachines[0].Name}, controlClusterNamespace).
 					Should(gomega.BeTrue())
 			})
-			ginkgo.It("Should preserve machine on failure when it's corresponding node is manually annotated", func() {
+			ginkgo.It("When it's corresponding node is manually annotated with `node.machine.sapcloud.io/preserve=when-failed`", func() {
 				ginkgo.By("Create a MCD with AutoPreserveFailedMachineMax set to 0")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to have preservation fields
@@ -1522,8 +1522,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 		})
-		ginkgo.Context("Ensure that machines annotated with `when-failed` are preserved", func() {
-			ginkgo.It("Should ensure that a machine marked for preservation using `when-failed` is preserved even if `autoPreserveFailedMachineMax` number of machines are already preserved", func() {
+		ginkgo.Context("Should ensure that machines annotated with `when-failed` are preserved", func() {
+			ginkgo.It("Such that these manually annotated machines are preserved even if `autoPreserveFailedMachineMax` number of machines have already preserved", func() {
 				ginkgo.By("Create a MCD with with AutoPreserveFailedMachineMax set to 1")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to have preservation fields
@@ -1604,8 +1604,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					Should(gomega.BeTrue())
 			})
 		})
-		ginkgo.Context("Ensure preserved machines are deleted when preserve annotation is removed", func() {
-			ginkgo.It("Should ensure that a manually preserved failed machine is deleted if the preservation annotation is removed", func() {
+		ginkgo.Context("Should ensure preserved machines are deleted when preserve annotation is removed", func() {
+			ginkgo.It("When the preservation annotation is removed, a manually preserved failed machine should be deleted", func() {
 				ginkgo.By("Create a MCD with no preservation fields populated")
 				mcd := helpers.NewMachineDeployment(controlClusterNamespace, gnaSecretNameLabelValue, 2)
 				// Update the standard mcd to a low machine health timeout to speed up tests

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -1028,7 +1028,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1086,7 +1086,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1099,7 +1099,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Simulate kubelet failure for the other node too. This node is expected to fail, but is not expected to be preserved
 				// because autoPreserveFailedMachineMax=1 and one machine is already preserved
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for other machine as well")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels["node"], nonPreservedMachine.ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{preservedMachine.ObjectMeta.Labels[v1alpha1.NodeLabelKey], nonPreservedMachine.ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for the other machine to be deleted")
 				gomega.Eventually(
@@ -1140,7 +1140,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"], runningMachines[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey], runningMachines[1].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Wait for both machines to fail and be preserved")
 				gomega.Eventually(
@@ -1202,7 +1202,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1265,7 +1265,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to be deleted")
 				gomega.Eventually(
@@ -1310,7 +1310,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1420,7 +1420,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1466,7 +1466,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running node to ensure its corresponding machine is preserved when it fails
 				ginkgo.By("get node name from machine")
-				nodeName := runningMachines[0].ObjectMeta.Labels["node"]
+				nodeName := runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]
 				gomega.Expect(len(nodeName)).Should(gomega.BeNumerically(">", 0))
 				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running node")
 				ginkgo.DeferCleanup(func() {
@@ -1500,7 +1500,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(
@@ -1553,7 +1553,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be auto-preserved")
 				gomega.Eventually(
@@ -1593,7 +1593,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// The first node is already auto-preserved and counts towards AutoPreserveFailedMachineMax.
 				// We expect this machine to be preserved as well since it is explicitely marked
 				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the second machine")
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"], runningMachines[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey], runningMachines[1].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for second machine to fail and be preserved while ensuring that the first machine remains preserved")
 				gomega.Eventually(
@@ -1648,7 +1648,7 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					ginkgo.By("cleanup deployed VAP/VAPB")
 					gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 				})
-				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{runningMachines[0].ObjectMeta.Labels[v1alpha1.NodeLabelKey]})).To(gomega.BeNil())
 
 				ginkgo.By("Waiting for machine to fail and be preserved")
 				gomega.Eventually(

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -16,7 +16,9 @@ import (
 )
 
 const (
-	VAPName  = "integration-test-block-node-heartbeats"
+	// VAPName is the name of the ValidatingAdmissionPolicy that blocks kubelet from updating node leases and node status.
+	VAPName = "integration-test-block-node-heartbeats"
+	// VAPBName is the name of the ValidatingAdmissionPolicyBinding that binds the above ValidatingAdmissionPolicy to the cluster.
 	VAPBName = "integration-test-block-node-heartbeats-binding"
 )
 
@@ -29,7 +31,7 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	for _, noName := range nodeNames {
 		_, err := c.Clientset.CoreV1().Nodes().Get(ctx, noName, metav1.GetOptions{})
 		if err != nil {
-			log.Println("error fetching node: ", err)
+			log.Printf("error fetching node: %v", err)
 			return err
 		}
 	}
@@ -92,18 +94,18 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	if errors.IsAlreadyExists(err) {
 		existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("error fetching validating admission policy: ", err)
+			log.Printf("error fetching validating admission policy: %v", err)
 			return err
 		}
 		VAPolicy.ResourceVersion = existingVAPolicy.ResourceVersion
 
 		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
 		if err != nil {
-			log.Printf("error updating validating admission policy: ", err)
+			log.Printf("error updating validating admission policy: %v", err)
 			return err
 		}
 	} else if err != nil {
-		log.Println("error creating validating admission policy: ", err)
+		log.Printf("error creating validating admission policy: %v", err)
 		return err
 	}
 
@@ -111,18 +113,18 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	if errors.IsAlreadyExists(err) {
 		existingVAPBinding, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(ctx, VAPBName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("error fetching validating admission policy binding: ", err)
+			log.Printf("error fetching validating admission policy binding: %v", err)
 			return err
 		}
 		VAPBinding.ResourceVersion = existingVAPBinding.ResourceVersion
 
 		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Update(ctx, VAPBinding, metav1.UpdateOptions{})
 		if err != nil {
-			log.Printf("error updating validating admission policy binding: ", err)
+			log.Printf("error updating validating admission policy binding: %v", err)
 			return err
 		}
 	} else if err != nil {
-		log.Println("error creating validating admission policy binding: ", err)
+		log.Printf("error creating validating admission policy binding: %v", err)
 		return err
 	}
 
@@ -142,16 +144,17 @@ func blockedKubeletExpression(nodes []string) string {
 	)
 }
 
+// DeleteVAPToRestartKubeletUpdates deletes the ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding that were created to block kubelet from updating node leases and node status.
 func (c *Cluster) DeleteVAPToRestartKubeletUpdates(ctx context.Context) error {
 	err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, VAPName, metav1.DeleteOptions{})
 	if err != nil {
-		log.Printf("error deleting validating admission policy: ", err)
+		log.Printf("error deleting validating admission policy: %v", err)
 		return err
 	}
 
 	err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, VAPBName, metav1.DeleteOptions{})
 	if err != nil {
-		log.Printf("error deleting validating admission policy binding: ", err)
+		log.Printf("error deleting validating admission policy binding: %v", err)
 		return err
 	}
 

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	VAPName  = "integration-test-block-node-heartbeats"
+	VAPBName = "integration-test-block-node-heartbeats-binding"
+)
+
+// CreateVAPToBlockKubeletUpdates is a utility method to create a ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+// to block kubelet from updating node leases and node status.
+// This is used to cause nodes to go into the NotReady state to test the machine preservation feature of MCM.
+// TODO: pass context from caller
+func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames []string) error {
+	var err error
+	for _, noName := range nodeNames {
+		_, err := c.Clientset.CoreV1().Nodes().Get(ctx, noName, metav1.GetOptions{})
+		if err != nil {
+			log.Println("error fetching node: ", err)
+			return err
+		}
+	}
+
+	VAPolicy := &admissionregistrationv1.ValidatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: VAPName,
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"nodes/status"},
+							},
+						},
+					},
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"coordination.k8s.io"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"leases"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{
+					Expression: blockedKubeletExpression(nodeNames),
+					Message:    "blocking kubelet heartbeat for test",
+				},
+			},
+		},
+	}
+
+	VAPBinding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: VAPBName,
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
+			PolicyName: VAPName,
+			ValidationActions: []admissionregistrationv1.ValidationAction{
+				admissionregistrationv1.Deny,
+			},
+		},
+	}
+
+	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, VAPolicy, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error fetching validating admission policy: ", err)
+			return err
+		}
+		VAPolicy.ResourceVersion = existingVAPolicy.ResourceVersion
+
+		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
+		if err != nil {
+			log.Printf("error updating validating admission policy: ", err)
+			return err
+		}
+	} else if err != nil {
+		log.Println("error creating validating admission policy: ", err)
+		return err
+	}
+
+	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(ctx, VAPBinding, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		existingVAPBinding, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(ctx, VAPBName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error fetching validating admission policy binding: ", err)
+			return err
+		}
+		VAPBinding.ResourceVersion = existingVAPBinding.ResourceVersion
+
+		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Update(ctx, VAPBinding, metav1.UpdateOptions{})
+		if err != nil {
+			log.Printf("error updating validating admission policy binding: ", err)
+			return err
+		}
+	} else if err != nil {
+		log.Println("error creating validating admission policy binding: ", err)
+		return err
+	}
+
+	return nil
+}
+
+func blockedKubeletExpression(nodes []string) string {
+	users := make([]string, 0, len(nodes))
+
+	for _, node := range nodes {
+		users = append(users, fmt.Sprintf(`"system:node:%s"`, node))
+	}
+
+	return fmt.Sprintf(
+		"!(request.userInfo.username in [%s])",
+		strings.Join(users, ", "),
+	)
+}
+
+func (c *Cluster) DeleteVAPToRestartKubeletUpdates(ctx context.Context) error {
+	err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, VAPName, metav1.DeleteOptions{})
+	if err != nil {
+		log.Printf("error deleting validating admission policy: ", err)
+		return err
+	}
+
+	err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, VAPBName, metav1.DeleteOptions{})
+	if err != nil {
+		log.Printf("error deleting validating admission policy binding: ", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -153,12 +153,22 @@ func (c *Cluster) DeleteVAPToRestartKubeletUpdates(ctx context.Context) error {
 	var vapErr, vapbErr error
 	vapErr = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, VAPName, metav1.DeleteOptions{})
 	if vapErr != nil {
-		log.Printf("error deleting validating admission policy: %v\n", vapErr)
+		if apierrors.IsNotFound(vapErr) {
+			log.Printf("validating admission policy %s not found\n", VAPName)
+			vapErr = nil
+		} else {
+			log.Printf("error deleting validating admission policy %s: %v\n", VAPName, vapErr)
+		}
 	}
 
 	vapbErr = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, VAPBName, metav1.DeleteOptions{})
 	if vapbErr != nil {
-		log.Printf("error deleting validating admission policy binding: %v\n", vapbErr)
+		if apierrors.IsNotFound(vapbErr) {
+			log.Printf("validating admission policy binding %s not found\n", VAPBName)
+			vapbErr = nil
+		} else {
+			log.Printf("error deleting validating admission policy binding %s: %v\n", VAPBName, vapbErr)
+		}
 	}
 
 	return errors.Join(vapErr, vapbErr)

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -108,6 +108,10 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 				},
 			},
 		})
+		if err != nil {
+			log.Printf("error marshalling patch for validating admission policy %s: %v\n", VAPName, err)
+			return err
+		}
 		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Patch(ctx, VAPName, types.MergePatchType, patch, metav1.PatchOptions{})
 		if err != nil {
 			log.Printf("error patching validating admission policy %s: %v\n", VAPName, err)

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -35,7 +35,7 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	for _, noName := range nodeNames {
 		_, err := c.Clientset.CoreV1().Nodes().Get(ctx, noName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("error fetching node: %v", err)
+			log.Printf("error fetching node: %v\n", err)
 			return err
 		}
 	}
@@ -98,18 +98,18 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	if apierrors.IsAlreadyExists(err) {
 		existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("error fetching validating admission policy: %v", err)
+			log.Printf("error fetching validating admission policy %s: %v\n", VAPName, err)
 			return err
 		}
 		VAPolicy.ResourceVersion = existingVAPolicy.ResourceVersion
 
 		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
 		if err != nil {
-			log.Printf("error updating validating admission policy: %v", err)
+			log.Printf("error updating validating admission policy: %v\n", err)
 			return err
 		}
 	} else if err != nil {
-		log.Printf("error creating validating admission policy: %v", err)
+		log.Printf("error creating validating admission policy: %v\n", err)
 		return err
 	}
 
@@ -117,18 +117,18 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	if apierrors.IsAlreadyExists(err) {
 		existingVAPBinding, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(ctx, VAPBName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("error fetching validating admission policy binding: %v", err)
+			log.Printf("error fetching validating admission policy binding %s: %v\n", VAPBName, err)
 			return err
 		}
 		VAPBinding.ResourceVersion = existingVAPBinding.ResourceVersion
 
 		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Update(ctx, VAPBinding, metav1.UpdateOptions{})
 		if err != nil {
-			log.Printf("error updating validating admission policy binding: %v", err)
+			log.Printf("error updating validating admission policy binding: %v\n", err)
 			return err
 		}
 	} else if err != nil {
-		log.Printf("error creating validating admission policy binding: %v", err)
+		log.Printf("error creating validating admission policy binding: %v\n", err)
 		return err
 	}
 
@@ -153,12 +153,12 @@ func (c *Cluster) DeleteVAPToRestartKubeletUpdates(ctx context.Context) error {
 	var vapErr, vapbErr error
 	vapErr = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, VAPName, metav1.DeleteOptions{})
 	if vapErr != nil {
-		log.Printf("error deleting validating admission policy: %v", vapErr)
+		log.Printf("error deleting validating admission policy: %v\n", vapErr)
 	}
 
 	vapbErr = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, VAPBName, metav1.DeleteOptions{})
 	if vapbErr != nil {
-		log.Printf("error deleting validating admission policy binding: %v", vapbErr)
+		log.Printf("error deleting validating admission policy binding: %v\n", vapbErr)
 	}
 
 	return errors.Join(vapErr, vapbErr)

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -33,7 +33,7 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 
 	var err error
 	for _, noName := range nodeNames {
-		_, err := c.Clientset.CoreV1().Nodes().Get(ctx, noName, metav1.GetOptions{})
+		_, err = c.Clientset.CoreV1().Nodes().Get(ctx, noName, metav1.GetOptions{})
 		if err != nil {
 			log.Printf("error fetching node: %v\n", err)
 			return err
@@ -105,11 +105,11 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 
 		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
 		if err != nil {
-			log.Printf("error updating validating admission policy: %v\n", err)
+			log.Printf("error updating validating admission policy %s: %v\n", VAPName, err)
 			return err
 		}
 	} else if err != nil {
-		log.Printf("error creating validating admission policy: %v\n", err)
+		log.Printf("error creating validating admission policy %s: %v\n", VAPName, err)
 		return err
 	}
 
@@ -124,11 +124,11 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 
 		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Update(ctx, VAPBinding, metav1.UpdateOptions{})
 		if err != nil {
-			log.Printf("error updating validating admission policy binding: %v\n", err)
+			log.Printf("error updating validating admission policy binding %s: %v\n", VAPBName, err)
 			return err
 		}
 	} else if err != nil {
-		log.Printf("error creating validating admission policy binding: %v\n", err)
+		log.Printf("error creating validating admission policy binding %s: %v\n", VAPBName, err)
 		return err
 	}
 

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -6,12 +6,13 @@ package helpers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -25,8 +26,11 @@ const (
 // CreateVAPToBlockKubeletUpdates is a utility method to create a ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
 // to block kubelet from updating node leases and node status.
 // This is used to cause nodes to go into the NotReady state to test the machine preservation feature of MCM.
-// TODO: pass context from caller
 func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames []string) error {
+	if len(nodeNames) == 0 {
+		return fmt.Errorf("no node names provided to block kubelet updates")
+	}
+
 	var err error
 	for _, noName := range nodeNames {
 		_, err := c.Clientset.CoreV1().Nodes().Get(ctx, noName, metav1.GetOptions{})
@@ -91,7 +95,7 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	}
 
 	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, VAPolicy, metav1.CreateOptions{})
-	if errors.IsAlreadyExists(err) {
+	if apierrors.IsAlreadyExists(err) {
 		existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
 		if err != nil {
 			log.Printf("error fetching validating admission policy: %v", err)
@@ -110,7 +114,7 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	}
 
 	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(ctx, VAPBinding, metav1.CreateOptions{})
-	if errors.IsAlreadyExists(err) {
+	if apierrors.IsAlreadyExists(err) {
 		existingVAPBinding, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(ctx, VAPBName, metav1.GetOptions{})
 		if err != nil {
 			log.Printf("error fetching validating admission policy binding: %v", err)
@@ -146,17 +150,16 @@ func blockedKubeletExpression(nodes []string) string {
 
 // DeleteVAPToRestartKubeletUpdates deletes the ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding that were created to block kubelet from updating node leases and node status.
 func (c *Cluster) DeleteVAPToRestartKubeletUpdates(ctx context.Context) error {
-	err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, VAPName, metav1.DeleteOptions{})
-	if err != nil {
-		log.Printf("error deleting validating admission policy: %v", err)
-		return err
+	var vapErr, vapbErr error
+	vapErr = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, VAPName, metav1.DeleteOptions{})
+	if vapErr != nil {
+		log.Printf("error deleting validating admission policy: %v", vapErr)
 	}
 
-	err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, VAPBName, metav1.DeleteOptions{})
-	if err != nil {
-		log.Printf("error deleting validating admission policy binding: %v", err)
-		return err
+	vapbErr = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, VAPBName, metav1.DeleteOptions{})
+	if vapbErr != nil {
+		log.Printf("error deleting validating admission policy binding: %v", vapbErr)
 	}
 
-	return nil
+	return errors.Join(vapErr, vapbErr)
 }

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -14,6 +14,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -96,17 +97,20 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 
 	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, VAPolicy, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
-		existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
-		if err != nil {
-			log.Printf("error fetching validating admission policy %s: %v\n", VAPName, err)
-			return err
-		}
-		VAPolicy.ResourceVersion = existingVAPolicy.ResourceVersion
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
+			if err != nil {
+				log.Printf("error fetching validating admission policy %s: %v\n", VAPName, err)
+				return err
+			}
+			VAPolicy.ResourceVersion = existingVAPolicy.ResourceVersion
+			_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
 
-		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
-		if err != nil {
-			log.Printf("error updating validating admission policy %s: %v\n", VAPName, err)
 			return err
+		})
+		if retryErr != nil {
+			log.Printf("error updating validating admission policy %s: %v\n", VAPName, retryErr)
+			return retryErr
 		}
 	} else if err != nil {
 		log.Printf("error creating validating admission policy %s: %v\n", VAPName, err)
@@ -114,20 +118,8 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 	}
 
 	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(ctx, VAPBinding, metav1.CreateOptions{})
-	if apierrors.IsAlreadyExists(err) {
-		existingVAPBinding, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(ctx, VAPBName, metav1.GetOptions{})
-		if err != nil {
-			log.Printf("error fetching validating admission policy binding %s: %v\n", VAPBName, err)
-			return err
-		}
-		VAPBinding.ResourceVersion = existingVAPBinding.ResourceVersion
-
-		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Update(ctx, VAPBinding, metav1.UpdateOptions{})
-		if err != nil {
-			log.Printf("error updating validating admission policy binding %s: %v\n", VAPBName, err)
-			return err
-		}
-	} else if err != nil {
+	// Since VAPB is static, no action needed if it already exists
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		log.Printf("error creating validating admission policy binding %s: %v\n", VAPBName, err)
 		return err
 	}

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -6,6 +6,7 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -14,7 +15,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -97,23 +98,22 @@ func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames 
 
 	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, VAPolicy, metav1.CreateOptions{})
 	if apierrors.IsAlreadyExists(err) {
-		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
-			if err != nil {
-				log.Printf("error fetching validating admission policy %s: %v\n", VAPName, err)
-				return err
-			}
-			VAPolicy.ResourceVersion = existingVAPolicy.ResourceVersion
-			_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
-
-			return err
+		patch, err := json.Marshal(map[string]any{
+			"spec": map[string]any{
+				"validations": []map[string]any{
+					{
+						"expression": blockedKubeletExpression(nodeNames),
+						"message":    "blocking kubelet heartbeat for test",
+					},
+				},
+			},
 		})
-		if retryErr != nil {
-			log.Printf("error updating validating admission policy %s: %v\n", VAPName, retryErr)
-			return retryErr
+		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Patch(ctx, VAPName, types.MergePatchType, patch, metav1.PatchOptions{})
+		if err != nil {
+			log.Printf("error patching validating admission policy %s: %v\n", VAPName, err)
+			return err
 		}
 	} else if err != nil {
-		log.Printf("error creating validating admission policy %s: %v\n", VAPName, err)
 		return err
 	}
 

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -132,7 +132,7 @@ func (c *Cluster) GetMachineList(ctx context.Context) *v1alpha1.MachineList {
 		},
 	)
 	if err != nil {
-		log.Printf("error listing machines: ", err)
+		log.Printf("error listing machines: %v", err)
 		return nil
 	}
 
@@ -180,7 +180,7 @@ func (c *Cluster) IsFailingMachinePreserved(ctx context.Context, namespace strin
 			Machines(namespace).
 			Get(ctx, mcName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("error listing machines: ", err)
+			log.Printf("error listing machines: %v", err)
 			return false
 		}
 

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -6,16 +6,25 @@ package helpers
 
 import (
 	"context"
+	"log"
 	"os"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
+const (
+	gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
+	mcdName               = "test-machine-deployment"
+)
+
+var (
+	testLabels = map[string]string{"test-label": "test-label"}
+)
 
 // CreateMachine creates a test-machine using machineclass "test-mc"
 func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
@@ -50,7 +59,6 @@ func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
 
 // CreateMachineDeployment creates a test-machine-deployment with 3 replicas and returns error if it occurs
 func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string, replicas int32) error {
-	labels := map[string]string{"test-label": "test-label"}
 	_, err := c.McmClient.
 		MachineV1alpha1().
 		MachineDeployments(namespace).
@@ -58,7 +66,7 @@ func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string
 			context.Background(),
 			&v1alpha1.MachineDeployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-machine-deployment",
+					Name:      mcdName,
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.MachineDeploymentSpec{
@@ -74,11 +82,11 @@ func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string
 						},
 					},
 					Selector: &metav1.LabelSelector{
-						MatchLabels: labels,
+						MatchLabels: testLabels,
 					},
 					Template: v1alpha1.MachineTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: labels,
+							Labels: testLabels,
 						},
 						Spec: v1alpha1.MachineSpec{
 							Class: v1alpha1.ClassSpec{
@@ -110,4 +118,122 @@ func (c *Cluster) IsTestMachineDeleted() bool {
 		Get(context.Background(), "test-machine", metav1.GetOptions{})
 
 	return errors.IsNotFound(err)
+}
+
+// GetMachineList lists all machines that contain the given machine labels and returns the list of machines
+func (c *Cluster) GetMachineList(ctx context.Context) *v1alpha1.MachineList {
+	selector := labels.SelectorFromSet(testLabels)
+	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+
+	machineList, err := c.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: selector.String(),
+		},
+	)
+	if err != nil {
+		log.Printf("error listing machines: ", err)
+		return nil
+	}
+
+	return machineList
+}
+
+// IsMachineDeleted returns boolean value indicating whether the specified machine is deleted or not
+func (c *Cluster) IsMachineDeleted(ctx context.Context, machineName string) bool {
+	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+	_, err := c.McmClient.
+		MachineV1alpha1().
+		Machines(controlClusterNamespace).
+		Get(ctx, machineName, metav1.GetOptions{})
+
+	return errors.IsNotFound(err)
+}
+
+// IsMachineRunning returns boolean value indicating whether the specified machine is in the running state or not
+func (c *Cluster) IsMachineRunning(ctx context.Context, machineNames []string) bool {
+	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+	for _, mcName := range machineNames {
+		mc, err := c.McmClient.
+			MachineV1alpha1().
+			Machines(controlClusterNamespace).
+			Get(ctx, mcName, metav1.GetOptions{})
+
+		if err != nil {
+			log.Println("error fetching machine: ", err)
+			return false
+		}
+
+		if mc.Status.CurrentStatus.Phase != v1alpha1.MachineRunning {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsFailingMachinePreserved returns boolean value indicating whether the specified machine is in the failed state and preserved or not
+func (c *Cluster) IsFailingMachinePreserved(ctx context.Context, namespace string, machineNames []string) bool {
+	for _, mcName := range machineNames {
+		mc, err := c.McmClient.
+			MachineV1alpha1().
+			Machines(namespace).
+			Get(ctx, mcName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error listing machines: ", err)
+			return false
+		}
+
+		if mc.Status.CurrentStatus.PreserveExpiryTime == nil || mc.Status.CurrentStatus.Phase != v1alpha1.MachineFailed {
+			return false
+		}
+	}
+
+	return true
+}
+
+// GetMCD returns a MachineDeployment object with the specified namespace, gnaSecretName, replicas and machineLabels
+func GetMCD(namespace string, gnaSecretName string, replicas int32) v1alpha1.MachineDeployment {
+	mcd := v1alpha1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mcdName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.MachineDeploymentSpec{
+			Replicas:        replicas,
+			MinReadySeconds: 500,
+			Strategy: v1alpha1.MachineDeploymentStrategy{
+				Type: v1alpha1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: &v1alpha1.RollingUpdateMachineDeployment{
+					UpdateConfiguration: v1alpha1.UpdateConfiguration{
+						MaxSurge:       &intstr.IntOrString{IntVal: 2},
+						MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+					},
+				},
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: testLabels,
+			},
+			Template: v1alpha1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: testLabels,
+				},
+				Spec: v1alpha1.MachineSpec{
+					Class: v1alpha1.ClassSpec{
+						Kind: "MachineClass",
+						Name: "test-mc-v1",
+					},
+					NodeTemplateSpec: v1alpha1.NodeTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								gnaSecretNameLabelKey: gnaSecretName,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return mcd
 }

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -130,19 +130,21 @@ func (c *Cluster) AreMachinesRunning(ctx context.Context, machineNames []string)
 	return true
 }
 
-// IsFailingMachinePreserved checks if the specified machine is in the failed state and is preserved
-func (c *Cluster) IsFailingMachinePreserved(ctx context.Context, namespace string, machineName string) bool {
-	mc, err := c.McmClient.
-		MachineV1alpha1().
-		Machines(namespace).
-		Get(ctx, machineName, metav1.GetOptions{})
-	if err != nil {
-		log.Printf("error listing machine %s: %v", machineName, err)
-		return false
-	}
+// AreFailingMachinesPreserved checks if the all specified machines are in the failed state and are preserved
+func (c *Cluster) AreFailingMachinesPreserved(ctx context.Context, namespace string, machineNames []string) bool {
+	for _, mcName := range machineNames {
+		mc, err := c.McmClient.
+			MachineV1alpha1().
+			Machines(namespace).
+			Get(ctx, mcName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error listing machine %s: %v", mcName, err)
+			return false
+		}
 
-	if mc.Status.CurrentStatus.PreserveExpiryTime == nil || mc.Status.CurrentStatus.Phase != v1alpha1.MachineFailed {
-		return false
+		if mc.Status.CurrentStatus.PreserveExpiryTime == nil || mc.Status.CurrentStatus.Phase != v1alpha1.MachineFailed {
+			return false
+		}
 	}
 
 	return true

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -69,16 +69,6 @@ func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string
 	return err
 }
 
-// // IsTestMachineDeleted returns boolean value of presence of 'test-machine' object
-// func (c *Cluster) IsTestMachineDeleted(ctx context.Context, namespace string) bool {
-// 	_, err := c.McmClient.
-// 		MachineV1alpha1().
-// 		Machines(namespace).
-// 		Get(ctx, "test-machine", metav1.GetOptions{})
-
-// 	return errors.IsNotFound(err)
-// }
-
 // GetRunningMachineList lists all running machines that contain the given machine labels and returns the list of such machines
 func (c *Cluster) GetRunningMachineList(ctx context.Context, namespace string) ([]v1alpha1.Machine, error) {
 	selector := labels.SelectorFromSet(testLabels)

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -20,8 +20,10 @@ import (
 
 const (
 	gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
-	McdName               = "test-machine-deployment"
-	McName                = "test-machine"
+	// McdName is the name of the test machine deployment
+	McdName = "test-machine-deployment"
+	// McName is the name of the test machine
+	McName = "test-machine"
 )
 
 var (
@@ -37,7 +39,7 @@ func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
 			context.Background(),
 			&v1alpha1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-machine",
+					Name:      McName,
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.MachineSpec{
@@ -105,6 +107,7 @@ func (c *Cluster) IsMachineDeleted(ctx context.Context, machineName string, name
 	return errors.IsNotFound(err)
 }
 
+// IsMachineDeploymentDeleted returns boolean value indicating whether the specified machine deployment is deleted or not
 func (c *Cluster) IsMachineDeploymentDeleted(ctx context.Context, machineDeploymentName string, namespace string) bool {
 	_, err := c.McmClient.
 		MachineV1alpha1().

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -90,7 +90,7 @@ func (c *Cluster) GetMachineList(ctx context.Context) *v1alpha1.MachineList {
 		},
 	)
 	if err != nil {
-		log.Printf("error listing machines: %v", err)
+		log.Printf("error listing machines: %v\n", err)
 		return nil
 	}
 
@@ -130,7 +130,7 @@ func (c *Cluster) AreMachinesRunning(ctx context.Context, machineNames []string)
 	return true
 }
 
-// AreFailingMachinesPreserved checks if the all specified machines are in the failed state and are preserved
+// AreFailingMachinesPreserved checks if all the specified machines are in the Failed phase and are preserved
 func (c *Cluster) AreFailingMachinesPreserved(ctx context.Context, namespace string, machineNames []string) bool {
 	for _, mcName := range machineNames {
 		mc, err := c.McmClient.
@@ -138,7 +138,7 @@ func (c *Cluster) AreFailingMachinesPreserved(ctx context.Context, namespace str
 			Machines(namespace).
 			Get(ctx, mcName, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("error listing machine %s: %v", mcName, err)
+			log.Printf("error listing machine %s: %v\n", mcName, err)
 			return false
 		}
 

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -201,7 +201,7 @@ func NewMachineDeployment(namespace string, gnaSecretName string, replicas int32
 	return mcd
 }
 
-// CreateOrUpdateMachineDeployment creates or updates a MachineDeployment with the specified namespace, gnaSecretName, replicas and machineLabels
+// CreateOrUpdateMcd creates or updates a MachineDeployment with the specified namespace, gnaSecretName, replicas and machineLabels
 func (c *Cluster) CreateOrUpdateMcd(ctx context.Context, mcd v1alpha1.MachineDeployment, namespace string) error {
 	_, err := c.McmClient.MachineV1alpha1().MachineDeployments(namespace).Create(ctx, &mcd, metav1.CreateOptions{})
 	if errors.IsAlreadyExists(err) {

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
-	mcdName               = "test-machine-deployment"
+	McdName               = "test-machine-deployment"
 )
 
 var (
@@ -114,6 +114,15 @@ func (c *Cluster) IsMachineDeleted(ctx context.Context, machineName string, name
 	return errors.IsNotFound(err)
 }
 
+func (c *Cluster) IsMachineDeploymentDeleted(ctx context.Context, machineDeploymentName string, namespace string) bool {
+	_, err := c.McmClient.
+		MachineV1alpha1().
+		MachineDeployments(namespace).
+		Get(ctx, machineDeploymentName, metav1.GetOptions{})
+
+	return errors.IsNotFound(err)
+}
+
 // AreMachinesRunning returns boolean value indicating whether all the machines names passed to it are in the running state or not
 func (c *Cluster) AreMachinesRunning(ctx context.Context, machineNames []string, namespace string) bool {
 	for _, mcName := range machineNames {
@@ -159,7 +168,7 @@ func (c *Cluster) AreFailingMachinesPreserved(ctx context.Context, namespace str
 func NewMachineDeployment(namespace string, gnaSecretName string, replicas int32) v1alpha1.MachineDeployment {
 	mcd := v1alpha1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      mcdName,
+			Name:      McdName,
 			Namespace: namespace,
 		},
 		Spec: v1alpha1.MachineDeploymentSpec{

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -59,7 +59,7 @@ func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
 
 // CreateMachineDeployment creates a test-machine-deployment with a specified number of replicas and returns error if it occurs
 func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string, replicas int32) error {
-	mcd := GetMCD(namespace, gnaSecretName, replicas)
+	mcd := NewMachineDeployment(namespace, gnaSecretName, replicas)
 	_, err := c.McmClient.
 		MachineV1alpha1().
 		MachineDeployments(namespace).
@@ -108,8 +108,8 @@ func (c *Cluster) IsMachineDeleted(ctx context.Context, machineName string) bool
 	return errors.IsNotFound(err)
 }
 
-// IsMachineRunning returns boolean value indicating whether the specified machine is in the running state or not
-func (c *Cluster) IsMachineRunning(ctx context.Context, machineNames []string) bool {
+// AreMachinesRunning returns boolean value indicating whether all the machines names passed to it are in the running state or not
+func (c *Cluster) AreMachinesRunning(ctx context.Context, machineNames []string) bool {
 	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
 	for _, mcName := range machineNames {
 		mc, err := c.McmClient.
@@ -130,28 +130,26 @@ func (c *Cluster) IsMachineRunning(ctx context.Context, machineNames []string) b
 	return true
 }
 
-// IsFailingMachinePreserved returns boolean value indicating whether the specified machine is in the failed state and preserved or not
-func (c *Cluster) IsFailingMachinePreserved(ctx context.Context, namespace string, machineNames []string) bool {
-	for _, mcName := range machineNames {
-		mc, err := c.McmClient.
-			MachineV1alpha1().
-			Machines(namespace).
-			Get(ctx, mcName, metav1.GetOptions{})
-		if err != nil {
-			log.Printf("error listing machines: %v", err)
-			return false
-		}
+// IsFailingMachinePreserved checks if the specified machine is in the failed state and is preserved
+func (c *Cluster) IsFailingMachinePreserved(ctx context.Context, namespace string, machineName string) bool {
+	mc, err := c.McmClient.
+		MachineV1alpha1().
+		Machines(namespace).
+		Get(ctx, machineName, metav1.GetOptions{})
+	if err != nil {
+		log.Printf("error listing machine %s: %v", machineName, err)
+		return false
+	}
 
-		if mc.Status.CurrentStatus.PreserveExpiryTime == nil || mc.Status.CurrentStatus.Phase != v1alpha1.MachineFailed {
-			return false
-		}
+	if mc.Status.CurrentStatus.PreserveExpiryTime == nil || mc.Status.CurrentStatus.Phase != v1alpha1.MachineFailed {
+		return false
 	}
 
 	return true
 }
 
-// GetMCD returns a MachineDeployment object with the specified namespace, gnaSecretName, replicas and machineLabels
-func GetMCD(namespace string, gnaSecretName string, replicas int32) v1alpha1.MachineDeployment {
+// NewMachineDeployment returns a MachineDeployment object with the specified namespace, gnaSecretName, replicas and machineLabels
+func NewMachineDeployment(namespace string, gnaSecretName string, replicas int32) v1alpha1.MachineDeployment {
 	mcd := v1alpha1.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mcdName,

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -21,6 +21,7 @@ import (
 const (
 	gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
 	McdName               = "test-machine-deployment"
+	McName                = "test-machine"
 )
 
 var (
@@ -68,15 +69,15 @@ func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string
 	return err
 }
 
-// IsTestMachineDeleted returns boolean value of presence of 'test-machine' object
-func (c *Cluster) IsTestMachineDeleted(ctx context.Context, namespace string) bool {
-	_, err := c.McmClient.
-		MachineV1alpha1().
-		Machines(namespace).
-		Get(ctx, "test-machine", metav1.GetOptions{})
+// // IsTestMachineDeleted returns boolean value of presence of 'test-machine' object
+// func (c *Cluster) IsTestMachineDeleted(ctx context.Context, namespace string) bool {
+// 	_, err := c.McmClient.
+// 		MachineV1alpha1().
+// 		Machines(namespace).
+// 		Get(ctx, "test-machine", metav1.GetOptions{})
 
-	return errors.IsNotFound(err)
-}
+// 	return errors.IsNotFound(err)
+// }
 
 // GetRunningMachineList lists all running machines that contain the given machine labels and returns the list of such machines
 func (c *Cluster) GetRunningMachineList(ctx context.Context, namespace string) ([]v1alpha1.Machine, error) {
@@ -144,8 +145,8 @@ func (c *Cluster) AreMachinesRunning(ctx context.Context, machineNames []string,
 	return true
 }
 
-// AreFailingMachinesPreserved checks if all the specified machines are in the Failed phase and are preserved
-func (c *Cluster) AreFailingMachinesPreserved(ctx context.Context, namespace string, machineNames []string) bool {
+// AreMachinesFailedAndPreserved checks if all the specified machines are in the Failed phase and are preserved
+func (c *Cluster) AreMachinesFailedAndPreserved(ctx context.Context, namespace string, machineNames []string) bool {
 	for _, mcName := range machineNames {
 		mc, err := c.McmClient.
 			MachineV1alpha1().

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -7,7 +7,6 @@ package helpers
 import (
 	"context"
 	"log"
-	"os"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 
@@ -15,6 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"k8s.io/client-go/util/retry"
 )
 
 const (
@@ -68,22 +69,22 @@ func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string
 }
 
 // IsTestMachineDeleted returns boolean value of presence of 'test-machine' object
-func (c *Cluster) IsTestMachineDeleted() bool {
-	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+func (c *Cluster) IsTestMachineDeleted(ctx context.Context, namespace string) bool {
 	_, err := c.McmClient.
 		MachineV1alpha1().
-		Machines(controlClusterNamespace).
-		Get(context.Background(), "test-machine", metav1.GetOptions{})
+		Machines(namespace).
+		Get(ctx, "test-machine", metav1.GetOptions{})
 
 	return errors.IsNotFound(err)
 }
 
-// GetMachineList lists all machines that contain the given machine labels and returns the list of machines
-func (c *Cluster) GetMachineList(ctx context.Context) *v1alpha1.MachineList {
+// GetRunningMachineList lists all running machines that contain the given machine labels and returns the list of such machines
+func (c *Cluster) GetRunningMachineList(ctx context.Context, namespace string) ([]v1alpha1.Machine, error) {
 	selector := labels.SelectorFromSet(testLabels)
-	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
 
-	machineList, err := c.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).List(
+	var runningMachines []v1alpha1.Machine
+
+	machineList, err := c.McmClient.MachineV1alpha1().Machines(namespace).List(
 		ctx,
 		metav1.ListOptions{
 			LabelSelector: selector.String(),
@@ -91,30 +92,34 @@ func (c *Cluster) GetMachineList(ctx context.Context) *v1alpha1.MachineList {
 	)
 	if err != nil {
 		log.Printf("error listing machines: %v\n", err)
-		return nil
+		return nil, err
 	}
 
-	return machineList
+	for _, mc := range machineList.Items {
+		if mc.Status.CurrentStatus.Phase == v1alpha1.MachineRunning {
+			runningMachines = append(runningMachines, mc)
+		}
+	}
+
+	return runningMachines, nil
 }
 
 // IsMachineDeleted returns boolean value indicating whether the specified machine is deleted or not
-func (c *Cluster) IsMachineDeleted(ctx context.Context, machineName string) bool {
-	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+func (c *Cluster) IsMachineDeleted(ctx context.Context, machineName string, namespace string) bool {
 	_, err := c.McmClient.
 		MachineV1alpha1().
-		Machines(controlClusterNamespace).
+		Machines(namespace).
 		Get(ctx, machineName, metav1.GetOptions{})
 
 	return errors.IsNotFound(err)
 }
 
 // AreMachinesRunning returns boolean value indicating whether all the machines names passed to it are in the running state or not
-func (c *Cluster) AreMachinesRunning(ctx context.Context, machineNames []string) bool {
-	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+func (c *Cluster) AreMachinesRunning(ctx context.Context, machineNames []string, namespace string) bool {
 	for _, mcName := range machineNames {
 		mc, err := c.McmClient.
 			MachineV1alpha1().
-			Machines(controlClusterNamespace).
+			Machines(namespace).
 			Get(ctx, mcName, metav1.GetOptions{})
 
 		if err != nil {
@@ -194,4 +199,22 @@ func NewMachineDeployment(namespace string, gnaSecretName string, replicas int32
 	}
 
 	return mcd
+}
+
+// CreateOrUpdateMachineDeployment creates or updates a MachineDeployment with the specified namespace, gnaSecretName, replicas and machineLabels
+func (c *Cluster) CreateOrUpdateMcd(ctx context.Context, mcd v1alpha1.MachineDeployment, namespace string) error {
+	_, err := c.McmClient.MachineV1alpha1().MachineDeployments(namespace).Create(ctx, &mcd, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			existingMCD, err := c.McmClient.MachineV1alpha1().MachineDeployments(namespace).Get(ctx, mcd.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			mcd.ResourceVersion = existingMCD.ResourceVersion
+			_, updateErr := c.McmClient.MachineV1alpha1().MachineDeployments(namespace).Update(ctx, &mcd, metav1.UpdateOptions{})
+			return updateErr
+		})
+		return retryErr
+	}
+	return err
 }

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -57,55 +57,13 @@ func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
 	return err
 }
 
-// CreateMachineDeployment creates a test-machine-deployment with 3 replicas and returns error if it occurs
+// CreateMachineDeployment creates a test-machine-deployment with a specified number of replicas and returns error if it occurs
 func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string, replicas int32) error {
+	mcd := GetMCD(namespace, gnaSecretName, replicas)
 	_, err := c.McmClient.
 		MachineV1alpha1().
 		MachineDeployments(namespace).
-		Create(
-			context.Background(),
-			&v1alpha1.MachineDeployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      mcdName,
-					Namespace: namespace,
-				},
-				Spec: v1alpha1.MachineDeploymentSpec{
-					Replicas:        replicas,
-					MinReadySeconds: 500,
-					Strategy: v1alpha1.MachineDeploymentStrategy{
-						Type: v1alpha1.RollingUpdateMachineDeploymentStrategyType,
-						RollingUpdate: &v1alpha1.RollingUpdateMachineDeployment{
-							UpdateConfiguration: v1alpha1.UpdateConfiguration{
-								MaxSurge:       &intstr.IntOrString{IntVal: 2},
-								MaxUnavailable: &intstr.IntOrString{IntVal: 1},
-							},
-						},
-					},
-					Selector: &metav1.LabelSelector{
-						MatchLabels: testLabels,
-					},
-					Template: v1alpha1.MachineTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: testLabels,
-						},
-						Spec: v1alpha1.MachineSpec{
-							Class: v1alpha1.ClassSpec{
-								Kind: "MachineClass",
-								Name: "test-mc-v1",
-							},
-							NodeTemplateSpec: v1alpha1.NodeTemplateSpec{
-								ObjectMeta: metav1.ObjectMeta{
-									Labels: map[string]string{
-										gnaSecretNameLabelKey: gnaSecretName,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			metav1.CreateOptions{},
-		)
+		Create(context.Background(), &mcd, metav1.CreateOptions{})
 	return err
 }
 

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -6,6 +6,7 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
@@ -13,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"k8s.io/client-go/util/retry"
@@ -219,5 +221,20 @@ func (c *Cluster) CreateOrUpdateMcd(ctx context.Context, mcd v1alpha1.MachineDep
 		})
 		return retryErr
 	}
+	return err
+}
+
+// PatchMachineAnnotations patches the annotations of a machine with the specified name and namespace with the provided annotation map
+func (c *Cluster) PatchMachineAnnotations(ctx context.Context, mcName string, namespace string, annMap map[string]any) error {
+	patch := map[string]any{
+		"metadata": map[string]any{
+			"annotations": annMap,
+		},
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return err
+	}
+	_, err = c.McmClient.MachineV1alpha1().Machines(namespace).Patch(ctx, mcName, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 	return err
 }

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -830,8 +830,9 @@ func (c *controller) machineCreateErrorHandler(ctx context.Context, machine *v1a
 			LastUpdateTime: metav1.Now(),
 		},
 		v1alpha1.CurrentStatus{
-			Phase:          c.getCreateFailurePhase(machine),
-			LastUpdateTime: metav1.Now(),
+			Phase:              c.getCreateFailurePhase(machine),
+			LastUpdateTime:     metav1.Now(),
+			PreserveExpiryTime: machine.Status.CurrentStatus.PreserveExpiryTime,
 		},
 		lastKnownState,
 	)

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -818,8 +818,9 @@ func (c *controller) machineCreateErrorHandler(ctx context.Context, machine *v1a
 			LastUpdateTime: metav1.Now(),
 		},
 		v1alpha1.CurrentStatus{
-			Phase:          c.getCreateFailurePhase(machine),
-			LastUpdateTime: metav1.Now(),
+			Phase:              c.getCreateFailurePhase(machine),
+			LastUpdateTime:     metav1.Now(),
+			PreserveExpiryTime: machine.Status.CurrentStatus.PreserveExpiryTime,
 		},
 		lastKnownState,
 	)

--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -68,7 +68,7 @@ import (
 var emptyMap = make(map[string]string)
 var (
 	errSuccessfulALTsync     = errors.New("machine ALTs have been reconciled")
-	errSuccessfulPhaseUpdate = errors.New("machine creation is successful. Machine Phase/Conditions have been UPDATED")
+	errSuccessfulPhaseUpdate = errors.New("machine Update is successful. Machine Phase/Conditions have been UPDATED")
 )
 
 const (
@@ -2165,6 +2165,7 @@ func (c *controller) updateMachineToFailedState(ctx context.Context, description
 		klog.Errorf("update failed for machine %q in function. Retrying, error: %q", machine.Name, err)
 	} else {
 		updated = true
+		err = errSuccessfulPhaseUpdate
 		klog.Infof("Machine State has been updated to Phase %q for %q with providerID %q and backing node %q", clone.Status.CurrentStatus.Phase, machine.Name, getProviderID(machine), getNodeName(machine))
 	}
 

--- a/pkg/util/provider/machinecontroller/machine_util_test.go
+++ b/pkg/util/provider/machinecontroller/machine_util_test.go
@@ -2551,6 +2551,7 @@ var _ = Describe("machine_util", func() {
 				expect: expect{
 					retryPeriod:   machineutils.ShortRetry,
 					expectedPhase: machinev1.MachineFailed,
+					err:           errSuccessfulPhaseUpdate,
 				},
 			}),
 			Entry("Machine in Unknown state WITHOUT backing node obj for over 10min(healthTimeout) should be marked Failed", &data{
@@ -2567,6 +2568,7 @@ var _ = Describe("machine_util", func() {
 				expect: expect{
 					retryPeriod:   machineutils.ShortRetry,
 					expectedPhase: machinev1.MachineFailed,
+					err:           errSuccessfulPhaseUpdate,
 				},
 			}),
 			Entry("simple machine WITHOUT creation Timeout(20 min) and Pending state", &data{
@@ -2681,6 +2683,7 @@ var _ = Describe("machine_util", func() {
 				expect: expect{
 					retryPeriod:   machineutils.ShortRetry,
 					expectedPhase: machinev1.MachineFailed,
+					err:           errSuccessfulPhaseUpdate,
 				},
 			}),
 			Entry("Machine in InPlaceUpdateFailed state for over 10min(healthTimeout) should not be marked Failed if DisableHealthTimeout is set", &data{
@@ -2902,6 +2905,7 @@ var _ = Describe("machine_util", func() {
 				expect: expect{
 					retryPeriod:   machineutils.ShortRetry,
 					expectedPhase: machinev1.MachineFailed,
+					err:           errSuccessfulPhaseUpdate,
 				},
 			}),
 			Entry("1 HealthTimedOut, 1 Failed machine: from different machinedeployments,only 1 machine per machineDeployment present, targetMachine should be marked Failed", &data{
@@ -2926,6 +2930,7 @@ var _ = Describe("machine_util", func() {
 				expect: expect{
 					retryPeriod:   machineutils.ShortRetry,
 					expectedPhase: machinev1.MachineFailed,
+					err:           errSuccessfulPhaseUpdate,
 				},
 			}),
 			Entry("2 HealthTimedOut machines: from same machinedeployment,only 2 machines for machineDeployment present, targetMachine should be marked Failed", &data{
@@ -2943,6 +2948,7 @@ var _ = Describe("machine_util", func() {
 				expect: expect{
 					retryPeriod:   machineutils.ShortRetry,
 					expectedPhase: machinev1.MachineFailed,
+					err:           errSuccessfulPhaseUpdate,
 				},
 			}),
 			Entry("1 HealthTimedOut , 1 Failed machine: from same machinedeployment,only 2 machines for machineDeployment present, healthTimeoutOut one should NOT be marked Failed", &data{


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR adds integration tests for machine preservation.

The following cases have been covered:

Auto Machine Preservation:
- [x] Ensure failed machine is preserved and rejoins the cluster on recovery
- [x] Failed machines that cross the max threshold are not preserved
- [x] machinePreserveTimeout is honoured for failing machines
- [x] Machine should not be preserved when the `preserve=false` annotation is present
- [x] Preserved machine should stop being preserved when `preserve=false` annotation is added
- [x] When `AutoPreserveFailedMachineMax` is reduced, failed machines that exceed the new `AutoPreserveFailedMachineMax ` count are moved to terminating

Manual Machine Preservation:
- [x] Machine in an mcd without any preservation fields should be preserved when failed if it has the `when-failed` annotation and move back to `Running` phase when it recovers
- [x]  Machine should be preserved when it's corresponding node is annotated with `when-failed`
- [x] A machine marked for preservation using the `when-failed` annotation should be preserved when failed even if `autoPreserveMax` is crossed
- [x] Preserved machine should terminate if the preservation annotation is removed 

**Which issue(s) this PR fixes**:
Fixes partially #1123

**Special notes for your reviewer**:
To trigger machine failures, this PR takes the approach of applying a validating admission policy to block all kubelet updates. This causes kubelet not to be able to update it's node lease or it's node status and results in the node going into the `Unknown` state.
This is a k8s native way of achieving node failures and has no dependency on the provider or any other node/worker-pool setting

This might not work with the virtual provider of the virtual provider does not use kubelets, but imo this can be considered a special case and can be tackled in a separate PR

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Added integration tests for machine preservation
```
