### PR TITLE
Make drain package reusable for controller-runtime based callers

### DIFF
--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -77,6 +77,25 @@ type Options struct {
 	volumeAttachmentHandler      *VolumeAttachmentHandler
 	Timeout                      time.Duration
 	podSynced                    cache.InformerSynced
+
+	// AdditionalPodFilters are extra predicates evaluated alongside the built-in filters when selecting pods to
+	// drain.
+	AdditionalPodFilters []AdditionalPodFilter
+	// podProvider, if set, is used to list the pods on the node instead of podLister. It allows callers that do not
+	// run client-go informers (e.g. controller-runtime based controllers) to supply their own pod source.
+	podProvider PodProvider
+	// SkipVolumeHandling, if true, skips the PersistentVolume detach/reattach handling during eviction.
+	SkipVolumeHandling bool
+}
+
+// AdditionalPodFilter takes a pod and returns whether the pod should be included for draining (true) or excluded
+// (false). It is a caller-supplied predicate evaluated in addition to the built-in filters.
+type AdditionalPodFilter func(corev1.Pod) bool
+
+// PodProvider lists the pods running on a given node. It abstracts the pod source (client-go lister vs. a
+// controller-runtime client) used during drain.
+type PodProvider interface {
+	PodsForNode(ctx context.Context, nodeName string) ([]corev1.Pod, error)
 }
 
 // Takes a pod and returns a bool indicating whether or not to operate on the
@@ -214,6 +233,13 @@ func NewDrainOptions(
 	}
 }
 
+// SetPodProvider sets the PodProvider used to list the pods on the node instead of the client-go pod lister. It lets
+// callers that do not run client-go informers (e.g. controller-runtime based controllers) supply their own pod
+// source when using NewDrainOptions/RunDrain.
+func (o *Options) SetPodProvider(podProvider PodProvider) {
+	o.podProvider = podProvider
+}
+
 // RunDrain runs the 'drain' command
 func (o *Options) RunDrain(ctx context.Context) error {
 	o.drainStartedOn = time.Now()
@@ -239,7 +265,7 @@ func (o *Options) RunDrain(ctx context.Context) error {
 		klog.Errorf("Drain Error: Cordoning of node failed with error: %v", err)
 		return err
 	}
-	if !cache.WaitForCacheSync(drainContext.Done(), o.podSynced) {
+	if o.podSynced != nil && !cache.WaitForCacheSync(drainContext.Done(), o.podSynced) {
 		err := fmt.Errorf("timed out waiting for pod cache to sync")
 		return err
 	}
@@ -249,14 +275,14 @@ func (o *Options) RunDrain(ctx context.Context) error {
 }
 
 func (o *Options) deleteOrEvictPodsSimple(ctx context.Context) error {
-	pods, err := o.getPodsForDeletion()
+	pods, err := o.getPodsForDeletion(ctx)
 	if err != nil {
 		return err
 	}
 
 	err = o.deleteOrEvictPods(ctx, pods)
 	if err != nil {
-		pendingPods, newErr := o.getPodsForDeletion()
+		pendingPods, newErr := o.getPodsForDeletion(ctx)
 		if newErr != nil {
 			return newErr
 		}
@@ -348,10 +374,21 @@ func (ps podStatuses) Message() string {
 
 // getPodsForDeletion returns all the pods we're going to delete.  If there are
 // any pods preventing us from deleting, we return that list in an error.
-func (o *Options) getPodsForDeletion() (pods []corev1.Pod, err error) {
-	podList, err := o.podLister.List(labels.Everything())
-	if err != nil {
-		return
+func (o *Options) getPodsForDeletion(ctx context.Context) (pods []corev1.Pod, err error) {
+	var podList []*corev1.Pod
+	if o.podProvider != nil {
+		nodePods, providerErr := o.podProvider.PodsForNode(ctx, o.nodeName)
+		if providerErr != nil {
+			return nil, providerErr
+		}
+		for _, pod := range nodePods {
+			podList = append(podList, &pod)
+		}
+	} else {
+		podList, err = o.podLister.List(labels.Everything())
+		if err != nil {
+			return
+		}
 	}
 	if len(podList) == 0 {
 		klog.Infof("no pods found in store")
@@ -374,6 +411,9 @@ func (o *Options) getPodsForDeletion() (pods []corev1.Pod, err error) {
 			if f != nil {
 				fs[f.string] = append(fs[f.string], pod.Name)
 			}
+		}
+		for _, filt := range o.AdditionalPodFilters {
+			podOk = podOk && filt(*pod)
 		}
 		if podOk {
 			pods = append(pods, *pod)
@@ -491,15 +531,15 @@ func (o *Options) evictPods(ctx context.Context, attemptEvict bool, pods []corev
 	returnCh := make(chan error, len(pods))
 	defer close(returnCh)
 
-	if o.ForceDeletePods {
+	if o.ForceDeletePods || o.SkipVolumeHandling {
 		podsToDrain := make([]*corev1.Pod, len(pods))
 		for i := range pods {
 			podsToDrain[i] = &pods[i]
 		}
 
-		klog.V(3).Infof("Forceful eviction of pods on the node: %q", o.nodeName)
+		klog.V(3).Infof("Eviction of pods on the node without volume handling: %q", o.nodeName)
 
-		// evict all pods in parallel without waiting for pods or volume detachment
+		// Evict all pods without waiting for volume detachment.
 		go o.evictPodsWithoutPv(ctx, attemptEvict, podsToDrain, policyGroupVersion, getPodFn, returnCh)
 	} else {
 		podsWithPv, podsWithoutPv := filterPodsWithPv(pods)
@@ -1193,6 +1233,9 @@ func (o *Options) GetDrainDuration() time.Duration {
 }
 
 func getPdbForPod(pdbLister policyv1listers.PodDisruptionBudgetLister, pod *corev1.Pod) *policyv1.PodDisruptionBudget {
+	if pdbLister == nil {
+		return nil
+	}
 	// GetPodPodDisruptionBudgets returns an error only if no PodDisruptionBudgets are found.
 	// We don't return that as an error to the caller.
 	pdbs, err := pdbLister.GetPodPodDisruptionBudgets(pod)

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -86,13 +86,13 @@ type Options struct {
 	// podProvider, if set, is used to list the pods on the node instead of podLister. It allows callers that do not
 	// run client-go informers (e.g. controller-runtime based controllers) to supply their own pod source.
 	podProvider PodProvider
-	// SkipVolumeHandling, if true, skips the PersistentVolume detach/reattach handling during eviction.
-	SkipVolumeHandling bool
+	// SkipVolumeDetach, if true, skips the PersistentVolume detach handling during eviction.
+	SkipVolumeDetach bool
 }
 
 // AdditionalPodFilter takes a pod and returns whether the pod should be included for draining (true) or excluded
 // (false). It is a caller-supplied predicate evaluated in addition to the built-in filters.
-type AdditionalPodFilter func(corev1.Pod) bool
+type AdditionalPodFilter func(corev1.Pod) (include bool)
 
 // PodProvider lists the pods running on a given node. It abstracts the pod source (client-go lister vs. a
 // controller-runtime client) used during drain.
@@ -205,7 +205,7 @@ func NewDrainOptions(
 	volumeAttachmentHandler *VolumeAttachmentHandler,
 	podSynced cache.InformerSynced,
 ) *Options {
-	return &Options{
+	drainOptions := &Options{
 		client:                       client,
 		kubernetesVersion:            kubernetesVersion,
 		ForceDeletePods:              forceDeletePods,
@@ -229,6 +229,12 @@ func NewDrainOptions(
 		volumeAttachmentHandler:      volumeAttachmentHandler,
 		podSynced:                    podSynced,
 	}
+
+	if drainOptions.podLister != nil {
+		drainOptions.SetPodProvider(&podProvider{Lister: podLister})
+	}
+
+	return drainOptions
 }
 
 // SetPodProvider sets the PodProvider used to list the pods on the node instead of the client-go pod lister. It lets
@@ -236,6 +242,26 @@ func NewDrainOptions(
 // source when using NewDrainOptions/RunDrain.
 func (o *Options) SetPodProvider(podProvider PodProvider) {
 	o.podProvider = podProvider
+}
+
+type podProvider struct {
+	Lister corelisters.PodLister
+}
+
+// PodsForNode returns all pods scheduled on the given node.
+func (p *podProvider) PodsForNode(_ context.Context, nodeName string) ([]corev1.Pod, error) {
+	podList, err := p.Lister.List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods: %w", err)
+	}
+
+	pods := make([]corev1.Pod, 0)
+	for _, pod := range podList {
+		if pod.Spec.NodeName == nodeName {
+			pods = append(pods, *pod)
+		}
+	}
+	return pods, nil
 }
 
 // RunDrain runs the 'drain' command
@@ -369,21 +395,15 @@ func (ps podStatuses) Message() string {
 // getPodsForDeletion returns all the pods we're going to delete.  If there are
 // any pods preventing us from deleting, we return that list in an error.
 func (o *Options) getPodsForDeletion(ctx context.Context) (pods []corev1.Pod, err error) {
-	var podList []*corev1.Pod
-	if o.podProvider != nil {
-		nodePods, providerErr := o.podProvider.PodsForNode(ctx, o.nodeName)
-		if providerErr != nil {
-			return nil, providerErr
-		}
-		for _, pod := range nodePods {
-			podList = append(podList, &pod)
-		}
-	} else {
-		podList, err = o.podLister.List(labels.Everything())
-		if err != nil {
-			return
-		}
+	if o.podProvider == nil {
+		return nil, fmt.Errorf("pod provider is not set, unable to get pods for deletion")
 	}
+
+	podList, providerErr := o.podProvider.PodsForNode(ctx, o.nodeName)
+	if providerErr != nil {
+		return nil, providerErr
+	}
+
 	if len(podList) == 0 {
 		klog.Infof("no pods found in store")
 		return
@@ -397,7 +417,7 @@ func (o *Options) getPodsForDeletion(ctx context.Context) (pods []corev1.Pod, er
 		}
 		podOk := true
 		for _, filt := range []podFilter{mirrorPodFilter, o.localStorageFilter, o.unreplicatedFilter, o.daemonsetFilter} {
-			filterOk, w, f := filt(*pod)
+			filterOk, w, f := filt(pod)
 			podOk = podOk && filterOk
 			if w != nil {
 				ws[w.string] = append(ws[w.string], pod.Name)
@@ -407,10 +427,10 @@ func (o *Options) getPodsForDeletion(ctx context.Context) (pods []corev1.Pod, er
 			}
 		}
 		for _, filt := range o.AdditionalPodFilters {
-			podOk = podOk && filt(*pod)
+			podOk = podOk && filt(pod)
 		}
 		if podOk {
-			pods = append(pods, *pod)
+			pods = append(pods, pod)
 		}
 	}
 
@@ -513,7 +533,7 @@ func (o *Options) evictPods(ctx context.Context, attemptEvict bool, pods []corev
 	returnCh := make(chan error, len(pods))
 	defer close(returnCh)
 
-	if o.ForceDeletePods || o.SkipVolumeHandling {
+	if o.ForceDeletePods || o.SkipVolumeDetach {
 		podsToDrain := make([]*corev1.Pod, len(pods))
 		for i := range pods {
 			podsToDrain[i] = &pods[i]

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -79,6 +79,25 @@ type Options struct {
 	volumeAttachmentHandler      *VolumeAttachmentHandler
 	Timeout                      time.Duration
 	podSynced                    cache.InformerSynced
+
+	// AdditionalPodFilters are extra predicates evaluated alongside the built-in filters when selecting pods to
+	// drain.
+	AdditionalPodFilters []AdditionalPodFilter
+	// podProvider, if set, is used to list the pods on the node instead of podLister. It allows callers that do not
+	// run client-go informers (e.g. controller-runtime based controllers) to supply their own pod source.
+	podProvider PodProvider
+	// SkipVolumeHandling, if true, skips the PersistentVolume detach/reattach handling during eviction.
+	SkipVolumeHandling bool
+}
+
+// AdditionalPodFilter takes a pod and returns whether the pod should be included for draining (true) or excluded
+// (false). It is a caller-supplied predicate evaluated in addition to the built-in filters.
+type AdditionalPodFilter func(corev1.Pod) bool
+
+// PodProvider lists the pods running on a given node. It abstracts the pod source (client-go lister vs. a
+// controller-runtime client) used during drain.
+type PodProvider interface {
+	PodsForNode(ctx context.Context, nodeName string) ([]corev1.Pod, error)
 }
 
 // Takes a pod and returns a bool indicating whether or not to operate on the
@@ -212,6 +231,13 @@ func NewDrainOptions(
 	}
 }
 
+// SetPodProvider sets the PodProvider used to list the pods on the node instead of the client-go pod lister. It lets
+// callers that do not run client-go informers (e.g. controller-runtime based controllers) supply their own pod
+// source when using NewDrainOptions/RunDrain.
+func (o *Options) SetPodProvider(podProvider PodProvider) {
+	o.podProvider = podProvider
+}
+
 // RunDrain runs the 'drain' command
 func (o *Options) RunDrain(ctx context.Context) error {
 	o.drainStartedOn = time.Now()
@@ -233,7 +259,7 @@ func (o *Options) RunDrain(ctx context.Context) error {
 		)
 	}()
 
-	if !cache.WaitForCacheSync(drainContext.Done(), o.podSynced) {
+	if o.podSynced != nil && !cache.WaitForCacheSync(drainContext.Done(), o.podSynced) {
 		err := fmt.Errorf("timed out waiting for pod cache to sync")
 		return err
 	}
@@ -243,14 +269,14 @@ func (o *Options) RunDrain(ctx context.Context) error {
 }
 
 func (o *Options) deleteOrEvictPodsSimple(ctx context.Context) error {
-	pods, err := o.getPodsForDeletion()
+	pods, err := o.getPodsForDeletion(ctx)
 	if err != nil {
 		return err
 	}
 
 	err = o.deleteOrEvictPods(ctx, pods)
 	if err != nil {
-		pendingPods, newErr := o.getPodsForDeletion()
+		pendingPods, newErr := o.getPodsForDeletion(ctx)
 		if newErr != nil {
 			return newErr
 		}
@@ -342,10 +368,21 @@ func (ps podStatuses) Message() string {
 
 // getPodsForDeletion returns all the pods we're going to delete.  If there are
 // any pods preventing us from deleting, we return that list in an error.
-func (o *Options) getPodsForDeletion() (pods []corev1.Pod, err error) {
-	podList, err := o.podLister.List(labels.Everything())
-	if err != nil {
-		return
+func (o *Options) getPodsForDeletion(ctx context.Context) (pods []corev1.Pod, err error) {
+	var podList []*corev1.Pod
+	if o.podProvider != nil {
+		nodePods, providerErr := o.podProvider.PodsForNode(ctx, o.nodeName)
+		if providerErr != nil {
+			return nil, providerErr
+		}
+		for _, pod := range nodePods {
+			podList = append(podList, &pod)
+		}
+	} else {
+		podList, err = o.podLister.List(labels.Everything())
+		if err != nil {
+			return
+		}
 	}
 	if len(podList) == 0 {
 		klog.Infof("no pods found in store")
@@ -368,6 +405,9 @@ func (o *Options) getPodsForDeletion() (pods []corev1.Pod, err error) {
 			if f != nil {
 				fs[f.string] = append(fs[f.string], pod.Name)
 			}
+		}
+		for _, filt := range o.AdditionalPodFilters {
+			podOk = podOk && filt(*pod)
 		}
 		if podOk {
 			pods = append(pods, *pod)
@@ -473,15 +513,15 @@ func (o *Options) evictPods(ctx context.Context, attemptEvict bool, pods []corev
 	returnCh := make(chan error, len(pods))
 	defer close(returnCh)
 
-	if o.ForceDeletePods {
+	if o.ForceDeletePods || o.SkipVolumeHandling {
 		podsToDrain := make([]*corev1.Pod, len(pods))
 		for i := range pods {
 			podsToDrain[i] = &pods[i]
 		}
 
-		klog.V(3).Infof("Forceful eviction of pods on the node: %q", o.nodeName)
+		klog.V(3).Infof("Eviction of pods on the node without volume handling: %q", o.nodeName)
 
-		// evict all pods in parallel without waiting for pods or volume detachment
+		// Evict all pods without waiting for volume detachment.
 		go o.evictPodsWithoutPv(ctx, attemptEvict, podsToDrain, policyGroupVersion, getPodFn, returnCh)
 	} else {
 		podsWithPv, podsWithoutPv := filterPodsWithPv(pods)
@@ -1163,6 +1203,9 @@ func (o *Options) GetDrainDuration() time.Duration {
 }
 
 func getPdbForPod(pdbLister policyv1listers.PodDisruptionBudgetLister, pod *corev1.Pod) *policyv1.PodDisruptionBudget {
+	if pdbLister == nil {
+		return nil
+	}
 	// GetPodPodDisruptionBudgets returns an error only if no PodDisruptionBudgets are found.
 	// We don't return that as an error to the caller.
 	pdbs, err := pdbLister.GetPodPodDisruptionBudgets(pod)

--- a/pkg/util/provider/drain/drain.go
+++ b/pkg/util/provider/drain/drain.go
@@ -412,9 +412,6 @@ func (o *Options) getPodsForDeletion(ctx context.Context) (pods []corev1.Pod, er
 	fs := podStatuses{}
 
 	for _, pod := range podList {
-		if pod.Spec.NodeName != o.nodeName {
-			continue
-		}
 		podOk := true
 		for _, filt := range []podFilter{mirrorPodFilter, o.localStorageFilter, o.unreplicatedFilter, o.daemonsetFilter} {
 			filterOk, w, f := filt(pod)

--- a/pkg/util/provider/drain/drain_test.go
+++ b/pkg/util/provider/drain/drain_test.go
@@ -60,6 +60,7 @@ var _ = Describe("drain", func() {
 		terminationGracePeriod    time.Duration
 		pvReattachTimeout         time.Duration
 		force                     bool
+		skipVolumeHandling        bool
 		evictError                error
 		deleteError               error
 	}
@@ -163,6 +164,7 @@ var _ = Describe("drain", func() {
 			Timeout:                      2 * time.Minute,
 			volumeAttachmentHandler:      volumeAttachmentHandler,
 			podSynced:                    podSynced,
+			SkipVolumeHandling:           setup.skipVolumeHandling,
 		}
 
 		// Get the pod directly from the ObjectTracker to avoid locking issues in the Fake object.
@@ -298,12 +300,10 @@ var _ = Describe("drain", func() {
 					}
 
 					// Delete the pod asyncronously to work around the lock problems in testing.Fake
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						runPodDrainHandlers(pod)
 						fmt.Fprintf(GinkgoWriter, "Drained pod %s/%s in %s\n", pod.Namespace, pod.Name, time.Since(start).String())
-					}()
+					})
 
 					nEvictions++
 					return
@@ -330,12 +330,10 @@ var _ = Describe("drain", func() {
 					}
 
 					// Delete the pod asyncronously to work around the lock problems in testing.Fake
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						runPodDrainHandlers(pod)
 						fmt.Fprintf(GinkgoWriter, "Drained pod %s/%s in %s\n", pod.Namespace, pod.Name, time.Since(start).String())
-					}()
+					})
 				default:
 					err = fmt.Errorf("Expected type k8stesting.GetAction but got %T", action)
 				}
@@ -858,7 +856,184 @@ var _ = Describe("drain", func() {
 				// Because waitForDetach polling Interval is equal to terminationGracePeriodShort
 				minDrainDuration: terminationGracePeriodMedium,
 			}),
+		Entry("Successful drain with SkipVolumeHandling and eviction of pods with exclusive volumes",
+			&setup{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      2,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+					nPVsPerPodWithExclusivePV:     1,
+				},
+				attemptEviction:        true,
+				terminationGracePeriod: terminationGracePeriodShort,
+				skipVolumeHandling:     true,
+			},
+			// SkipVolumeHandling routes pods through evictPodsWithoutPv, which does NOT wait for volume detach.
+			// The test only needs deletePod so that the fake eviction reactor finds and removes the pod.
+			[]podDrainHandler{deletePod},
+			&expectation{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      0,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+				},
+				// No PV detach/reattach wait — completes quickly.
+				timeout:          terminationGracePeriodMedium,
+				drainTimeout:     false,
+				drainError:       nil,
+				nEvictions:       2,
+				minDrainDuration: 0,
+			}),
+		Entry("Successful drain with SkipVolumeHandling without eviction of pods with exclusive volumes",
+			&setup{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      2,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+					nPVsPerPodWithExclusivePV:     1,
+				},
+				attemptEviction:        false,
+				terminationGracePeriod: terminationGracePeriodShort,
+				skipVolumeHandling:     true,
+			},
+			nil,
+			&expectation{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      0,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+				},
+				timeout:          terminationGracePeriodShort,
+				drainTimeout:     false,
+				drainError:       nil,
+				nEvictions:       0,
+				minDrainDuration: 0,
+			}),
 	)
+
+	Describe("getPodsForDeletion", func() {
+		var (
+			ctx      context.Context
+			nodeName string
+			drain    *Options
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			nodeName = oldNodeName
+			drain = &Options{
+				ErrOut:                       GinkgoWriter,
+				Out:                          GinkgoWriter,
+				nodeName:                     nodeName,
+				IgnorePodsWithoutControllers: true,
+				IgnoreDaemonsets:             true,
+				DeleteLocalData:              true,
+			}
+		})
+
+		Context("PodProvider", func() {
+			It("uses PodProvider instead of podLister when set", func() {
+				pod := getPodWithoutPV(testNamespace, "pod-0", nodeName, terminationGracePeriodDefault, nil)
+				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{*pod}}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(1))
+				Expect(pods[0].Name).To(Equal("pod-0"))
+			})
+
+			It("returns only pods on the target node from PodProvider", func() {
+				podOnNode := getPodWithoutPV(testNamespace, "on-node", nodeName, terminationGracePeriodDefault, nil)
+				podOtherNode := getPodWithoutPV(testNamespace, "other-node", "different-node", terminationGracePeriodDefault, nil)
+				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{*podOnNode, *podOtherNode}}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(1))
+				Expect(pods[0].Name).To(Equal("on-node"))
+			})
+
+			It("returns error when PodProvider fails", func() {
+				drain.podProvider = &fakePodProvider{err: fmt.Errorf("provider error")}
+
+				_, err := drain.getPodsForDeletion(ctx)
+				Expect(err).To(MatchError("provider error"))
+			})
+
+			It("returns empty list when PodProvider returns no pods", func() {
+				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{}}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(BeEmpty())
+			})
+		})
+
+		Context("AdditionalPodFilters", func() {
+			var podProvider *fakePodProvider
+
+			BeforeEach(func() {
+				pods := getPodsWithoutPV(4, testNamespace, "pod-", nodeName, terminationGracePeriodDefault, nil)
+				podProvider = &fakePodProvider{}
+				for _, p := range pods {
+					podProvider.pods = append(podProvider.pods, *p)
+				}
+				drain.podProvider = podProvider
+			})
+
+			It("includes all pods when no additional filters are set", func() {
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(4))
+			})
+
+			It("filters pods with a single additional filter", func() {
+				// Keep only pods whose name ends with "0" or "1"
+				drain.AdditionalPodFilters = []AdditionalPodFilter{
+					func(pod corev1.Pod) bool {
+						return pod.Name == "pod-0" || pod.Name == "pod-1"
+					},
+				}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(2))
+				Expect(pods).To(ConsistOf(
+					HaveField("Name", "pod-0"),
+					HaveField("Name", "pod-1"),
+				))
+			})
+
+			It("combines multiple additional filters with AND semantics", func() {
+				drain.AdditionalPodFilters = []AdditionalPodFilter{
+					func(pod corev1.Pod) bool { return pod.Name != "pod-0" },
+					func(pod corev1.Pod) bool { return pod.Name != "pod-1" },
+				}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(2))
+				Expect(pods).To(ConsistOf(
+					HaveField("Name", "pod-2"),
+					HaveField("Name", "pod-3"),
+				))
+			})
+
+			It("returns empty list when an additional filter excludes all pods", func() {
+				drain.AdditionalPodFilters = []AdditionalPodFilter{
+					func(_ corev1.Pod) bool { return false },
+				}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(BeEmpty())
+			})
+		})
+	})
 
 	Describe("getPodVolumeInfos", func() {
 		var (
@@ -1312,4 +1487,16 @@ func appendSuffixToVolumeHandles(pvs []*corev1.PersistentVolume, suffix string) 
 		pv.Spec.CSI.VolumeHandle += suffix
 	}
 	return pvs
+}
+
+type fakePodProvider struct {
+	pods []corev1.Pod
+	err  error
+}
+
+func (f *fakePodProvider) PodsForNode(_ context.Context, _ string) ([]corev1.Pod, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.pods, nil
 }

--- a/pkg/util/provider/drain/drain_test.go
+++ b/pkg/util/provider/drain/drain_test.go
@@ -167,8 +167,9 @@ var _ = Describe("drain", func() {
 			Timeout:                      2 * time.Minute,
 			volumeAttachmentHandler:      volumeAttachmentHandler,
 			podSynced:                    podSynced,
-			SkipVolumeHandling:           setup.skipVolumeHandling,
+			SkipVolumeDetach:             setup.skipVolumeHandling,
 		}
+		d.SetPodProvider(&podProvider{Lister: fakePodLister})
 
 		// Get the pod directly from the ObjectTracker to avoid locking issues in the Fake object.
 		getPod := func(gvr schema.GroupVersionResource, ns, name string) (*corev1.Pod, error) {

--- a/pkg/util/provider/drain/drain_test.go
+++ b/pkg/util/provider/drain/drain_test.go
@@ -63,6 +63,7 @@ var _ = Describe("drain", func() {
 		terminationGracePeriod    time.Duration
 		pvReattachTimeout         time.Duration
 		force                     bool
+		skipVolumeHandling        bool
 		evictError                error
 		deleteError               error
 	}
@@ -166,6 +167,7 @@ var _ = Describe("drain", func() {
 			Timeout:                      2 * time.Minute,
 			volumeAttachmentHandler:      volumeAttachmentHandler,
 			podSynced:                    podSynced,
+			SkipVolumeHandling:           setup.skipVolumeHandling,
 		}
 
 		// Get the pod directly from the ObjectTracker to avoid locking issues in the Fake object.
@@ -301,12 +303,10 @@ var _ = Describe("drain", func() {
 					}
 
 					// Delete the pod asyncronously to work around the lock problems in testing.Fake
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						runPodDrainHandlers(pod)
 						fmt.Fprintf(GinkgoWriter, "Drained pod %s/%s in %s\n", pod.Namespace, pod.Name, time.Since(start).String())
-					}()
+					})
 
 					nEvictions++
 					return
@@ -333,12 +333,10 @@ var _ = Describe("drain", func() {
 					}
 
 					// Delete the pod asyncronously to work around the lock problems in testing.Fake
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+					wg.Go(func() {
 						runPodDrainHandlers(pod)
 						fmt.Fprintf(GinkgoWriter, "Drained pod %s/%s in %s\n", pod.Namespace, pod.Name, time.Since(start).String())
-					}()
+					})
 				default:
 					err = fmt.Errorf("Expected type k8stesting.GetAction but got %T", action)
 				}
@@ -861,7 +859,184 @@ var _ = Describe("drain", func() {
 				// Because waitForDetach polling Interval is equal to terminationGracePeriodShort
 				minDrainDuration: terminationGracePeriodMedium,
 			}),
+		Entry("Successful drain with SkipVolumeHandling and eviction of pods with exclusive volumes",
+			&setup{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      2,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+					nPVsPerPodWithExclusivePV:     1,
+				},
+				attemptEviction:        true,
+				terminationGracePeriod: terminationGracePeriodShort,
+				skipVolumeHandling:     true,
+			},
+			// SkipVolumeHandling routes pods through evictPodsWithoutPv, which does NOT wait for volume detach.
+			// The test only needs deletePod so that the fake eviction reactor finds and removes the pod.
+			[]podDrainHandler{deletePod},
+			&expectation{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      0,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+				},
+				// No PV detach/reattach wait — completes quickly.
+				timeout:          terminationGracePeriodMedium,
+				drainTimeout:     false,
+				drainError:       nil,
+				nEvictions:       2,
+				minDrainDuration: 0,
+			}),
+		Entry("Successful drain with SkipVolumeHandling without eviction of pods with exclusive volumes",
+			&setup{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      2,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+					nPVsPerPodWithExclusivePV:     1,
+				},
+				attemptEviction:        false,
+				terminationGracePeriod: terminationGracePeriodShort,
+				skipVolumeHandling:     true,
+			},
+			nil,
+			&expectation{
+				stats: stats{
+					nPodsWithoutPV:                0,
+					nPodsWithOnlyExclusivePV:      0,
+					nPodsWithOnlySharedPV:         0,
+					nPodsWithExclusiveAndSharedPV: 0,
+				},
+				timeout:          terminationGracePeriodShort,
+				drainTimeout:     false,
+				drainError:       nil,
+				nEvictions:       0,
+				minDrainDuration: 0,
+			}),
 	)
+
+	Describe("getPodsForDeletion", func() {
+		var (
+			ctx      context.Context
+			nodeName string
+			drain    *Options
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			nodeName = oldNodeName
+			drain = &Options{
+				ErrOut:                       GinkgoWriter,
+				Out:                          GinkgoWriter,
+				nodeName:                     nodeName,
+				IgnorePodsWithoutControllers: true,
+				IgnoreDaemonsets:             true,
+				DeleteLocalData:              true,
+			}
+		})
+
+		Context("PodProvider", func() {
+			It("uses PodProvider instead of podLister when set", func() {
+				pod := getPodWithoutPV(testNamespace, "pod-0", nodeName, terminationGracePeriodDefault, nil)
+				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{*pod}}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(1))
+				Expect(pods[0].Name).To(Equal("pod-0"))
+			})
+
+			It("returns only pods on the target node from PodProvider", func() {
+				podOnNode := getPodWithoutPV(testNamespace, "on-node", nodeName, terminationGracePeriodDefault, nil)
+				podOtherNode := getPodWithoutPV(testNamespace, "other-node", "different-node", terminationGracePeriodDefault, nil)
+				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{*podOnNode, *podOtherNode}}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(1))
+				Expect(pods[0].Name).To(Equal("on-node"))
+			})
+
+			It("returns error when PodProvider fails", func() {
+				drain.podProvider = &fakePodProvider{err: fmt.Errorf("provider error")}
+
+				_, err := drain.getPodsForDeletion(ctx)
+				Expect(err).To(MatchError("provider error"))
+			})
+
+			It("returns empty list when PodProvider returns no pods", func() {
+				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{}}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(BeEmpty())
+			})
+		})
+
+		Context("AdditionalPodFilters", func() {
+			var podProvider *fakePodProvider
+
+			BeforeEach(func() {
+				pods := getPodsWithoutPV(4, testNamespace, "pod-", nodeName, terminationGracePeriodDefault, nil)
+				podProvider = &fakePodProvider{}
+				for _, p := range pods {
+					podProvider.pods = append(podProvider.pods, *p)
+				}
+				drain.podProvider = podProvider
+			})
+
+			It("includes all pods when no additional filters are set", func() {
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(4))
+			})
+
+			It("filters pods with a single additional filter", func() {
+				// Keep only pods whose name ends with "0" or "1"
+				drain.AdditionalPodFilters = []AdditionalPodFilter{
+					func(pod corev1.Pod) bool {
+						return pod.Name == "pod-0" || pod.Name == "pod-1"
+					},
+				}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(2))
+				Expect(pods).To(ConsistOf(
+					HaveField("Name", "pod-0"),
+					HaveField("Name", "pod-1"),
+				))
+			})
+
+			It("combines multiple additional filters with AND semantics", func() {
+				drain.AdditionalPodFilters = []AdditionalPodFilter{
+					func(pod corev1.Pod) bool { return pod.Name != "pod-0" },
+					func(pod corev1.Pod) bool { return pod.Name != "pod-1" },
+				}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(HaveLen(2))
+				Expect(pods).To(ConsistOf(
+					HaveField("Name", "pod-2"),
+					HaveField("Name", "pod-3"),
+				))
+			})
+
+			It("returns empty list when an additional filter excludes all pods", func() {
+				drain.AdditionalPodFilters = []AdditionalPodFilter{
+					func(_ corev1.Pod) bool { return false },
+				}
+
+				pods, err := drain.getPodsForDeletion(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pods).To(BeEmpty())
+			})
+		})
+	})
 
 	Describe("getPodVolumeInfos", func() {
 		var (
@@ -1444,4 +1619,16 @@ func createFakeController(
 	podSynced := pods.Informer().HasSynced
 
 	return fakeTargetCoreClient, pvLister, pvcLister, nodeLister, podLister, pvcSynced, pvSynced, nodeSynced, podSynced, targetCoreObjectTracker
+}
+
+type fakePodProvider struct {
+	pods []corev1.Pod
+	err  error
+}
+
+func (f *fakePodProvider) PodsForNode(_ context.Context, _ string) ([]corev1.Pod, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.pods, nil
 }

--- a/pkg/util/provider/drain/drain_test.go
+++ b/pkg/util/provider/drain/drain_test.go
@@ -940,25 +940,15 @@ var _ = Describe("drain", func() {
 		})
 
 		Context("PodProvider", func() {
-			It("uses PodProvider instead of podLister when set", func() {
+			It("should returns only pods on the target node from PodProvider", func() {
 				pod := getPodWithoutPV(testNamespace, "pod-0", nodeName, terminationGracePeriodDefault, nil)
-				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{*pod}}
+				podOtherNode := getPodWithoutPV(testNamespace, "other-node", "different-node", terminationGracePeriodDefault, nil)
+				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{*pod, *podOtherNode}}
 
 				pods, err := drain.getPodsForDeletion(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pods).To(HaveLen(1))
 				Expect(pods[0].Name).To(Equal("pod-0"))
-			})
-
-			It("returns only pods on the target node from PodProvider", func() {
-				podOnNode := getPodWithoutPV(testNamespace, "on-node", nodeName, terminationGracePeriodDefault, nil)
-				podOtherNode := getPodWithoutPV(testNamespace, "other-node", "different-node", terminationGracePeriodDefault, nil)
-				drain.podProvider = &fakePodProvider{pods: []corev1.Pod{*podOnNode, *podOtherNode}}
-
-				pods, err := drain.getPodsForDeletion(ctx)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(pods).To(HaveLen(1))
-				Expect(pods[0].Name).To(Equal("on-node"))
 			})
 
 			It("returns error when PodProvider fails", func() {
@@ -1627,9 +1617,16 @@ type fakePodProvider struct {
 	err  error
 }
 
-func (f *fakePodProvider) PodsForNode(_ context.Context, _ string) ([]corev1.Pod, error) {
+func (f *fakePodProvider) PodsForNode(_ context.Context, nodeName string) ([]corev1.Pod, error) {
 	if f.err != nil {
 		return nil, f.err
 	}
-	return f.pods, nil
+
+	pods := make([]corev1.Pod, 0)
+	for _, pod := range f.pods {
+		if pod.Spec.NodeName == nodeName {
+			pods = append(pods, pod)
+		}
+	}
+	return pods, nil
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
/kind enhancement

**What this PR does / why we need it**:
This PR extends the drain Options API to support callers (e.g. Gardener) that do not run client-go informers and need to plug in their own pod source or customize pod selection.

- Add `PodProvider` interface (PodsForNode) and SetPodProvider setter — allows callers to supply pods via a controller-runtime client instead of a pod lister/informer.
- Add `AdditionalPodFilters` field — caller-supplied predicates evaluated alongside the built-in drain filters.
- Add `SkipVolumeDetach` flag — skips PV detach during eviction, independent of ForceDeletePods.
- Make `podSynced` cache-sync conditional — skipped when no informer is running (podSynced == nil).
- Make `pdbLister` nil-safe so callers that don't set one don't panic.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager/issues/1133

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The drain package now exposes a `PodProvider` interface, `AdditionalPodFilters`, `SkipVolumeHandling`, and a nil-safe `pdbLister` guard, allowing external controllers (e.g. Gardener) to reuse the drain logic without running a client-go informer stack.
```
