### PR TITLE
Add integration tests for manual machine preservation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -26,6 +26,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	appsV1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
@@ -34,6 +35,7 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/test/integration/common/helpers"
 	"github.com/gardener/machine-controller-manager/pkg/test/utils/matchers"
+	mc_utils "github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 )
 
 const (
@@ -978,6 +980,272 @@ func (c *IntegrationTestFramework) ControllerTests() {
 					c.pollingInterval).
 					Should(gomega.BeEquivalentTo(false))
 
+			})
+		})
+	})
+
+	// Testcase #05 | Manual Machine preservation
+
+	ginkgo.Describe("Manual Machine Preservation", func() {
+		ginkgo.Context("Manual-Preserve Failed machine", func() {
+			ginkgo.It("Should preserve machine when it fails and let it join the cluster again when it recovers before preservation timeout", func() {
+				ginkgo.By("Creating a MCD with no preservation fields populated")
+				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				//Update the standard mcd to a low machine health timeout to make the test run faster
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+					mcd.ResourceVersion = existingMCD.ResourceVersion
+					_, err = c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+				ginkgo.By("wait for machine to be created")
+				var machineList *v1alpha1.MachineList
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
+				ginkgo.By("wait for machine to start running")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+				// Fetch machine list again to ensure we have the latest state of the machine
+				machineList = c.ControlCluster.GetMachineList(ctx)
+				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine to ensure it is preserved when it fails
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				// Simulate kubelet failure for the node
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("remove VAP and VAPB to simulate kubelet restart")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+
+				ginkgo.By("wait for node to recover and move to Running phase")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+			})
+		})
+		ginkgo.Context("Ensure that machine annotated with `when-failed` are preserved", func() {
+			ginkgo.It("Should ensure that a machine marked for preservation using `when-failed` is preserved even if `autoPreserveMax` number of machines already preserved", func() {
+				ginkgo.By("Creating a MCD with preservation fields populated")
+				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 2)
+
+				mcd.Spec.AutoPreserveFailedMachineMax = 1
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+						existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+						gomega.Expect(err).To(gomega.BeNil())
+						mcd.ResourceVersion = existingMCD.ResourceVersion
+						_, updateErr := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+						return updateErr
+					})
+					gomega.Expect(retryErr).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+
+				ginkgo.By("wait for machine to be created")
+				var machineList *v1alpha1.MachineList
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(2)))
+
+				ginkgo.By("wait for machine to start running")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name, machineList.Items[1].Name}).
+					Should(gomega.BeTrue())
+
+				// Fetch machine list again to ensure we have the latest state of the machine
+				machineList = c.ControlCluster.GetMachineList(ctx)
+
+				// Simulate kubelet failure for one node so that it can be auto preserved
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for one node")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the second machine that is running to ensure it is preserved when it fails
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the other running machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[1].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				// Simulate kubelet failure for the second node.
+				// The first node is already auto preserved and counts AutoPreserveFailedMachineMax.
+				// We expect this machine to be preserved as well since it is explicitely marked
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure for the second machine")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"], machineList.Items[1].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for second machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[1].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("Ensure that first machine is still preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("cleanup deployed VAP and VAPB")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
+			})
+		})
+		ginkgo.Context("Ensure preserved machines are deleted when preserve annotated is removed", func() {
+			ginkgo.It("Should ensure that a manually preserved machine is deleted if the preservation annotation is removed", func() {
+				ginkgo.By("Creating a MCD with no preservation fields populated")
+				mcd := helpers.GetMCD(controlClusterNamespace, gnaSecretNameLabelValue, 1)
+				//Update the standard mcd to a low machine health timeout to make the test run faster
+				mcd.Spec.Template.Spec.MachineConfiguration = &v1alpha1.MachineConfiguration{
+					MachineHealthTimeout: &metav1.Duration{Duration: 15 * time.Second},
+				}
+				_, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Create(ctx, &mcd, metav1.CreateOptions{})
+				if errors.IsAlreadyExists(err) {
+					existingMCD, err := c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Get(context.Background(), mcd.Name, metav1.GetOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+					mcd.ResourceVersion = existingMCD.ResourceVersion
+					_, err = c.ControlCluster.McmClient.MachineV1alpha1().MachineDeployments(controlClusterNamespace).Update(context.Background(), &mcd, metav1.UpdateOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+				} else if !errors.IsAlreadyExists(err) {
+					gomega.Expect(err).To(gomega.BeNil())
+				}
+				ginkgo.By("wait for machine to be created")
+				var machineList *v1alpha1.MachineList
+				gomega.Eventually(
+					func() *v1alpha1.MachineList {
+						machineList = c.ControlCluster.GetMachineList(ctx)
+						return machineList
+					},
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.HaveField("Items", gomega.HaveLen(1)))
+
+				ginkgo.By("wait for machine to start running")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineRunning,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+					// Fetch machine list again to ensure we have the latest state of the machine
+				machineList = c.ControlCluster.GetMachineList(ctx)
+
+				// Add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine to ensure it is preserved when it fails
+				ginkgo.By("add the node.machine.sapcloud.io/preserve=when-failed annotation to the running machine")
+				patch := map[string]any{
+					"metadata": map[string]any{
+						"annotations": map[string]any{
+							mc_utils.PreserveMachineAnnotationKey: mc_utils.PreserveMachineAnnotationValueWhenFailed,
+						},
+					},
+				}
+				patchBytes, err := json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				// Simulate kubelet failure for the node
+				ginkgo.By("deploy VAP and VAPB to simulate kubelet failure")
+				gomega.Expect(c.TargetCluster.CreateVAPToBlockKubeletUpdates(ctx, []string{machineList.Items[0].ObjectMeta.Labels["node"]})).To(gomega.BeNil())
+
+				ginkgo.By("Waiting for machine to fail and be preserved")
+				gomega.Eventually(
+					c.ControlCluster.IsFailingMachinePreserved,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, controlClusterNamespace, []string{machineList.Items[0].Name}).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("remove the node.machine.sapcloud.io/preserve=when-failed annotation from the preserved machine")
+				patch = map[string]any{
+					"metadata": map[string]any{
+						"annotations": nil,
+					},
+				}
+				patchBytes, err = json.Marshal(patch)
+				gomega.Expect(err).To(gomega.BeNil())
+				_, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Patch(ctx, machineList.Items[0].Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("wait for machine to be deleted")
+				gomega.Eventually(
+					c.ControlCluster.IsMachineDeleted,
+					c.timeout,
+					c.pollingInterval).
+					WithArguments(ctx, machineList.Items[0].Name).
+					Should(gomega.BeTrue())
+
+				ginkgo.By("cleanup deployed VAP and VAPB")
+				gomega.Expect(c.TargetCluster.DeleteVAPToRestartKubeletUpdates(ctx)).To(gomega.BeNil())
 			})
 		})
 	})

--- a/pkg/test/integration/common/helpers/admission_policy.go
+++ b/pkg/test/integration/common/helpers/admission_policy.go
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// VAPName is the name of the ValidatingAdmissionPolicy that blocks kubelet from updating node leases and node status.
+	VAPName = "integration-test-block-node-heartbeats"
+	// VAPBName is the name of the ValidatingAdmissionPolicyBinding that binds the above ValidatingAdmissionPolicy to the cluster.
+	VAPBName = "integration-test-block-node-heartbeats-binding"
+)
+
+// CreateVAPToBlockKubeletUpdates is a utility method to create a ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+// to block kubelet from updating node leases and node status.
+// This is used to cause nodes to go into the NotReady state to test the machine preservation feature of MCM.
+// TODO: pass context from caller
+func (c *Cluster) CreateVAPToBlockKubeletUpdates(ctx context.Context, nodeNames []string) error {
+	var err error
+	for _, noName := range nodeNames {
+		_, err := c.Clientset.CoreV1().Nodes().Get(ctx, noName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error fetching node: %v", err)
+			return err
+		}
+	}
+
+	VAPolicy := &admissionregistrationv1.ValidatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: VAPName,
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
+			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{""},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"nodes/status"},
+							},
+						},
+					},
+					{
+						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
+							Operations: []admissionregistrationv1.OperationType{
+								admissionregistrationv1.Update,
+							},
+							Rule: admissionregistrationv1.Rule{
+								APIGroups:   []string{"coordination.k8s.io"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"leases"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionregistrationv1.Validation{
+				{
+					Expression: blockedKubeletExpression(nodeNames),
+					Message:    "blocking kubelet heartbeat for test",
+				},
+			},
+		},
+	}
+
+	VAPBinding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: VAPBName,
+		},
+		Spec: admissionregistrationv1.ValidatingAdmissionPolicyBindingSpec{
+			PolicyName: VAPName,
+			ValidationActions: []admissionregistrationv1.ValidationAction{
+				admissionregistrationv1.Deny,
+			},
+		},
+	}
+
+	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, VAPolicy, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		existingVAPolicy, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Get(ctx, VAPName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error fetching validating admission policy: %v", err)
+			return err
+		}
+		VAPolicy.ResourceVersion = existingVAPolicy.ResourceVersion
+
+		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Update(ctx, VAPolicy, metav1.UpdateOptions{})
+		if err != nil {
+			log.Printf("error updating validating admission policy: %v", err)
+			return err
+		}
+	} else if err != nil {
+		log.Printf("error creating validating admission policy: %v", err)
+		return err
+	}
+
+	_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(ctx, VAPBinding, metav1.CreateOptions{})
+	if errors.IsAlreadyExists(err) {
+		existingVAPBinding, err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Get(ctx, VAPBName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error fetching validating admission policy binding: %v", err)
+			return err
+		}
+		VAPBinding.ResourceVersion = existingVAPBinding.ResourceVersion
+
+		_, err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Update(ctx, VAPBinding, metav1.UpdateOptions{})
+		if err != nil {
+			log.Printf("error updating validating admission policy binding: %v", err)
+			return err
+		}
+	} else if err != nil {
+		log.Printf("error creating validating admission policy binding: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func blockedKubeletExpression(nodes []string) string {
+	users := make([]string, 0, len(nodes))
+
+	for _, node := range nodes {
+		users = append(users, fmt.Sprintf(`"system:node:%s"`, node))
+	}
+
+	return fmt.Sprintf(
+		"!(request.userInfo.username in [%s])",
+		strings.Join(users, ", "),
+	)
+}
+
+// DeleteVAPToRestartKubeletUpdates deletes the ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding that were created to block kubelet from updating node leases and node status.
+func (c *Cluster) DeleteVAPToRestartKubeletUpdates(ctx context.Context) error {
+	err := c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete(ctx, VAPName, metav1.DeleteOptions{})
+	if err != nil {
+		log.Printf("error deleting validating admission policy: %v", err)
+		return err
+	}
+
+	err = c.Clientset.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete(ctx, VAPBName, metav1.DeleteOptions{})
+	if err != nil {
+		log.Printf("error deleting validating admission policy binding: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -6,16 +6,25 @@ package helpers
 
 import (
 	"context"
+	"log"
 	"os"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
+const (
+	gnaSecretNameLabelKey = "worker.gardener.cloud/gardener-node-agent-secret-name"
+	mcdName               = "test-machine-deployment"
+)
+
+var (
+	testLabels = map[string]string{"test-label": "test-label"}
+)
 
 // CreateMachine creates a test-machine using machineclass "test-mc"
 func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
@@ -50,7 +59,6 @@ func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
 
 // CreateMachineDeployment creates a test-machine-deployment with 3 replicas and returns error if it occurs
 func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string, replicas int32) error {
-	labels := map[string]string{"test-label": "test-label"}
 	_, err := c.McmClient.
 		MachineV1alpha1().
 		MachineDeployments(namespace).
@@ -58,7 +66,7 @@ func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string
 			context.Background(),
 			&v1alpha1.MachineDeployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-machine-deployment",
+					Name:      mcdName,
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.MachineDeploymentSpec{
@@ -74,11 +82,11 @@ func (c *Cluster) CreateMachineDeployment(namespace string, gnaSecretName string
 						},
 					},
 					Selector: &metav1.LabelSelector{
-						MatchLabels: labels,
+						MatchLabels: testLabels,
 					},
 					Template: v1alpha1.MachineTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: labels,
+							Labels: testLabels,
 						},
 						Spec: v1alpha1.MachineSpec{
 							Class: v1alpha1.ClassSpec{
@@ -110,4 +118,122 @@ func (c *Cluster) IsTestMachineDeleted() bool {
 		Get(context.Background(), "test-machine", metav1.GetOptions{})
 
 	return errors.IsNotFound(err)
+}
+
+// GetMachineList lists all machines that contain the given machine labels and returns the list of machines
+func (c *Cluster) GetMachineList(ctx context.Context) *v1alpha1.MachineList {
+	selector := labels.SelectorFromSet(testLabels)
+	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+
+	machineList, err := c.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).List(
+		ctx,
+		metav1.ListOptions{
+			LabelSelector: selector.String(),
+		},
+	)
+	if err != nil {
+		log.Printf("error listing machines: %v", err)
+		return nil
+	}
+
+	return machineList
+}
+
+// IsMachineDeleted returns boolean value indicating whether the specified machine is deleted or not
+func (c *Cluster) IsMachineDeleted(ctx context.Context, machineName string) bool {
+	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+	_, err := c.McmClient.
+		MachineV1alpha1().
+		Machines(controlClusterNamespace).
+		Get(ctx, machineName, metav1.GetOptions{})
+
+	return errors.IsNotFound(err)
+}
+
+// IsMachineRunning returns boolean value indicating whether the specified machine is in the running state or not
+func (c *Cluster) IsMachineRunning(ctx context.Context, machineNames []string) bool {
+	controlClusterNamespace := os.Getenv("CONTROL_CLUSTER_NAMESPACE")
+	for _, mcName := range machineNames {
+		mc, err := c.McmClient.
+			MachineV1alpha1().
+			Machines(controlClusterNamespace).
+			Get(ctx, mcName, metav1.GetOptions{})
+
+		if err != nil {
+			log.Println("error fetching machine: ", err)
+			return false
+		}
+
+		if mc.Status.CurrentStatus.Phase != v1alpha1.MachineRunning {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsFailingMachinePreserved returns boolean value indicating whether the specified machine is in the failed state and preserved or not
+func (c *Cluster) IsFailingMachinePreserved(ctx context.Context, namespace string, machineNames []string) bool {
+	for _, mcName := range machineNames {
+		mc, err := c.McmClient.
+			MachineV1alpha1().
+			Machines(namespace).
+			Get(ctx, mcName, metav1.GetOptions{})
+		if err != nil {
+			log.Printf("error listing machines: %v", err)
+			return false
+		}
+
+		if mc.Status.CurrentStatus.PreserveExpiryTime == nil || mc.Status.CurrentStatus.Phase != v1alpha1.MachineFailed {
+			return false
+		}
+	}
+
+	return true
+}
+
+// GetMCD returns a MachineDeployment object with the specified namespace, gnaSecretName, replicas and machineLabels
+func GetMCD(namespace string, gnaSecretName string, replicas int32) v1alpha1.MachineDeployment {
+	mcd := v1alpha1.MachineDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mcdName,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.MachineDeploymentSpec{
+			Replicas:        replicas,
+			MinReadySeconds: 500,
+			Strategy: v1alpha1.MachineDeploymentStrategy{
+				Type: v1alpha1.RollingUpdateMachineDeploymentStrategyType,
+				RollingUpdate: &v1alpha1.RollingUpdateMachineDeployment{
+					UpdateConfiguration: v1alpha1.UpdateConfiguration{
+						MaxSurge:       &intstr.IntOrString{IntVal: 2},
+						MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+					},
+				},
+			},
+			Selector: &metav1.LabelSelector{
+				MatchLabels: testLabels,
+			},
+			Template: v1alpha1.MachineTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: testLabels,
+				},
+				Spec: v1alpha1.MachineSpec{
+					Class: v1alpha1.ClassSpec{
+						Kind: "MachineClass",
+						Name: "test-mc-v1",
+					},
+					NodeTemplateSpec: v1alpha1.NodeTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								gnaSecretNameLabelKey: gnaSecretName,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return mcd
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR adds integration tests for manual machine preservation.

The following cases have been covered:
- [x] Machine in an mcd without any preservation fields should be preserved when failed if it has the `when-failed` annotation
- [x] Failed machine that has been preserved using `when-failed` should move back to `Running` phase when it recovers
- [x] A machine marked for preservation using the `when-failed` annotation should be preserved when failed even if `autoPreserveMax` is crossed
- [x] Preserved machine should terminate if the preservation annotation is removed 

**Which issue(s) this PR fixes**:
Fixes partially #1123 

**Special notes for your reviewer**:
To trigger machine failures, this PR takes the approach of applying a validating admission policy to block all kubelet updates. This causes kubelet not to be able to update it's node lease or it's node status and results in the node going into the Unknown state.
This is a k8s native way of achieving node failures and has no dependency on the provider or any other node/worker-pool setting

This might not work with the virtual provider of the virtual provider does not use kubelets, but imo this can be considered a special case and can be tackled in a separate PR

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Added integration tests for manual machine preservation
```
