### PR TITLE
fix: `isMisconfiguredPdb` to properly handle "outdated" `currentHealth`

### DIFF
--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -1208,5 +1208,14 @@ func isMisconfiguredPdb(pdb *policyv1.PodDisruptionBudget) bool {
 		return false
 	}
 
-	return pdb.Status.ExpectedPods > 0 && pdb.Status.CurrentHealthy >= pdb.Status.ExpectedPods && pdb.Status.DisruptionsAllowed == 0
+	hasPods := pdb.Status.ExpectedPods > 0
+	// `>=` instead of `==` (because of an in progress scale down `CurrentHealthy` can be larger than `ExpectedPods` current might be larger than expected
+	allPodsReady := pdb.Status.CurrentHealthy >= pdb.Status.ExpectedPods
+	// Because of how the PDB controller and eviction requests work together `CurrentHealthy` can be outdated, therefore additionally ensuring that the `DisruptedPods` map is empty
+	noDisruptedPods := len(pdb.Status.DisruptedPods) == 0
+
+	return hasPods && // Only check PDBs that currently have Pods
+		allPodsReady && // Only check PDBs where all Pods are ready
+		noDisruptedPods && // Only check PDBs that have **no** `DisruptedPods`
+		pdb.Status.DisruptionsAllowed == 0 // PDB is misconfigured
 }

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -1209,7 +1209,7 @@ func isMisconfiguredPdb(pdb *policyv1.PodDisruptionBudget) bool {
 	}
 
 	hasPods := pdb.Status.ExpectedPods > 0
-	// `>=` instead of `==` (because of an in progress scale down `CurrentHealthy` can be larger than `ExpectedPods` current might be larger than expected
+	// `>=` instead of `==` (because of an in progress scale down `CurrentHealthy` can be larger than `ExpectedPods`.
 	allPodsReady := pdb.Status.CurrentHealthy >= pdb.Status.ExpectedPods
 	// Because of how the PDB controller and eviction requests work together `CurrentHealthy` can be outdated, therefore additionally ensuring that the `DisruptedPods` map is empty
 	noDisruptedPods := len(pdb.Status.DisruptedPods) == 0

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -27,7 +27,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -730,9 +732,14 @@ func (o *Options) evictPodsWithPVInternal(
 
 		if attemptEvict && apierrors.IsTooManyRequests(err) {
 			// Pod eviction failed because of PDB violation, we will retry one we are done with this list.
-			klog.V(3).Infof("Pod %s/%s couldn't be evicted from node %s. This may also occur due to PDB violation. Will be retried. Error: %v", pod.Namespace, pod.Name, pod.Spec.NodeName, err)
 
+			var disruptedPods []string
 			pdb := getPdbForPod(o.pdbLister, pod)
+			if pdb != nil {
+				disruptedPods = slices.Collect(maps.Keys(pdb.Status.DisruptedPods))
+			}
+			klog.V(3).Infof("Pod %s/%s couldn't be evicted from node %s. This may also occur due to PDB violation (current disruptedPods: %v). Will be retried. Error: %v", pod.Namespace, pod.Name, pod.Spec.NodeName, disruptedPods, err)
+
 			if pdb != nil {
 				if isMisconfiguredPdb(pdb) {
 					pdbErr := fmt.Errorf("error while evicting pod %q: pod disruption budget %s/%s is misconfigured and requires zero voluntary evictions",
@@ -1064,10 +1071,16 @@ func (o *Options) evictPodWithoutPVInternal(ctx context.Context, attemptEvict bo
 			returnCh <- fmt.Errorf("error when evicting pod %q: %v scheduled on node %v", pod.Name, err, pod.Spec.NodeName)
 			return
 		}
-		// Pod couldn't be evicted because of PDB violation
-		klog.V(3).Infof("Pod %s/%s couldn't be evicted from node %s. This may also occur due to PDB violation. Will be retried. Error: %v", pod.Namespace, pod.Name, pod.Spec.NodeName, err)
 
+		// Pod couldn't be evicted because of PDB violation
+
+		var disruptedPods []string
 		pdb := getPdbForPod(o.pdbLister, pod)
+		if pdb != nil {
+			disruptedPods = slices.Collect(maps.Keys(pdb.Status.DisruptedPods))
+		}
+		klog.V(3).Infof("Pod %s/%s couldn't be evicted from node %s. This may also occur due to PDB violation (current disruptedPods: %v). Will be retried. Error: %v", pod.Namespace, pod.Name, pod.Spec.NodeName, disruptedPods, err)
+
 		if pdb != nil {
 			if isMisconfiguredPdb(pdb) {
 				pdbErr := fmt.Errorf("error while evicting pod %q: pod disruption budget %s/%s is misconfigured and requires zero voluntary evictions",

--- a/pkg/util/provider/drain/drain_test.go
+++ b/pkg/util/provider/drain/drain_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/onsi/gomega/gcustom"
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	coreinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	k8stesting "k8s.io/client-go/testing"
@@ -985,6 +987,91 @@ var _ = Describe("drain", func() {
 			Expect(podVolumeInfos).To(HaveKeyWithValue(
 				"foo/bar", matchPodPersistentVolumeNames(BeEmpty()),
 			))
+		})
+	})
+
+})
+
+var _ = Describe("isMisconfiguredPdb", func() {
+	Context("Good PDB", Ordered, func() {
+		var pdb *policyv1.PodDisruptionBudget
+		Context("normal", func() {
+			It("returns false", func() {
+				// Example PDB from etcd-druid (3 replicas)
+				pdb = &policyv1.PodDisruptionBudget{
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						// MaxUnavailable: new(intstr.FromInt(1)),
+						MinAvailable: new(intstr.FromInt(2)),
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						ExpectedPods:       3,
+						DesiredHealthy:     2, // `MinAvailable`
+						CurrentHealthy:     3,
+						DisruptionsAllowed: 1, // `CurrentHealthy` - `DesiredHealthy`
+					},
+					// `ExpectedPods` - `MaxUnavailable`
+				}
+
+				// All healthy and `DisruptionsAllowed` > 0 -> not misconfigured
+				Expect(isMisconfiguredPdb(pdb)).To(BeFalse())
+			})
+		})
+		Context("Pod getting evicted", func() {
+			It("returns false", func() {
+				// Evict request decrements `DisruptionsAllowed`
+				pdb.Status.DisruptionsAllowed = 0
+				// Evict request decrements `DisruptionsAllowed`
+				pdb.Status.DisruptedPods = map[string]metav1.Time{"pod-a": metav1.Now()}
+
+				// All healthy but has `DisruptedPods` -> `DisruptionsAllowed` is not checked -> not necessarily misconfigured
+				Expect(isMisconfiguredPdb(pdb)).To(BeFalse())
+			})
+		})
+		Context("Next PDB controller reconcile", func() {
+			It("returns false", func() {
+				// PDB controller recalculates everything
+				// `CurrentHealthy` excludes Pods that are being deleted (`DeletionTimestamp` not nil) or Pods that are in the `DisruptedPods` map
+				pdb.Status.CurrentHealthy = 2
+
+				// Not all healthy -> `DisruptionsAllowed` is not checked -> not necessarily misconfigured
+				Expect(isMisconfiguredPdb(pdb)).To(BeFalse())
+			})
+		})
+	})
+
+	Context("Bad PDB", Ordered, func() {
+		var pdb *policyv1.PodDisruptionBudget
+		Context("normal", func() {
+			It("returns true", func() {
+				// Example PDB: 3 replicas, prevent eviction
+				pdb = &policyv1.PodDisruptionBudget{
+					Spec: policyv1.PodDisruptionBudgetSpec{
+						MaxUnavailable: new(intstr.FromInt(0)),
+					},
+					Status: policyv1.PodDisruptionBudgetStatus{
+						ExpectedPods:       3,
+						DesiredHealthy:     3, // `ExpectedPods` - `MaxUnavailable`
+						CurrentHealthy:     3,
+						DisruptionsAllowed: 0, // `CurrentHealthy` - `DesiredHealthy`
+					},
+				}
+
+				// All healthy but `DisruptionsAllowed` still 0 -> misconfigured
+				Expect(isMisconfiguredPdb(pdb)).To(BeTrue())
+			})
+		})
+
+		// No "Pod getting evicted" context here: `DisruptionsAllowed == 0` always blocks evictions
+
+		Context("Pod was force deleted, next PDB controller reconcile", func() {
+			It("returns false", func() {
+				// One less pod
+				pdb.Status.CurrentHealthy = 2
+				pdb.Status.DisruptionsAllowed = 2 - 3
+
+				// Not all healthy -> `DisruptionsAllowed` is not checked -> not necessarily misconfigured
+				Expect(isMisconfiguredPdb(pdb)).To(BeFalse())
+			})
 		})
 	})
 })

--- a/pkg/util/provider/drain/drain_test.go
+++ b/pkg/util/provider/drain/drain_test.go
@@ -997,10 +997,8 @@ var _ = Describe("isMisconfiguredPdb", func() {
 		var pdb *policyv1.PodDisruptionBudget
 		Context("normal", func() {
 			It("returns false", func() {
-				// Example PDB from etcd-druid (3 replicas)
 				pdb = &policyv1.PodDisruptionBudget{
 					Spec: policyv1.PodDisruptionBudgetSpec{
-						// MaxUnavailable: new(intstr.FromInt(1)),
 						MinAvailable: new(intstr.FromInt(2)),
 					},
 					Status: policyv1.PodDisruptionBudgetStatus{
@@ -1009,7 +1007,6 @@ var _ = Describe("isMisconfiguredPdb", func() {
 						CurrentHealthy:     3,
 						DisruptionsAllowed: 1, // `CurrentHealthy` - `DesiredHealthy`
 					},
-					// `ExpectedPods` - `MaxUnavailable`
 				}
 
 				// All healthy and `DisruptionsAllowed` > 0 -> not misconfigured
@@ -1043,7 +1040,7 @@ var _ = Describe("isMisconfiguredPdb", func() {
 		var pdb *policyv1.PodDisruptionBudget
 		Context("normal", func() {
 			It("returns true", func() {
-				// Example PDB: 3 replicas, prevent eviction
+				// Example PDB: 3 replicas, prevent all evictions
 				pdb = &policyv1.PodDisruptionBudget{
 					Spec: policyv1.PodDisruptionBudgetSpec{
 						MaxUnavailable: new(intstr.FromInt(0)),


### PR DESCRIPTION
**What this PR does / why we need it**:
/kind bug

We see many `pod disruption budget ... is misconfigured and requires zero voluntary evictions` for PDBs that are (when all pods are healthy) actually not misconfigured.

This happens when the MCM gets the PDB between a pod getting evicted and the PDB controller reconciling the PDB.

Currently the MCM only takes into account the perspective of the PDB controller. But the eviction calls also cause [changes in the PDB object](https://github.com/kubernetes/kubernetes/blob/6fd1049740274a3adfa5d5be904715a780465bf2/pkg/registry/core/pod/storage/eviction.go#L471-L492):
- decrement `disruptionsAllowed`
- add pod to `disruptedPods`

More details about the changes in the PDB object:
<details><summary>Details</summary>
<p>

Everything is running:

```json
{
  "apiVersion": "policy/v1",
  "kind": "PodDisruptionBudget",
  "metadata": {
    "creationTimestamp": "2026-04-27T15:44:24Z",
    "generation": 1,
    "labels": {
      "app": "kubernetes",
      "role": "apiserver"
    },
    "name": "kube-apiserver",
    "namespace": "shoot--xxx--xxx",
    "resourceVersion": "11475386785",
    "uid": "9931059a-5e59-47ba-b1d1-33211c5f8c2d"
  },
  "spec": {
    "maxUnavailable": 1,
    "selector": {
      "matchLabels": {
        "app": "kubernetes",
        "role": "apiserver"
      }
    },
    "unhealthyPodEvictionPolicy": "AlwaysAllow"
  },
  "status": {
    "conditions": [
      {
        "lastTransitionTime": "2026-07-25T12:33:41Z",
        "message": "",
        "observedGeneration": 1,
        "reason": "SufficientPods",
        "status": "True",
        "type": "DisruptionAllowed"
      }
    ],
    "currentHealthy": 3,
    "desiredHealthy": 2,
    "disruptionsAllowed": 1,
    "expectedPods": 3,
    "observedGeneration": 1
  }
}
```

---

After evict call:

```json
{
  "apiVersion": "policy/v1",
  "kind": "PodDisruptionBudget",
  "metadata": {
    "creationTimestamp": "2026-04-27T15:44:24Z",
    "generation": 1,
    "labels": {
      "app": "kubernetes",
      "role": "apiserver"
    },
    "name": "kube-apiserver",
    "namespace": "shoot--xxx--xxx",
    "resourceVersion": "11550070628",
    "uid": "9931059a-5e59-47ba-b1d1-33211c5f8c2d"
  },
  "spec": {
    "maxUnavailable": 1,
    "selector": {
      "matchLabels": {
        "app": "kubernetes",
        "role": "apiserver"
      }
    },
    "unhealthyPodEvictionPolicy": "AlwaysAllow"
  },
  "status": {
    "conditions": [
      {
        "lastTransitionTime": "2026-07-28T12:34:25Z",
        "message": "",
        "observedGeneration": 1,
        "reason": "InsufficientPods",
        "status": "False",
        "type": "DisruptionAllowed"
      }
    ],
    "currentHealthy": 3,
    "desiredHealthy": 2,
    "disruptedPods": {
      "kube-apiserver-65cbbb5d5d-zmm29": "2026-07-28T12:34:25Z"
    },
    "disruptionsAllowed": 0,
    "expectedPods": 3,
    "observedGeneration": 1
  },
  "timestamp": "2026-07-28T12:34:25Z"
}
```

Evict call:
- decrements `disruptionsAllowed` by 1
- adds to be evicted pod to `disruptedPods`
- `currentHealthy` **remains** at `3`!

-> Before my PR: Misconfigured as `currentHealthy` >= `expectedPods`
-> After my PR: Not misconfigured as `len(disruptedPods)` == 0

---

First PDB controller reconcile after eviction:

```json
{
  "apiVersion": "policy/v1",
  "kind": "PodDisruptionBudget",
  "metadata": {
    "creationTimestamp": "2026-04-27T15:44:24Z",
    "generation": 1,
    "labels": {
      "app": "kubernetes",
      "role": "apiserver"
    },
    "name": "kube-apiserver",
    "namespace": "shoot--xxx--xxx",
    "resourceVersion": "11550071136",
    "uid": "9931059a-5e59-47ba-b1d1-33211c5f8c2d"
  },
  "spec": {
    "maxUnavailable": 1,
    "selector": {
      "matchLabels": {
        "app": "kubernetes",
        "role": "apiserver"
      }
    },
    "unhealthyPodEvictionPolicy": "AlwaysAllow"
  },
  "status": {
    "conditions": [
      {
        "lastTransitionTime": "2026-07-28T12:34:25Z",
        "message": "",
        "observedGeneration": 1,
        "reason": "InsufficientPods",
        "status": "False",
        "type": "DisruptionAllowed"
      }
    ],
    "currentHealthy": 2,
    "desiredHealthy": 2,
    "disruptionsAllowed": 0,
    "expectedPods": 3,
    "observedGeneration": 1
  },
  "timestamp": "2026-07-28T12:34:26Z"
}
```

PDB controller:
- Removes pods from `disruptedPods` that are getting deleted `DeletionTimestamp != nil`
- Recalculates `currentHealthy` -> now `2`
- `expectedPods` remains at `3`

-> Not misconfigured as not all pods are healthy

---

Replacement pod healthy and PDB controller reconcile done (same as the first one):

```json
{
  "apiVersion": "policy/v1",
  "kind": "PodDisruptionBudget",
  "metadata": {
    "creationTimestamp": "2026-04-27T15:44:24Z",
    "generation": 1,
    "labels": {
      "app": "kubernetes",
      "role": "apiserver"
    },
    "name": "kube-apiserver",
    "namespace": "shoot--xxx--xxx",
    "resourceVersion": "11550090088",
    "uid": "9931059a-5e59-47ba-b1d1-33211c5f8c2d"
  },
  "spec": {
    "maxUnavailable": 1,
    "selector": {
      "matchLabels": {
        "app": "kubernetes",
        "role": "apiserver"
      }
    },
    "unhealthyPodEvictionPolicy": "AlwaysAllow"
  },
  "status": {
    "conditions": [
      {
        "lastTransitionTime": "2026-07-28T12:35:24Z",
        "message": "",
        "observedGeneration": 1,
        "reason": "SufficientPods",
        "status": "True",
        "type": "DisruptionAllowed"
      }
    ],
    "currentHealthy": 3,
    "desiredHealthy": 2,
    "disruptionsAllowed": 1,
    "expectedPods": 3,
    "observedGeneration": 1
  },
  "timestamp": "2026-07-28T12:35:24Z"
}
```

</p>
</details> 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Prevent `error while evicting pod X: pod disruption budget X/X is misconfigured and requires zero voluntary evictions` when pods are being evicted
```