### PR TITLE
Fix flaky `MachineDeployment` tests on GHA

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -717,10 +717,7 @@ func GetFakeMachineFromTemplate(template *v1alpha1.MachineTemplateSpec, parentOb
 	desiredAnnotations := getMachinesAnnotationSet(template, parentMetaObj)
 
 	prefix := getMachinesPrefix(parentMetaObj.GetName())
-	// Use the full UUID as the suffix to avoid name collisions when many machines
-	// are created in a single reconcile (e.g. burstReplicas). Unlike the real
-	// apiserver, the fake client does not retry on GenerateName conflicts, so a
-	// truncated suffix can produce duplicate names and flake the test.
+	// Use the full UUID as the suffix to avoid name collisions when many machines are created in a single reconcile.
 	prefix = prefix + "-" + uuid.New().String()
 	machine := &v1alpha1.Machine{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -717,7 +717,11 @@ func GetFakeMachineFromTemplate(template *v1alpha1.MachineTemplateSpec, parentOb
 	desiredAnnotations := getMachinesAnnotationSet(template, parentMetaObj)
 
 	prefix := getMachinesPrefix(parentMetaObj.GetName())
-	prefix = prefix + "-" + uuid.New().String()[:5]
+	// Use the full UUID as the suffix to avoid name collisions when many machines
+	// are created in a single reconcile (e.g. burstReplicas). Unlike the real
+	// apiserver, the fake client does not retry on GenerateName conflicts, so a
+	// truncated suffix can produce duplicate names and flake the test.
+	prefix = prefix + "-" + uuid.New().String()
 	machine := &v1alpha1.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:      desiredLabels,

--- a/pkg/controller/deployment_test.go
+++ b/pkg/controller/deployment_test.go
@@ -1992,12 +1992,7 @@ var _ = Describe("machineDeployment", func() {
 				func(testMachineDeployment *machinev1.MachineDeployment, testMachineSet *machinev1.MachineSet) {
 					testMachineDeployment.Annotations[machineutils.LastDeploymentReplicaChangeByScalerTime] = ts
 					testMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM] = fmt.Sprintf("%s~%s", testMachine.Name, time.Now().Format(time.RFC3339))
-
-					const hash = "testhash"
-					testMachineSet.Labels = labelsutil.CloneAndAddLabel(testMachineSet.Labels, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
-					testMachineSet.Spec.Selector = labelsutil.CloneSelectorAndAddLabel(testMachineSet.Spec.Selector, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
-					testMachineSet.Spec.Template.Labels = labelsutil.CloneAndAddLabel(testMachineSet.Spec.Template.Labels, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
-					testMachine.Labels = labelsutil.CloneAndAddLabel(testMachine.Labels, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
+					testMachineSet.Spec.Selector = labelsutil.CloneSelectorAndAddLabel(testMachineSet.Spec.Selector, machinev1.DefaultMachineDeploymentUniqueLabelKey, "testhash")
 				},
 				func(_ *machinev1.MachineDeployment, mcs []machinev1.MachineSet, _ []machinev1.Machine, _ *corev1.Node) error {
 					var ms *machinev1.MachineSet

--- a/pkg/controller/deployment_test.go
+++ b/pkg/controller/deployment_test.go
@@ -1968,8 +1968,9 @@ var _ = Describe("machineDeployment", func() {
 				},
 			),
 			Entry("should set MachinePriority=1 for the machines named in TriggerDeletionByMCM annotation in the MachineDeployment",
-				func(testMachineDeployment *machinev1.MachineDeployment, _ *machinev1.MachineSet) {
+				func(testMachineDeployment *machinev1.MachineDeployment, testMachineSet *machinev1.MachineSet) {
 					testMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM] = fmt.Sprintf("%s~%s", testMachine.Name, time.Now().Format(time.RFC3339))
+					testMachineSet.Spec.Selector = labelsutil.CloneSelectorAndAddLabel(testMachineSet.Spec.Selector, machinev1.DefaultMachineDeploymentUniqueLabelKey, "testhash")
 				},
 				func(_ *machinev1.MachineDeployment, _ []machinev1.MachineSet, machines []machinev1.Machine, _ *corev1.Node) error {
 					var targetMachine *machinev1.Machine

--- a/pkg/controller/deployment_test.go
+++ b/pkg/controller/deployment_test.go
@@ -1751,17 +1751,15 @@ var _ = Describe("machineDeployment", func() {
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
 				Key := testNamespace + "/" + testMachineDeployment.Name
-				Expect(c.reconcileClusterMachineDeployment(Key)).NotTo(HaveOccurred())
 
-				waitForCacheSync(stop, c)
-				actualMachineDeployment, _ := c.controlMachineClient.MachineDeployments(testNamespace).Get(context.Background(), testMachineDeployment.Name, metav1.GetOptions{})
-				waitForCacheSync(stop, c)
-				actualMachineSets, _ := c.controlMachineClient.MachineSets(testNamespace).List(context.Background(), metav1.ListOptions{})
-				waitForCacheSync(stop, c)
-				actualMachines, _ := c.controlMachineClient.Machines(testNamespace).List(context.Background(), metav1.ListOptions{})
-				testNode, _ := c.targetCoreClient.CoreV1().Nodes().Get(context.Background(), testNode.Name, metav1.GetOptions{})
-
-				Expect(postCheck(actualMachineDeployment, actualMachineSets.Items, actualMachines.Items, testNode)).To(BeNil())
+				Eventually(func() error {
+					_ = c.reconcileClusterMachineDeployment(Key)
+					actualMachineDeployment, _ := c.controlMachineClient.MachineDeployments(testNamespace).Get(context.Background(), testMachineDeployment.Name, metav1.GetOptions{})
+					actualMachineSets, _ := c.controlMachineClient.MachineSets(testNamespace).List(context.Background(), metav1.ListOptions{})
+					actualMachines, _ := c.controlMachineClient.Machines(testNamespace).List(context.Background(), metav1.ListOptions{})
+					actualNode, _ := c.targetCoreClient.CoreV1().Nodes().Get(context.Background(), testNode.Name, metav1.GetOptions{})
+					return postCheck(actualMachineDeployment, actualMachineSets.Items, actualMachines.Items, actualNode)
+				}).WithTimeout(500 * time.Millisecond).WithPolling(100 * time.Millisecond).Should(Succeed())
 			},
 			Entry("reconcile the machineDeployment and return nil",
 				func(_ *machinev1.MachineDeployment, _ *machinev1.MachineSet) {},
@@ -1966,13 +1964,24 @@ var _ = Describe("machineDeployment", func() {
 					return nil
 				},
 			),
-			// flaky test because of reusing same testMachine for mutilple tests.
 			Entry("should set MachinePriority=1 for the machines named in TriggerDeletionByMCM annotation in the MachineDeployment",
 				func(testMachineDeployment *machinev1.MachineDeployment, _ *machinev1.MachineSet) {
 					testMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM] = fmt.Sprintf("%s~%s", testMachine.Name, time.Now().Format(time.RFC3339))
 				},
 				func(_ *machinev1.MachineDeployment, _ []machinev1.MachineSet, machines []machinev1.Machine, _ *corev1.Node) error {
-					Expect(machines[0].Annotations[machineutils.MachinePriority]).To(Equal("1"))
+					var targetMachine *machinev1.Machine
+					for i := range machines {
+						if machines[i].Name == "Machine-test" {
+							targetMachine = &machines[i]
+							break
+						}
+					}
+					if targetMachine == nil {
+						return errors.New("machine \"Machine-test\" not found")
+					}
+					if targetMachine.Annotations[machineutils.MachinePriority] != "1" {
+						return errors.New("expected MachinePriority=1 on machine \"Machine-test\"")
+					}
 					return nil
 				},
 			),
@@ -1982,9 +1991,22 @@ var _ = Describe("machineDeployment", func() {
 					testMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM] = fmt.Sprintf("%s~%s", testMachine.Name, time.Now().Format(time.RFC3339))
 				},
 				func(_ *machinev1.MachineDeployment, mcs []machinev1.MachineSet, _ []machinev1.Machine, _ *corev1.Node) error {
-					Expect(mcs[0].Annotations[machineutils.LastDeploymentReplicaChangeByScalerTime]).To(Equal(ts))
-					_, exists := mcs[0].Annotations[machineutils.TriggerDeletionByMCM]
-					Expect(exists).To(BeFalse())
+					var ms *machinev1.MachineSet
+					for i := range mcs {
+						if mcs[i].Name == "MachineSet-test" {
+							ms = &mcs[i]
+							break
+						}
+					}
+					if ms == nil {
+						return errors.New("machineSet \"MachineSet-test\" not found")
+					}
+					if ms.Annotations[machineutils.LastDeploymentReplicaChangeByScalerTime] != ts {
+						return errors.New("expected LastDeploymentReplicaChangeByScalerTime annotation to be preserved on the machineSet")
+					}
+					if _, exists := ms.Annotations[machineutils.TriggerDeletionByMCM]; exists {
+						return errors.New("TriggerDeletionByMCM annotation should not be set on the machineSet")
+					}
 					return nil
 				},
 			),

--- a/pkg/controller/deployment_test.go
+++ b/pkg/controller/deployment_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gardener/machine-controller-manager/pkg/util/annotations"
+	labelsutil "github.com/gardener/machine-controller-manager/pkg/util/labels"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"k8s.io/utils/ptr"
 
@@ -1751,15 +1752,17 @@ var _ = Describe("machineDeployment", func() {
 				defer trackers.Stop()
 				waitForCacheSync(stop, c)
 				Key := testNamespace + "/" + testMachineDeployment.Name
+				Expect(c.reconcileClusterMachineDeployment(Key)).NotTo(HaveOccurred())
 
-				Eventually(func() error {
-					_ = c.reconcileClusterMachineDeployment(Key)
-					actualMachineDeployment, _ := c.controlMachineClient.MachineDeployments(testNamespace).Get(context.Background(), testMachineDeployment.Name, metav1.GetOptions{})
-					actualMachineSets, _ := c.controlMachineClient.MachineSets(testNamespace).List(context.Background(), metav1.ListOptions{})
-					actualMachines, _ := c.controlMachineClient.Machines(testNamespace).List(context.Background(), metav1.ListOptions{})
-					actualNode, _ := c.targetCoreClient.CoreV1().Nodes().Get(context.Background(), testNode.Name, metav1.GetOptions{})
-					return postCheck(actualMachineDeployment, actualMachineSets.Items, actualMachines.Items, actualNode)
-				}).WithTimeout(500 * time.Millisecond).WithPolling(100 * time.Millisecond).Should(Succeed())
+				waitForCacheSync(stop, c)
+				actualMachineDeployment, _ := c.controlMachineClient.MachineDeployments(testNamespace).Get(context.Background(), testMachineDeployment.Name, metav1.GetOptions{})
+				waitForCacheSync(stop, c)
+				actualMachineSets, _ := c.controlMachineClient.MachineSets(testNamespace).List(context.Background(), metav1.ListOptions{})
+				waitForCacheSync(stop, c)
+				actualMachines, _ := c.controlMachineClient.Machines(testNamespace).List(context.Background(), metav1.ListOptions{})
+				testNode, _ := c.targetCoreClient.CoreV1().Nodes().Get(context.Background(), testNode.Name, metav1.GetOptions{})
+
+				Expect(postCheck(actualMachineDeployment, actualMachineSets.Items, actualMachines.Items, testNode)).To(BeNil())
 			},
 			Entry("reconcile the machineDeployment and return nil",
 				func(_ *machinev1.MachineDeployment, _ *machinev1.MachineSet) {},
@@ -1986,9 +1989,15 @@ var _ = Describe("machineDeployment", func() {
 				},
 			),
 			Entry("set LDRCBST annotation on the machineSet and TriggerDeletionByMCM annotation is not set on the machineSet",
-				func(testMachineDeployment *machinev1.MachineDeployment, _ *machinev1.MachineSet) {
+				func(testMachineDeployment *machinev1.MachineDeployment, testMachineSet *machinev1.MachineSet) {
 					testMachineDeployment.Annotations[machineutils.LastDeploymentReplicaChangeByScalerTime] = ts
 					testMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM] = fmt.Sprintf("%s~%s", testMachine.Name, time.Now().Format(time.RFC3339))
+
+					const hash = "testhash"
+					testMachineSet.Labels = labelsutil.CloneAndAddLabel(testMachineSet.Labels, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
+					testMachineSet.Spec.Selector = labelsutil.CloneSelectorAndAddLabel(testMachineSet.Spec.Selector, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
+					testMachineSet.Spec.Template.Labels = labelsutil.CloneAndAddLabel(testMachineSet.Spec.Template.Labels, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
+					testMachine.Labels = labelsutil.CloneAndAddLabel(testMachine.Labels, machinev1.DefaultMachineDeploymentUniqueLabelKey, hash)
 				},
 				func(_ *machinev1.MachineDeployment, mcs []machinev1.MachineSet, _ []machinev1.Machine, _ *corev1.Node) error {
 					var ms *machinev1.MachineSet


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Fixes flaky unit tests in `pkg/controller/deployment_test.go`

There were three intermittently failing tests. Using tool [stress - gardener docs](https://github.com/gardener/gardener/blob/master/docs/development/testing.md#debugging-unit-tests)
<details>
<summary>Full test logs</summary>

```
(⎈|kwok-test-cluster:N/A)➜  machine-controller-manager git:(master) ginkgo build ./pkg/controller/ && stress -p 32 ./pkg/controller/controller.test
Compiled pkg/controller/controller.test
5s: 0 runs so far, 0 failures, 32 active
10s: 0 runs so far, 0 failures, 32 active
15s: 0 runs so far, 0 failures, 32 active
20s: 0 runs so far, 0 failures, 32 active
25s: 0 runs so far, 0 failures, 32 active
30s: 0 runs so far, 0 failures, 32 active

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-1624166675
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3576811015
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3073098980
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-1397379880
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-578637458
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3988945475
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3436669743
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-4110336539
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-297855395
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3709500559
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-74607856
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3702734340
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-4029236196
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-1097988279
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-597646032
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …
35s: 32 runs so far, 15 failures (46.88%), 32 active
40s: 32 runs so far, 15 failures (46.88%), 32 active
45s: 32 runs so far, 15 failures (46.88%), 32 active
50s: 32 runs so far, 15 failures (46.88%), 32 active
55s: 32 runs so far, 15 failures (46.88%), 32 active
1m0s: 32 runs so far, 15 failures (46.88%), 32 active
1m5s: 32 runs so far, 15 failures (46.88%), 32 active

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-685857104
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••E0901 00:22:03.664702   77736 controller_utils.go:662] machines.machine.sapcloud.io "MachineSet-test-d1300" already exists

------------------------------
• [FAILED] [0.115 seconds]
machineset #manageReplicas [It] should create new machines only equal to burstReplicas and should not return errors.
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/machineset_test.go:740

  [FAILED] Unexpected error:
      <*errors.StatusError | 0x31081528b860>:
      machines.machine.sapcloud.io "MachineSet-test-d1300" already exists
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingIte
…

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3767614264
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3499507508
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-2401787936
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-1503322385
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-102514203
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3863270275
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3084385920
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-274661307
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-697609929
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-1612137693
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-1949288950
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3218075268
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …

/var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3113097912
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
                                                                                                      …
1m10s: 64 runs so far, 29 failures (45.31%), 32 active
1m15s: 64 runs so far, 29 failures (45.31%), 32 active
1m20s: 64 runs so far, 29 failures (45.31%), 32 active
1m25s: 64 runs so far, 29 failures (45.31%), 32 active
1m30s: 64 runs so far, 29 failures (45.31%), 32 active
^C
```
</details>


<details>
<summary>should create new machines only equal to burstReplicas and should not return errors.</summary>

```
(⎈|kwok-test-cluster:N/A)➜  machine-controller-manager git:(master) cat /var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-685857104

Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202318

Will run 204 of 204 specs
••••••••••••••••••••••••••••••••••••••••••••••••••E0901 00:22:03.664702   77736 controller_utils.go:662] machines.machine.sapcloud.io "MachineSet-test-d1300" already exists

------------------------------
• [FAILED] [0.115 seconds]
machineset #manageReplicas [It] should create new machines only equal to burstReplicas and should not return errors.
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/machineset_test.go:740

  [FAILED] Unexpected error:
      <*errors.StatusError | 0x31081528b860>:
      machines.machine.sapcloud.io "MachineSet-test-d1300" already exists
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "machines.machine.sapcloud.io \"MachineSet-test-d1300\" already exists",
              Reason: "AlreadyExists",
              Details: {
                  Name: "MachineSet-test-d1300",
                  Group: "machine.sapcloud.io",
                  Kind: "machines",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
  occurred
  In [It] at: /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/machineset_test.go:752 @ 09/01/26 00:22:03.667
------------------------------
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••E0901 00:22:21.266492   77736 deployment.go:490] Validation of MachineDeployment failed spec.strategy.type: Invalid value: "Dummy": strategy type must be one of [InPlaceUpdate Recreate RollingUpdate]
•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••

Summarizing 1 Failure:
  [FAIL] machineset #manageReplicas [It] should create new machines only equal to burstReplicas and should not return errors.
  /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/machineset_test.go:752

Ran 204 of 204 Specs in 32.811 seconds
FAIL! -- 203 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestMachineControllerManagerSuite (32.81s)
FAIL


ERROR: exit status 1
```
</details>


<details>
<summary>should set MachinePriority=1 for the machines named in TriggerDeletionByMCM annotation in the MachineDeployment</summary>

```
(⎈|kwok-test-cluster:N/A)➜  machine-controller-manager git:(master) cat /var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-3576811015
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••E0901 00:21:48.054893   77669 deployment.go:490] Validation of MachineDeployment failed spec.strategy.type: Invalid value: "Dummy": strategy type must be one of [InPlaceUpdate Recreate RollingUpdate]
••••••••
------------------------------
• [FAILED] [0.412 seconds]
machineDeployment #reconcileClusterMachineDeployment This should [It] should set MachinePriority=1 for the machines named in TriggerDeletionByMCM annotation in the MachineDeployment
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1970

  [FAILED] Expected
      <string>:
  to equal
      <string>: 1
  In [It] at: /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1975 @ 09/01/26 00:21:51.647
------------------------------
••••••••••••••••••••••••••••••••••••••••••••••••••••••

Summarizing 1 Failure:
  [FAIL] machineDeployment #reconcileClusterMachineDeployment This should [It] should set MachinePriority=1 for the machines named in TriggerDeletionByMCM annotation in the MachineDeployment
  /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1975

Ran 204 of 204 Specs in 33.251 seconds
FAIL! -- 203 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestMachineControllerManagerSuite (33.26s)
FAIL


ERROR: exit status 1
```
</details>


<details>
<summary>set LDRCBST annotation on the machineSet and TriggerDeletionByMCM annotation is not set on the machineSet</summary>

```
(⎈|kwok-test-cluster:N/A)➜  machine-controller-manager git:(master) cat /var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260901T002124-1624166675
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788202285

Will run 204 of 204 specs
•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••E0901 00:21:48.046823   77674 deployment.go:490] Validation of MachineDeployment failed spec.strategy.type: Invalid value: "Dummy": strategy type must be one of [InPlaceUpdate Recreate RollingUpdate]
•••••••••
------------------------------
• [FAILED] [0.408 seconds]
machineDeployment #reconcileClusterMachineDeployment This should [It] set LDRCBST annotation on the machineSet and TriggerDeletionByMCM annotation is not set on the machineSet
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1979

  [FAILED] Expected
      <string>:
  to equal
      <string>: 2026-09-01T00:21:51+05:30
  In [It] at: /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1985 @ 09/01/26 00:21:52.042
------------------------------
•••••••••••••••••••••••••••••••••••••••••••••••••••••

Summarizing 1 Failure:
  [FAIL] machineDeployment #reconcileClusterMachineDeployment This should [It] set LDRCBST annotation on the machineSet and TriggerDeletionByMCM annotation is not set on the machineSet
  /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1985

Ran 204 of 204 Specs in 33.238 seconds
FAIL! -- 203 Passed | 1 Failed | 0 Pending | 0 Skipped
--- FAIL: TestMachineControllerManagerSuite (33.24s)
FAIL


ERROR: exit status 1
```
</details>


Adding some debug logs to understand the issue better, and re-running the stress test.
<details>
<summary>Full logs from run</summary>

```
(⎈|kwok-test-cluster:N/A)➜  ~ cat /var/folders/fl/g7dz200x30gdjq1ssmn_gshw0000gn/T/go-stress-20260831T203306-2395963410
Running Suite: Machine Controller Manager Suite - /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager
======================================================================================================================
Random Seed: 1788188590

Will run 1 of 204 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
E0831 20:33:10.561839   72651 deployment_sync.go:167] addHashKeyToISAndMachines proceeding (no hash label) is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561882   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561887   72651 machineset_util.go:65] UpdateISWithRetries client write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561923   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561926   72651 machineset_util.go:65] UpdateISWithRetries client write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561999   72651 deployment_sync.go:263] getNewMachineSet write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:10.562017   72651 deployment.go:579] reconcileClusterMachineDeployment end
E0831 20:33:10.562030   72651 deployment_sync.go:167] addHashKeyToISAndMachines proceeding (no hash label) is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.562050   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.562053   72651 machineset_util.go:65] UpdateISWithRetries client write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.562080   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:10.562097   72651 deployment_sync.go:266] getNewMachineSet noupdate is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:10.562120   72651 deployment_sync.go:270] getNewMachineSet noupdate LIVE read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.612780   72651 deployment_sync.go:164] addHashKeyToISAndMachines short (has hash label) is=MachineSet-test
E0831 20:33:10.612812   72651 deployment_sync.go:266] getNewMachineSet noupdate is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:10.612825   72651 deployment_sync.go:270] getNewMachineSet noupdate LIVE read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.612831   72651 deployment.go:579] reconcileClusterMachineDeployment end
E0831 20:33:10.612835   72651 deployment_sync.go:164] addHashKeyToISAndMachines short (has hash label) is=MachineSet-test
E0831 20:33:10.612925   72651 deployment_sync.go:266] getNewMachineSet noupdate is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:10.612938   72651 deployment_sync.go:270] getNewMachineSet noupdate LIVE read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.663269   72651 deployment_sync.go:164] addHashKeyToISAndMachines short (has hash label) is=MachineSet-test
E0831 20:33:10.663299   72651 deployment_sync.go:266] getNewMachineSet noupdate is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:10.663311   72651 deployment_sync.go:270] getNewMachineSet noupdate LIVE read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.663316   72651 deployment.go:579] reconcileClusterMachineDeployment end
...
... # Removed duplicate log lines to reduce trace size
...
E0831 20:33:25.519447   72651 deployment_sync.go:164] addHashKeyToISAndMachines short (has hash label) is=MachineSet-test
E0831 20:33:25.519463   72651 deployment_sync.go:266] getNewMachineSet noupdate is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:25.519468   72651 deployment_sync.go:270] getNewMachineSet noupdate LIVE read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]

------------------------------
• [FAILED] [15.102 seconds]
machineDeployment #reconcileClusterMachineDeployment This should [It] set LDRCBST annotation on the machineSet and TriggerDeletionByMCM annotation is not set on the machineSet
/Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1988

  [FAILED] Timed out after 15.000s.
  Expected success, but got an error:
      <*errors.errorString | 0x180e7129d850>:
      expected LastDeploymentReplicaChangeByScalerTime annotation to be set on the machineSet
      {
          s: "expected LastDeploymentReplicaChangeByScalerTime annotation to be set on the machineSet",
      }
  In [It] at: /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1762 @ 08/31/26 20:33:25.561
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Summarizing 1 Failure:
  [FAIL] machineDeployment #reconcileClusterMachineDeployment This should [It] set LDRCBST annotation on the machineSet and TriggerDeletionByMCM annotation is not set on the machineSet
  /Users/I765230/go/src/github.com/gagan16k/machine-controller-manager/pkg/controller/deployment_test.go:1762

Ran 1 of 204 Specs in 15.103 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 203 Skipped
--- FAIL: TestMachineControllerManagerSuite (15.11s)
FAIL


ERROR: exit status 1
```
</details>


From the logs,
```
E0831 20:33:10.561839   72651 deployment_sync.go:167] addHashKeyToISAndMachines proceeding (no hash label) is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561882   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561887   72651 machineset_util.go:65] UpdateISWithRetries client write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561923   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561926   72651 machineset_util.go:65] UpdateISWithRetries client write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.561999   72651 deployment_sync.go:263] getNewMachineSet write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
# Write the LDRCBST annotation on the MachineSet
E0831 20:33:10.562017   72651 deployment.go:579] reconcileClusterMachineDeployment end
```
Next reconcile,
```
E0831 20:33:10.562030   72651 deployment_sync.go:167] addHashKeyToISAndMachines proceeding (no hash label) is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]

E0831 20:33:10.562050   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]   
# Lister read lags and does not have the LDRCBST annotation 
E0831 20:33:10.562053   72651 machineset_util.go:65] UpdateISWithRetries client write is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]  
# Stale value is written back to the MachineSet, overwriting the LDRCBST annotation

E0831 20:33:10.562080   72651 machineset_util.go:60] UpdateISWithRetries lister read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
# Lister read now has the LDRCBST annotation, but it is too late, as the previous write has already overwritten it on the actual MachineSet object in the fake client.

E0831 20:33:10.562097   72651 deployment_sync.go:266] getNewMachineSet noupdate is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
# Cache read has the LDRCBST annotation
E0831 20:33:10.562120   72651 deployment_sync.go:270] getNewMachineSet noupdate LIVE read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
# Actual MachineSet object does not have the LDRCBST annotation, as it was overwritten by the stale lister read in the previous step.
E0831 20:33:10.612831   72651 deployment.go:579] reconcileClusterMachineDeployment end
...
...
# The actual machineSet object does not have the LDRCBST annotation, but the cache has it (?)
E0831 20:33:10.612780   72651 deployment_sync.go:164] addHashKeyToISAndMachines short (has hash label) is=MachineSet-test
E0831 20:33:10.612812   72651 deployment_sync.go:266] getNewMachineSet noupdate is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1 deployment.kubernetes.io/revision-history:1 machine.sapcloud.io/last-deployment-replica-change-by-scaler-time:2026-08-31T20:33:10+05:30]
E0831 20:33:10.612825   72651 deployment_sync.go:270] getNewMachineSet noupdate LIVE read is=MachineSet-test annotations=map[deployment.kubernetes.io/revision:1]
E0831 20:33:10.612831   72651 deployment.go:579] reconcileClusterMachineDeployment end
```



There seems to be two issues:

1. It appears that the lister is not able to read a field written earlier in the same reconcile of the MCD:
  - the machine hash-labelling step (`LabelMachinesWithHash` to `UpdateMachineWithRetries`) reads a stale machine and overwrites the `MachinePriority=1` annotation just set by the trigger-deletion path;
  - the annotation copy step (`copyMachineDeploymentAnnotationsToMachineSet`) reads a stale MachineDeployment and copies an empty `LastDeploymentReplicaChangeByScalerTime` onto the MachineSet.
  - The MachineSet now does not have the `LastDeploymentReplicaChangeByScalerTime`, but now the cache has caught up and has the annotation.
  - Subsequent reconciles read the MachineSet from the cache and sees the annotation, but the actual object does not have it, so the test fails.
  - No idea why the lister cache does not sync itself with the actual object for a substantial amount of time, however.

2) `GetFakeMachineFromTemplate` used only the first 5 chars of the UUID as the generated-name suffix. Unlike the real apiserver, the fake client does not retry on `GenerateName` conflicts, so when many machines are created in a single reconcile (e.g. `burstReplicas`) the truncated suffix could collide and produce duplicate machine names, flaking the test. Fixed by using the full UUID as the suffix.


Changes in the PR:
- Give the fixture `MachineSet` the `machine-template-hash` label on its `Spec.Selector` (in both affected entries) so `addHashKeyToISAndMachines` short-circuits from the first reconcile.
- Look up the target Machine/MachineSet by name instead of by list index, as the returned list order is not deterministic.
- Convert the affected `Expect(...)` postChecks to return `error`. Match the DescribeTable's postCheck signature.
- Use the full UUID (instead of the first 5 chars) as the generated-name suffix in `GetFakeMachineFromTemplate` to avoid duplicate machine names under `burstReplicas`.

Stress test after PR:
<details>
<summary>Click to expand</summary>

```
(⎈|kwok-test-cluster:N/A)➜  machine-controller-manager git:(flake-fix) ginkgo build ./pkg/controller/ && stress -p 64 ./pkg/controller/controller.test
Compiled pkg/controller/controller.test
5s: 0 runs so far, 0 failures, 64 active
10s: 0 runs so far, 0 failures, 64 active
15s: 0 runs so far, 0 failures, 64 active
20s: 0 runs so far, 0 failures, 64 active
25s: 0 runs so far, 0 failures, 64 active
30s: 0 runs so far, 0 failures, 64 active
35s: 64 runs so far, 0 failures, 64 active
40s: 64 runs so far, 0 failures, 64 active
45s: 64 runs so far, 0 failures, 64 active
50s: 64 runs so far, 0 failures, 64 active
55s: 64 runs so far, 0 failures, 64 active
1m0s: 64 runs so far, 0 failures, 64 active
1m5s: 64 runs so far, 0 failures, 64 active
1m10s: 128 runs so far, 0 failures, 64 active
1m15s: 128 runs so far, 0 failures, 64 active
1m20s: 128 runs so far, 0 failures, 64 active
1m25s: 128 runs so far, 0 failures, 64 active
1m30s: 128 runs so far, 0 failures, 64 active
1m35s: 128 runs so far, 0 failures, 64 active
1m40s: 192 runs so far, 0 failures, 64 active
1m45s: 192 runs so far, 0 failures, 64 active
1m50s: 192 runs so far, 0 failures, 64 active
1m55s: 192 runs so far, 0 failures, 64 active
2m0s: 192 runs so far, 0 failures, 64 active
2m5s: 192 runs so far, 0 failures, 64 active
2m10s: 192 runs so far, 0 failures, 64 active
2m15s: 256 runs so far, 0 failures, 64 active
2m20s: 256 runs so far, 0 failures, 64 active
2m25s: 256 runs so far, 0 failures, 64 active
2m30s: 256 runs so far, 0 failures, 64 active
2m35s: 256 runs so far, 0 failures, 64 active
2m40s: 256 runs so far, 0 failures, 64 active
2m45s: 256 runs so far, 0 failures, 64 active
2m50s: 320 runs so far, 0 failures, 64 active
2m55s: 320 runs so far, 0 failures, 64 active
3m0s: 320 runs so far, 0 failures, 64 active
3m5s: 320 runs so far, 0 failures, 64 active
3m10s: 320 runs so far, 0 failures, 64 active
3m15s: 320 runs so far, 0 failures, 64 active
3m20s: 384 runs so far, 0 failures, 64 active
3m25s: 384 runs so far, 0 failures, 64 active
3m30s: 384 runs so far, 0 failures, 64 active
3m35s: 384 runs so far, 0 failures, 64 active
3m40s: 384 runs so far, 0 failures, 64 active
3m45s: 384 runs so far, 0 failures, 64 active
3m50s: 384 runs so far, 0 failures, 64 active
3m55s: 448 runs so far, 0 failures, 64 active
4m0s: 448 runs so far, 0 failures, 64 active
4m5s: 448 runs so far, 0 failures, 64 active
4m10s: 448 runs so far, 0 failures, 64 active
4m15s: 448 runs so far, 0 failures, 64 active
4m20s: 448 runs so far, 0 failures, 64 active
4m25s: 512 runs so far, 0 failures, 64 active
4m30s: 512 runs so far, 0 failures, 64 active
4m35s: 512 runs so far, 0 failures, 64 active
4m40s: 512 runs so far, 0 failures, 64 active
4m45s: 512 runs so far, 0 failures, 64 active
4m50s: 512 runs so far, 0 failures, 64 active
4m55s: 512 runs so far, 0 failures, 64 active
5m0s: 576 runs so far, 0 failures, 64 active
5m5s: 576 runs so far, 0 failures, 64 active
5m10s: 576 runs so far, 0 failures, 64 active
5m15s: 576 runs so far, 0 failures, 64 active
5m20s: 576 runs so far, 0 failures, 64 active
5m25s: 576 runs so far, 0 failures, 64 active
5m30s: 640 runs so far, 0 failures, 64 active
5m35s: 640 runs so far, 0 failures, 64 active
5m40s: 640 runs so far, 0 failures, 64 active
5m45s: 640 runs so far, 0 failures, 64 active
5m50s: 640 runs so far, 0 failures, 64 active
5m55s: 640 runs so far, 0 failures, 64 active
6m0s: 640 runs so far, 0 failures, 64 active
6m5s: 704 runs so far, 0 failures, 64 active
6m10s: 704 runs so far, 0 failures, 64 active
6m15s: 704 runs so far, 0 failures, 64 active
6m20s: 704 runs so far, 0 failures, 64 active
6m25s: 704 runs so far, 0 failures, 64 active
6m30s: 704 runs so far, 0 failures, 64 active
6m35s: 704 runs so far, 0 failures, 64 active
6m40s: 768 runs so far, 0 failures, 64 active
6m45s: 768 runs so far, 0 failures, 64 active
6m50s: 768 runs so far, 0 failures, 64 active
6m55s: 768 runs so far, 0 failures, 64 active
7m0s: 768 runs so far, 0 failures, 64 active
7m5s: 768 runs so far, 0 failures, 64 active
7m10s: 832 runs so far, 0 failures, 64 active
7m15s: 832 runs so far, 0 failures, 64 active
7m20s: 832 runs so far, 0 failures, 64 active
7m25s: 832 runs so far, 0 failures, 64 active
7m30s: 832 runs so far, 0 failures, 64 active
7m35s: 832 runs so far, 0 failures, 64 active
7m40s: 832 runs so far, 0 failures, 64 active
7m45s: 896 runs so far, 0 failures, 64 active
7m50s: 896 runs so far, 0 failures, 64 active
7m55s: 896 runs so far, 0 failures, 64 active
8m0s: 896 runs so far, 0 failures, 64 active
8m5s: 896 runs so far, 0 failures, 64 active
8m10s: 896 runs so far, 0 failures, 64 active
8m15s: 949 runs so far, 0 failures, 64 active
8m20s: 960 runs so far, 0 failures, 64 active
8m25s: 960 runs so far, 0 failures, 64 active
8m30s: 960 runs so far, 0 failures, 64 active
8m35s: 960 runs so far, 0 failures, 64 active
8m40s: 960 runs so far, 0 failures, 64 active
8m45s: 960 runs so far, 0 failures, 64 active
8m50s: 1024 runs so far, 0 failures, 64 active
8m55s: 1024 runs so far, 0 failures, 64 active
9m0s: 1024 runs so far, 0 failures, 64 active
9m5s: 1024 runs so far, 0 failures, 64 active
9m10s: 1024 runs so far, 0 failures, 64 active
9m15s: 1024 runs so far, 0 failures, 64 active
^C
```
</details>

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix flaky tests for `MachineDeployments`
```