### PR TITLE
Fix: Align auto-preservation eviction order with scale-down deletion priority

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -361,11 +361,13 @@ The following can be the reason:
 
 ### Why are some preserved failed machines deleted even though they haven't passed their preserve expiry time yet?
 
-This can happen if either of the following values have been reduced
-1. `spec.autoPreserveFailedMachineMax`
-2. `spec.Replicas`
+The most likely reason would be due to a rolling or inPlace upgrade that happened, since preservation is not honoured during upgrades.
 
-When `spec.autoPreserveFailedMachineMax` is reduced and there are more auto-preserved machines than the max count, MCM will sort the machines according to their `PreserveExpiryTime`s and remove machines that have the nearest expiry time. This is to done to keep machines who have the potential for longer preservation and hence additional time for debugging.
+This can also happen if either of the following values have been reduced
+1. `machineDeployment.spec.autoPreserveFailedMachineMax`
+2. `machineDeployment.spec.Replicas`
+
+When `spec.autoPreserveFailedMachineMax` is reduced and there are more auto-preserved machines than the max count, MCM will sort the machines according to their `PreserveExpiryTime`s and remove machines that have the nearest expiry time. This is done to keep machines who have the potential for longer preservation and hence additional time for debugging.
 In the case where `spec.Replicas` has been reduced, MCM will always prioritize keeping preserved machines. If this is not possible due to all non-preserved machines being deleted already, then MCM uses the same mechanism as above. Additionally, MCM will also prioritize keeping manually preserved failed machines over auto-preserved failed machines. This might lead to a case where MCM deleted all auto preserved failed machines if `spec.Replicas` is reduced accordingly.
 
 # Developer

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,7 +9,7 @@ persona: Operators
 
 The answers in this FAQ apply to the newest (HEAD) version of Machine Controller Manager. If
 you're using an older version of MCM please refer to corresponding version of
-this document. Few of the answers assume that the MCM being used is in conjuction with [cluster-autoscaler](https://github.com/gardener/autoscaler):
+this document. Few of the answers assume that the MCM being used is in conjunction with [cluster-autoscaler](https://github.com/gardener/autoscaler):
 
 # Table of Contents:
 <!--- TOC BEGIN -->
@@ -48,6 +48,7 @@ this document. Few of the answers assume that the MCM being used is in conjuctio
     - [My machine is stuck in deletion for 1 hr, why?](#my-machine-is-stuck-in-deletion-for-1-hr-why)
     - [My machine is not joining the cluster, why?](#my-machine-is-not-joining-the-cluster-why)
     - [My rolling update is stuck, why?](#my-rolling-update-is-stuck-why)
+    - [Why are some preserved failed machines deleted even though they haven't passed their preserve expiry time yet?](#why-are-some-preserved-failed-machines-deleted-even-though-they-havent-passed-their-preserve-expiry-time-yet)
 - [Developer](#developer)
     - [How should I test my code before submitting a PR?](#how-should-i-test-my-code-before-submitting-a-pr)
     - [I need to change the APIs, what are the recommended steps?](#i-need-to-change-the-apis-what-are-the-recommended-steps)
@@ -239,7 +240,7 @@ It is recommended to only set `MachineDrainTimeout`. It satisfies the related re
   - MCM auto calculates the `maxEvictRetries` based on the `drainTimeout`.
 - If `drainTimeout` isn't set and only `maxEvictRetries` is set:
   - Default `drainTimeout` and user provided `maxEvictRetries` for each pod is considered.
-- If both `maxEvictRetries` and `drainTimoeut` are set:
+- If both `maxEvictRetries` and `drainTimeout` are set:
   - Then both will be respected.
 - If none are set:
   - Defaults are respected.
@@ -267,7 +268,7 @@ Below is a simple phase transition diagram:
 
 Health check performed on a machine are:
 
-- Existense of corresponding node obj
+- Existence of corresponding node obj
 - Status of certain user-configurable node conditions.
   - These conditions can be specified using the flag `--node-conditions` for OOT MCM provider or can be specified per machine object.
   - The default user configurable node conditions can be found [here](https://github.com/gardener/machine-controller-manager/blob/91eec24516b8339767db5a40e82698f9fe0daacd/pkg/util/provider/app/options/options.go#L60)
@@ -358,6 +359,15 @@ The following can be the reason:
 - [Old machines are stuck in deletion](#my-machine-is-stuck-in-deletion-for-1-hr-why)
 - If you are using Gardener for setting up kubernetes cluster, then machine object won't turn to `Running` state until `node-critical-components` are ready. Refer [this](https://github.com/gardener/gardener/blob/master/docs/usage/advanced/node-readiness.md) for more details.
 
+### Why are some preserved failed machines deleted even though they haven't passed their preserve expiry time yet?
+
+This can happen if either of the following values have been reduced
+1. `spec.autoPreserveFailedMachineMax`
+2. `spec.Replicas`
+
+When `spec.autoPreserveFailedMachineMax` is reduced and there are more auto-preserved machines than the max count, MCM will sort the machines according to their `PreserveExpiryTime`s and remove machines that have the nearest expiry time. This is to done to keep machines who have the potential for longer preservation and hence additional time for debugging.
+In the case where `spec.Replicas` has been reduced, MCM will always prioritize keeping preserved machines. If this is not possible due to all non-preserved machines being deleted already, then MCM uses the same mechanism as above. Additionally, MCM will also prioritize keeping manually preserved failed machines over auto-preserved failed machines. This might lead to a case where MCM deleted all auto preserved failed machines if `spec.Replicas` is reduced accordingly.
+
 # Developer
 
 ### How should I test my code before submitting a PR?
@@ -389,8 +399,8 @@ Please ignore the API-violation errors for now.
 
 ### How can I update the dependencies of MCM?
 
-MCM uses `gomod` for depedency management.
-Developer should add/udpate depedency in the go.mod file. Please run following command to automatically tidy the dependencies.
+MCM uses `gomod` for dependency management.
+Developer should add/udpate dependency in the go.mod file. Please run following command to automatically tidy the dependencies.
 
 ```sh
 make tidy

--- a/pkg/controller/machineset.go
+++ b/pkg/controller/machineset.go
@@ -988,7 +988,7 @@ func (c *controller) stopAutoPreservationForMachines(ctx context.Context, machin
 	}
 	if numOfAutoPreservedMachines > numToStop {
 		sort.Slice(autoPreservedMachines, func(i, j int) bool {
-			return autoPreservedMachines[i].CreationTimestamp.Before(&autoPreservedMachines[j].CreationTimestamp)
+			return autoPreservedMachines[i].Status.CurrentStatus.PreserveExpiryTime.Before(autoPreservedMachines[j].Status.CurrentStatus.PreserveExpiryTime)
 		})
 	}
 	for index, m := range autoPreservedMachines {

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -1623,6 +1623,26 @@ var _ = Describe("machineset", func() {
 			// expect machinesToDelete to contain testPreservedFailedMachine
 			Expect(machinesToDelete).To(ContainElement(testPreservedFailedMachine))
 		})
+		It("should remove auto-preservation from machine with earlier PreserveExpiryTime first, not oldest by creation time", func() {
+			testMachine1.CreationTimestamp = metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
+			testMachine1.Status.CurrentStatus = machinev1.CurrentStatus{
+				Phase:              MachineFailed,
+				PreserveExpiryTime: &metav1.Time{Time: time.Now().Add(1 * time.Hour)},
+			}
+
+			testMachine2.CreationTimestamp = metav1.Time{Time: time.Now().Add(-2 * time.Hour)}
+			testMachine2.Status.CurrentStatus = machinev1.CurrentStatus{
+				Phase:              MachineFailed,
+				PreserveExpiryTime: &metav1.Time{Time: time.Now().Add(2 * time.Hour)},
+			}
+
+			diff = 1
+			filteredMachines := []*machinev1.Machine{testMachine1, testMachine2}
+			machinesToDelete := getMachinesToDelete(filteredMachines, diff)
+			Expect(len(machinesToDelete)).To(Equal(diff))
+			// expect machinesToDelete to contain testMachine1 (earlier PreserveExpiryTime)
+			Expect(machinesToDelete).To(ContainElement(testMachine1))
+		})
 	})
 
 	Describe("#getMachineKeys", func() {

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -1623,7 +1623,7 @@ var _ = Describe("machineset", func() {
 			// expect machinesToDelete to contain testPreservedFailedMachine
 			Expect(machinesToDelete).To(ContainElement(testPreservedFailedMachine))
 		})
-		It("should remove auto-preservation from machine with earlier PreserveExpiryTime first, not oldest by creation time", func() {
+		It("should prioritize preserved machine with earlier PreserveExpiryTime first, not oldest by creation time", func() {
 			testMachine1.CreationTimestamp = metav1.Time{Time: time.Now().Add(-1 * time.Hour)}
 			testMachine1.Status.CurrentStatus = machinev1.CurrentStatus{
 				Phase:              MachineFailed,

--- a/pkg/controller/machineset_test.go
+++ b/pkg/controller/machineset_test.go
@@ -2254,6 +2254,83 @@ var _ = Describe("machineset", func() {
 				},
 			}),
 		)
+
+		It("should remove auto-preservation from machine with earlier PreserveExpiryTime first, not oldest by creation time", func() {
+			stop := make(chan struct{})
+			defer close(stop)
+
+			// machine-a: created recently, but expires sooner — should lose annotation first
+			machineA := &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-a",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						machineutils.PreserveMachineAnnotationKey: machineutils.PreserveMachineAnnotationValueAutoPreserved,
+					},
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(-1 * time.Hour)},
+				},
+				Status: machinev1.MachineStatus{
+					CurrentStatus: machinev1.CurrentStatus{
+						Phase:              MachineFailed,
+						PreserveExpiryTime: &metav1.Time{Time: time.Now().Add(1 * time.Hour)},
+					},
+				},
+			}
+			// machine-b: created earlier, but expires later — should keep annotation
+			machineB := &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-b",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						machineutils.PreserveMachineAnnotationKey: machineutils.PreserveMachineAnnotationValueAutoPreserved,
+					},
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(-2 * time.Hour)},
+				},
+				Status: machinev1.MachineStatus{
+					CurrentStatus: machinev1.CurrentStatus{
+						Phase:              MachineFailed,
+						PreserveExpiryTime: &metav1.Time{Time: time.Now().Add(2 * time.Hour)},
+					},
+				},
+			}
+			testMachineSet := &machinev1.MachineSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "MachineSet-test",
+					Namespace: testNamespace,
+					UID:       "1234567",
+				},
+				Spec: machinev1.MachineSetSpec{
+					Replicas:                     2,
+					AutoPreserveFailedMachineMax: 1,
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"test-label": "test-label"},
+					},
+					Template: machinev1.MachineTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{"test-label": "test-label"},
+						},
+					},
+				},
+				Status: machinev1.MachineSetStatus{
+					AutoPreserveFailedMachineCount: 2,
+				},
+			}
+
+			c, trackers := createController(stop, testNamespace, []runtime.Object{testMachineSet, machineA, machineB}, nil, nil)
+			defer trackers.Stop()
+			waitForCacheSync(stop, c)
+
+			c.manageAutoPreservationOfFailedMachines(context.TODO(), []*machinev1.Machine{machineA, machineB}, testMachineSet)
+			waitForCacheSync(stop, c)
+
+			updatedA, _ := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machineA.Name, metav1.GetOptions{})
+			updatedB, _ := c.controlMachineClient.Machines(testNamespace).Get(context.TODO(), machineB.Name, metav1.GetOptions{})
+
+			// machine-a has earlier expiry so it should no longer be preserved
+			Expect(updatedA.Annotations[machineutils.PreserveMachineAnnotationKey]).ToNot(Equal(machineutils.PreserveMachineAnnotationValueAutoPreserved))
+			// machine-b has later expiry so it should retain auto-preservation
+			Expect(updatedB.Annotations[machineutils.PreserveMachineAnnotationKey]).To(Equal(machineutils.PreserveMachineAnnotationValueAutoPreserved))
+		})
 	})
 
 	Describe("#shouldFailedMachineBeTerminated", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
We noticed an inconsistency between how auto-preserved failed machines are chosen for termination due to `mcs`'s `spec.replica` reduction and how auto-preserve failed machines are chosen for termination due to `mcs`'s `spec.autoPreserveFailedMachineMax` reduction.

Currently when `spec.autoPreserveFailedMachineMax` is reduced, auto-preserved failed machines that have a nearer `PreserveExpiryTime` are chosen for deletion, whereas when `spec.replica` is reduced auto-preserved failed machines that have an earlier `CreationTimestamp` are chosen for deletion.

This PR aligns both these orderings to ensure that now auto-preserved failed machines are only ordered based on their `PreserveExpiryTime`s

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Ensure auto-preserve failed machines are ordered by their `PreserveExpiryTime` in case of deletion due to reduction is mcs.spec.Replica or mcs.spec.autoPreserveFailedMachineMax
```
