### PR TITLE
Fix incorrect drain error drop in preservation flow

### DIFF
--- a/pkg/util/provider/machinecontroller/machine_util.go
+++ b/pkg/util/provider/machinecontroller/machine_util.go
@@ -24,6 +24,7 @@ package controller
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -2425,14 +2426,12 @@ func (c *controller) preserveMachine(ctx context.Context, machine *v1alpha1.Mach
 	if needsUpdate {
 		// Step 4: Update NodePreserved Condition on Node, with drain status
 		_, err = nodeops.AddOrUpdateConditionsOnNode(ctx, c.targetCoreClient, updatedNode.Name, *newCond)
-		if drainErr != nil {
-			klog.Errorf("error draining preserved node %q for machine %q : %v", nodeName, machine.Name, drainErr)
-			return machine, drainErr
-		}
 		if err != nil {
 			klog.Errorf("error trying to update node preserved condition for node %q of machine %q : %v", nodeName, machine.Name, err)
-			return machine, err
 		}
+	}
+	if drainErr != nil || err != nil {
+		return machine, cmp.Or(drainErr, err)
 	}
 	klog.V(2).Infof("Machine %q and backing node %q preserved successfully till %v.", machine.Name, nodeName, machine.Status.CurrentStatus.PreserveExpiryTime)
 	return machine, nil


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

There is a bug in `preserveMachine` where if draining a preserved node fails twice such that the node condition remains unchanged, no error is returned from the function, leading to a `LongRetry` rather than the desired `ShortRetry`, and the success log is incorrectly printed.

 The PR fixes the bug by moving the error return outside the block guarded by `needsUpdate`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

A log has been removed from `preserveMachine` when `drainPreservedNode` returns an error because we are already logging the error within  `drainPreservedNode`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix drain error drop in preservation flow where a failed drain on a previously-visited preserved node would not cause the reconciler to retry fast enough.
```
