### PR TITLE
Add an integration test for node deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -768,23 +768,27 @@ func (c *IntegrationTestFramework) ControllerTests() {
 
 				ginkgo.By("Waiting until number of ready nodes is 1 more than initial nodes")
 				gomega.Eventually(
-					c.TargetCluster.GetNumberOfNodes,
-					c.timeout,
-					c.pollingInterval).
-					Should(gomega.BeNumerically("==", initialNodes+1))
-
-				gomega.Eventually(
 					c.TargetCluster.GetNumberOfReadyNodes,
 					c.timeout,
 					c.pollingInterval).
 					Should(gomega.BeNumerically("==", initialNodes+1))
+
+				ginkgo.By("wait till node label is present on the machine")
+				gomega.Eventually(func() bool {
+					mc, err := c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Get(ctx, testMachineName, metav1.GetOptions{})
+					if err != nil {
+						return false
+					}
+					_, exists := mc.GetLabels()[v1alpha1.NodeLabelKey]
+					return exists
+				}).Should(gomega.BeTrue())
 
 				// Get existing machine. This is needed to fetch node name
 				existingMachine, err := c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Get(ctx, testMachineName, metav1.GetOptions{})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				ginkgo.By("Deleting node associated with test-machine")
-				err = c.TargetCluster.Clientset.CoreV1().Nodes().Delete(ctx, existingMachine.Labels["node"], metav1.DeleteOptions{})
+				err = c.TargetCluster.Clientset.CoreV1().Nodes().Delete(ctx, existingMachine.Labels[v1alpha1.NodeLabelKey], metav1.DeleteOptions{})
 				gomega.Expect(err).To(gomega.BeNil())
 
 				ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes")

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -761,6 +761,47 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				})
 			})
 		})
+		ginkgo.Context("node deletion", func() {
+			ginkgo.It("should delete machine resource when node resource is deleted", func() {
+				ginkgo.By("Create machine")
+				gomega.Expect(c.ControlCluster.CreateMachine(controlClusterNamespace, gnaSecretNameLabelValue)).To(gomega.BeNil())
+
+				ginkgo.By("Waiting until number of ready nodes is 1 more than initial nodes")
+				gomega.Eventually(
+					c.TargetCluster.GetNumberOfNodes,
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.BeNumerically("==", initialNodes+1))
+
+				gomega.Eventually(
+					c.TargetCluster.GetNumberOfReadyNodes,
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.BeNumerically("==", initialNodes+1))
+
+				// Get existing machine. This is needed to fetch node name
+				existingMachine, err := c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Get(ctx, testMachineName, metav1.GetOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("Deleting node associated with test-machine")
+				err = c.TargetCluster.Clientset.CoreV1().Nodes().Delete(ctx, existingMachine.Labels["node"], metav1.DeleteOptions{})
+				gomega.Expect(err).To(gomega.BeNil())
+
+				ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes")
+				gomega.Eventually(
+					c.TargetCluster.GetNumberOfNodes,
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.BeNumerically("==", initialNodes))
+
+				ginkgo.By("Waiting until test-machine machine object is deleted")
+				gomega.Eventually(
+					c.ControlCluster.IsTestMachineDeleted,
+					c.timeout,
+					c.pollingInterval).
+					Should(gomega.BeTrue())
+			})
+		})
 	})
 
 	// Testcase #02 | machine deployment

--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -671,8 +671,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 	ginkgo.Describe("machine resource", func() {
 		var initialNodes int16
 		ginkgo.Context("creation", func() {
-			ginkgo.It("should not lead to any errors and add 1 more node in target cluster", func() {
-				// In case of existing deployments creating nodes when starting simulated
+			ginkgo.It("should not lead to any errors and add 2 more node in target cluster", func() {
+				// In case of existing deployments creating nodes when starting virtual
 				// provider, the change in node count can be >1, this delay prevents
 				// checking node count immediately to allow for a correct initial count
 				if isSimulatedProvider {
@@ -681,20 +681,20 @@ func (c *IntegrationTestFramework) ControllerTests() {
 				// Probe nodes currently available in target cluster
 				initialNodes = c.TargetCluster.GetNumberOfNodes()
 				ginkgo.By("Checking for errors")
-				gomega.Expect(c.ControlCluster.CreateMachine(controlClusterNamespace, gnaSecretNameLabelValue)).To(gomega.BeNil())
+				gomega.Expect(c.ControlCluster.CreateMachines(controlClusterNamespace, gnaSecretNameLabelValue)).To(gomega.BeNil())
 
-				ginkgo.By("Waiting until number of ready nodes is 1 more than initial nodes")
+				ginkgo.By("Waiting until number of ready nodes is 2 more than initial nodes")
 				gomega.Eventually(
 					c.TargetCluster.GetNumberOfNodes,
 					c.timeout,
 					c.pollingInterval).
-					Should(gomega.BeNumerically("==", initialNodes+1))
+					Should(gomega.BeNumerically("==", initialNodes+2))
 
 				gomega.Eventually(
 					c.TargetCluster.GetNumberOfReadyNodes,
 					c.timeout,
 					c.pollingInterval).
-					Should(gomega.BeNumerically("==", initialNodes+1))
+					Should(gomega.BeNumerically("==", initialNodes+2))
 			})
 		})
 
@@ -722,19 +722,53 @@ func (c *IntegrationTestFramework) ControllerTests() {
 							WithArguments(ctx, helpers.McName, controlClusterNamespace).
 							Should(gomega.BeTrue())
 
-						ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes")
+						ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes+1")
 						gomega.Eventually(
 							c.TargetCluster.GetNumberOfNodes,
 							c.timeout,
 							c.pollingInterval).
-							Should(gomega.BeNumerically("==", initialNodes))
+							Should(gomega.BeNumerically("==", initialNodes+1))
 						gomega.Eventually(
 							c.TargetCluster.GetNumberOfReadyNodes,
 							c.timeout,
 							c.pollingInterval).
-							Should(gomega.BeNumerically("==", initialNodes))
+							Should(gomega.BeNumerically("==", initialNodes+1))
 					}
 
+				})
+			})
+			ginkgo.Context("node deletion", func() {
+				ginkgo.It("should delete machine resource when node resource is deleted", func() {
+					ginkgo.By("Ensure node label is present on the machine")
+					var existingMachine *v1alpha1.Machine
+					var err error
+					gomega.Eventually(func() bool {
+						existingMachine, err = c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Get(ctx, helpers.NodeDeleteMcName, metav1.GetOptions{})
+						if err != nil {
+							return false
+						}
+						_, exists := existingMachine.GetLabels()[v1alpha1.NodeLabelKey]
+						return exists
+					}).Should(gomega.BeTrue())
+
+					ginkgo.By("Deleting node associated with test-machine")
+					err = c.TargetCluster.Clientset.CoreV1().Nodes().Delete(ctx, existingMachine.Labels[v1alpha1.NodeLabelKey], metav1.DeleteOptions{})
+					gomega.Expect(err).To(gomega.BeNil())
+
+					ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes")
+					gomega.Eventually(
+						c.TargetCluster.GetNumberOfNodes,
+						c.timeout,
+						c.pollingInterval).
+						Should(gomega.BeNumerically("==", initialNodes))
+
+					ginkgo.By("Waiting until test-machine machine object is deleted")
+					gomega.Eventually(
+						c.ControlCluster.IsMachineDeleted,
+						c.timeout,
+						c.pollingInterval).
+						WithArguments(ctx, helpers.NodeDeleteMcName, controlClusterNamespace).
+						Should(gomega.BeTrue())
 				})
 			})
 			ginkgo.Context("when machines are not available", func() {
@@ -753,57 +787,12 @@ func (c *IntegrationTestFramework) ControllerTests() {
 							Delete(ctx, "test-machine-dummy", metav1.DeleteOptions{})
 						ginkgo.By("Checking for errors")
 						gomega.Expect(err).To(gomega.HaveOccurred())
-						ginkgo.By("Checking number of nodes is eual to number of initial nodes")
+						ginkgo.By("Checking number of nodes is equal to number of initial nodes")
 						gomega.Expect(c.TargetCluster.GetNumberOfNodes()).To(gomega.BeEquivalentTo(initialNodes))
 					} else {
 						ginkgo.By("Skipping as there are machines available and this check can't be performed")
 					}
 				})
-			})
-		})
-		ginkgo.Context("node deletion", func() {
-			ginkgo.It("should delete machine resource when node resource is deleted", func() {
-				ginkgo.By("Create machine")
-				gomega.Expect(c.ControlCluster.CreateMachine(controlClusterNamespace, gnaSecretNameLabelValue)).To(gomega.BeNil())
-
-				ginkgo.By("Waiting until number of ready nodes is 1 more than initial nodes")
-				gomega.Eventually(
-					c.TargetCluster.GetNumberOfReadyNodes,
-					c.timeout,
-					c.pollingInterval).
-					Should(gomega.BeNumerically("==", initialNodes+1))
-
-				ginkgo.By("wait till node label is present on the machine")
-				gomega.Eventually(func() bool {
-					mc, err := c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Get(ctx, testMachineName, metav1.GetOptions{})
-					if err != nil {
-						return false
-					}
-					_, exists := mc.GetLabels()[v1alpha1.NodeLabelKey]
-					return exists
-				}).Should(gomega.BeTrue())
-
-				// Get existing machine. This is needed to fetch node name
-				existingMachine, err := c.ControlCluster.McmClient.MachineV1alpha1().Machines(controlClusterNamespace).Get(ctx, testMachineName, metav1.GetOptions{})
-				gomega.Expect(err).To(gomega.BeNil())
-
-				ginkgo.By("Deleting node associated with test-machine")
-				err = c.TargetCluster.Clientset.CoreV1().Nodes().Delete(ctx, existingMachine.Labels[v1alpha1.NodeLabelKey], metav1.DeleteOptions{})
-				gomega.Expect(err).To(gomega.BeNil())
-
-				ginkgo.By("Waiting until number of ready nodes is equal to number of initial nodes")
-				gomega.Eventually(
-					c.TargetCluster.GetNumberOfNodes,
-					c.timeout,
-					c.pollingInterval).
-					Should(gomega.BeNumerically("==", initialNodes))
-
-				ginkgo.By("Waiting until test-machine machine object is deleted")
-				gomega.Eventually(
-					c.ControlCluster.IsTestMachineDeleted,
-					c.timeout,
-					c.pollingInterval).
-					Should(gomega.BeTrue())
 			})
 		})
 	})

--- a/pkg/test/integration/common/helpers/machine_resources.go
+++ b/pkg/test/integration/common/helpers/machine_resources.go
@@ -26,14 +26,16 @@ const (
 	McdName = "test-machine-deployment"
 	// McName is the name of the test machine
 	McName = "test-machine"
+	// NodeDeleteMcName is the name of the test machine used for the node deletion test
+	NodeDeleteMcName = "node-delete-test-machine"
 )
 
 var (
 	testLabels = map[string]string{"test-label": "test-label"}
 )
 
-// CreateMachine creates a test-machine using machineclass "test-mc"
-func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
+// CreateMachines creates test-machines using machineclass "test-mc"
+func (c *Cluster) CreateMachines(namespace string, gnaSecretName string) error {
 	_, err := c.McmClient.
 		MachineV1alpha1().
 		Machines(namespace).
@@ -42,6 +44,36 @@ func (c *Cluster) CreateMachine(namespace string, gnaSecretName string) error {
 			&v1alpha1.Machine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      McName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.MachineSpec{
+					Class: v1alpha1.ClassSpec{
+						Kind: "MachineClass",
+						Name: "test-mc-v1",
+					},
+					NodeTemplateSpec: v1alpha1.NodeTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								gnaSecretNameLabelKey: gnaSecretName,
+							},
+						},
+					},
+				},
+			},
+			metav1.CreateOptions{},
+		)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.McmClient.
+		MachineV1alpha1().
+		Machines(namespace).
+		Create(
+			context.Background(),
+			&v1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      NodeDeleteMcName,
 					Namespace: namespace,
 				},
 				Spec: v1alpha1.MachineSpec{

--- a/pkg/test/integration/common/helpers/nodes.go
+++ b/pkg/test/integration/common/helpers/nodes.go
@@ -23,7 +23,7 @@ func (c *Cluster) getNodes() (*corev1.NodeList, error) {
 	return c.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 }
 
-// GetNumberOfReadyNodes tries to retrieve the list of node objects in the cluster.
+// GetNumberOfReadyNodes tries to retrieve the number of ready nodes in the cluster.
 func (c *Cluster) GetNumberOfReadyNodes() int16 {
 	nodes, _ := c.getNodes()
 	count := 0
@@ -59,7 +59,7 @@ func (c *Cluster) addNodeRecoverAnnotation(ctx context.Context, nodeName string)
 	return nil
 }
 
-// GetNumberOfNodes tries to retrieve the list of node objects in the cluster.
+// GetNumberOfNodes tries to retrieve the number of node objects in the cluster.
 func (c *Cluster) GetNumberOfNodes() int16 {
 	nodes, _ := c.getNodes()
 	return int16(len(nodes.Items)) //#nosec G115 (CWE-190) -- Test only


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
This PR add an integration test to verify if machine deletion happens when node deletion is triggered

**Which issue(s) this PR fixes**:
Fixes partially #1123 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Added an integration test to validate machine deletion when it's corresponding node is deleted
```
